### PR TITLE
Add stats and templated thread to fastpath

### DIFF
--- a/include/stdio.hpp
+++ b/include/stdio.hpp
@@ -20,6 +20,7 @@ constexpr int WRITEMODE = 2;
 constexpr int UNBUFF = 4;
 constexpr int _EOF = 8;
 constexpr int ERR = 16;
+constexpr int _ERR = ERR; // compatibility with historical macro
 constexpr int IOMYBUF = 32;
 constexpr int PERPRINTF = 64;
 constexpr int STRINGS = 128;
@@ -34,7 +35,7 @@ extern struct _io_buf {
     int _flags; /** status flags */
     char *_buf; /** buffer start */
     char *_ptr; /** next char in buffer */
-} *io_table[NFILES];
+} *_io_table[NFILES];
 
 #endif /* FILE */
 

--- a/kernel/CMakeLists.txt
+++ b/kernel/CMakeLists.txt
@@ -7,7 +7,8 @@ endif()
 
 set(KERNEL_SRC
     clock.cpp dmp.cpp floppy.cpp main.cpp memory.cpp printer.cpp proc.cpp system.cpp
-    table.cpp tty.cpp idt64.cpp mpx64.cpp klib64.cpp klib88.cpp mpx88.cpp paging.cpp syscall.cpp ${WINI_SRC})
+    table.cpp tty.cpp idt64.cpp mpx64.cpp klib64.cpp klib88.cpp mpx88.cpp paging.cpp
+    fastpath.cpp syscall.cpp ${WINI_SRC})
 # Note: klib88.cpp and mpx88.cpp were added as they appear to be kernel related sources.
 # wini.cpp is a generic name, might be a common file or superseded by at_wini/xt_wini.
 # For now, including specific at_wini/xt_wini based on WINI_DRIVER.

--- a/kernel/fastpath.cpp
+++ b/kernel/fastpath.cpp
@@ -1,0 +1,86 @@
+#include "fastpath.hpp"
+
+#include <algorithm>
+
+namespace fastpath {
+
+// Helper to check Send right presence.
+static bool has_send_right(const CapRights &r) {
+    return r.write; // treat write as send for this model
+}
+
+/* Fastpath partial function implementing the formalized state transition.
+ * Returns true when all preconditions are satisfied and the fastpath is
+ * executed. On failure the state remains unchanged and false is returned.
+ */
+bool execute_fastpath(State &s, FastpathStats *stats /*= nullptr*/) {
+    // Helper lambda to update statistics.
+    auto check_precondition = [&](bool cond, size_t idx) {
+        if (!cond) {
+            if (stats) {
+                stats->failure_count.fetch_add(1, std::memory_order_relaxed);
+                stats->precondition_failures[idx].fetch_add(1, std::memory_order_relaxed);
+            }
+            return false;
+        }
+        return true;
+    };
+
+    // Preconditions from P1..P9
+    if (!check_precondition(s.extra_caps == 0, 0)) {
+        return false; // P1
+    }
+    if (!check_precondition(s.msg_len <= s.sender.mrs.size(), 1)) {
+        return false; // P2
+    }
+    if (!check_precondition(!s.sender.fault.has_value(), 2)) {
+        return false; // P3
+    }
+    if (!check_precondition(s.cap.type == CapType::Endpoint && has_send_right(s.cap.rights), 3)) {
+        return false; // P4
+    }
+    if (!check_precondition(s.endpoint.state == EndpointState::Recv && !s.endpoint.queue.empty(),
+                            4)) {
+        return false; // P5
+    }
+    if (!check_precondition(s.receiver.priority >= s.sender.priority, 5)) {
+        return false; // P6 simplified
+    }
+    if (!check_precondition(s.sender.domain == s.receiver.domain, 6)) {
+        return false; // P7 simplified
+    }
+    // P8 is not modeled; record as always satisfied
+    if (!check_precondition(true, 7)) {
+        return false; // P8 placeholder
+    }
+    if (!check_precondition(s.sender.core == s.receiver.core, 8)) {
+        return false; // P9 simplified
+    }
+
+    // Dequeue receiver from endpoint
+    auto it = std::find(s.endpoint.queue.begin(), s.endpoint.queue.end(), s.receiver.tid);
+    if (it != s.endpoint.queue.end()) {
+        s.endpoint.queue.erase(it);
+    }
+    if (s.endpoint.queue.empty()) {
+        s.endpoint.state = EndpointState::Idle;
+    }
+
+    // Transfer message registers
+    for (size_t i = 0; i < s.msg_len && i < s.sender.mrs.size(); ++i) {
+        s.receiver.mrs[i] = s.sender.mrs[i];
+    }
+
+    // Update thread states
+
+    s.receiver.status = ThreadStatus::Running;
+    s.sender.status = ThreadStatus::Blocked;
+
+    if (stats) {
+        stats->success_count.fetch_add(1, std::memory_order_relaxed);
+    }
+
+    return true;
+}
+
+} // namespace fastpath

--- a/kernel/fastpath.hpp
+++ b/kernel/fastpath.hpp
@@ -1,0 +1,91 @@
+#pragma once
+
+#include <array>
+#include <atomic>
+#include <cstdint>
+#include <optional>
+#include <vector>
+
+namespace fastpath {
+
+// State components as described in the formalization.
+
+// Possible thread execution states.
+enum class ThreadStatus { Running, Blocked, SendBlocked, RecvBlocked };
+
+// Receive endpoint state.
+enum class EndpointState { Idle, Send, Recv };
+
+// Capability type enumeration.
+enum class CapType { Endpoint };
+
+// Basic capability rights bitmask.
+struct CapRights {
+    bool read{false};
+    bool write{false};
+    bool grant{false};
+    bool grant_reply{false};
+};
+
+// Representation of a capability object.
+struct Capability {
+    uint32_t cptr{}; // capability pointer
+    CapType type{CapType::Endpoint};
+    CapRights rights{}; // access rights
+    uint32_t object{};  // referenced kernel object id
+};
+
+// Thread template provides configurable message register count.
+template <size_t MR_COUNT = 8> struct ThreadTemplate {
+    uint32_t tid{};                             // thread identifier
+    ThreadStatus status{ThreadStatus::Blocked}; // scheduler state
+    uint8_t priority{};                         // scheduling priority
+    uint16_t domain{};                          // domain identifier
+    uint32_t vspace{};                          // address space reference
+    std::optional<int> fault;                   // fault number, if any
+    uint8_t core{};                             // CPU affinity
+    std::array<uint64_t, MR_COUNT> mrs{};       // message registers
+
+    // Safe accessor returning nullopt when out of range.
+    std::optional<uint64_t> get_mr(size_t index) const {
+        return index < mrs.size() ? std::optional<uint64_t>{mrs[index]} : std::nullopt;
+    }
+};
+
+// Default thread type using eight message registers.
+using Thread = ThreadTemplate<>;
+
+// Endpoint structure holding a queue of waiting threads.
+struct Endpoint {
+    uint32_t eid{};              // endpoint identifier
+    std::vector<uint32_t> queue; // queued thread ids
+    EndpointState state{EndpointState::Idle};
+};
+
+// Complete system state used by the fastpath.
+struct State {
+    Thread sender;       // sending thread
+    Thread receiver;     // receiving thread
+    Endpoint endpoint;   // communication endpoint
+    Capability cap;      // capability used by sender
+    size_t msg_len{};    // message length
+    size_t extra_caps{}; // number of extra caps
+};
+
+// Statistics collected from fastpath execution.
+struct FastpathStats {
+    std::atomic<uint64_t> success_count{0};                       // completed runs
+    std::atomic<uint64_t> failure_count{0};                       // failed runs
+    std::array<std::atomic<uint64_t>, 9> precondition_failures{}; // P1-P9
+
+    FastpathStats() {
+        for (auto &counter : precondition_failures) {
+            counter.store(0, std::memory_order_relaxed);
+        }
+    }
+};
+
+// Fastpath operation modeled as a partial function on State.
+bool execute_fastpath(State &s, FastpathStats *stats = nullptr);
+
+} // namespace fastpath

--- a/lib/cleanup.cpp
+++ b/lib/cleanup.cpp
@@ -4,5 +4,5 @@
 void _cleanup(void) {
     for (int i = 0; i < NFILES; i++)
         if (_io_table[i] != nullptr)
-            __fflush(_io_table[i]);
+            fflush(_io_table[i]);
 }

--- a/lib/fclose.cpp
+++ b/lib/fclose.cpp
@@ -9,8 +9,8 @@ int fclose(FILE *fp) {
     int i; /* index within _io_table */
 
     for (i = 0; i < NFILES; i++) {
-        if (fp == io_table[i]) {
-            io_table[i] = 0;
+        if (fp == _io_table[i]) {
+            _io_table[i] = 0;
             break;
         }
     }

--- a/lib/fflush.cpp
+++ b/lib/fflush.cpp
@@ -22,3 +22,8 @@ int __fflush(FILE *iop) {
     return EOF;
 }
 
+// Public interface wrapper.
+int fflush(FILE *stream) {
+    return __fflush(stream);
+}
+

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -25,3 +25,11 @@ target_include_directories(minix_test_syscall PUBLIC
     "${CMAKE_SOURCE_DIR}/h"
 )
 add_test(NAME minix_test_syscall COMMAND minix_test_syscall)
+
+# Fastpath unit test
+add_executable(minix_test_fastpath test_fastpath.cpp
+    "${CMAKE_SOURCE_DIR}/kernel/fastpath.cpp")
+target_include_directories(minix_test_fastpath PUBLIC
+    "${CMAKE_SOURCE_DIR}/kernel"  # For fastpath headers
+)
+add_test(NAME minix_test_fastpath COMMAND minix_test_fastpath)

--- a/tests/test_fastpath.cpp
+++ b/tests/test_fastpath.cpp
@@ -1,0 +1,41 @@
+#include "../kernel/fastpath.hpp"
+#include <cassert>
+
+using namespace fastpath;
+
+// Simple sanity test of the fastpath partial function.
+int main() {
+    State s{};
+    s.sender.tid = 1;
+    s.sender.status = ThreadStatus::Running;
+    s.sender.priority = 5;
+    s.sender.domain = 0;
+    s.sender.core = 0;
+    s.sender.mrs[0] = 42;
+    s.msg_len = 1;
+    s.extra_caps = 0;
+
+    s.receiver.tid = 2;
+    s.receiver.status = ThreadStatus::RecvBlocked;
+    s.receiver.priority = 5;
+    s.receiver.domain = 0;
+    s.receiver.core = 0;
+
+    s.endpoint.eid = 1;
+    s.endpoint.state = EndpointState::Recv;
+    s.endpoint.queue.push_back(2);
+
+    s.cap.cptr = 1;
+    s.cap.type = CapType::Endpoint;
+    s.cap.rights.write = true;
+    s.cap.object = 1;
+
+    FastpathStats stats; // collect fastpath metrics
+    bool ok = execute_fastpath(s, &stats);
+    assert(ok);
+    assert(stats.success_count == 1);
+    assert(s.receiver.mrs[0] == 42);
+    assert(s.receiver.status == ThreadStatus::Running);
+    assert(s.sender.status == ThreadStatus::Blocked);
+    return 0;
+}

--- a/tools/find_knr.py
+++ b/tools/find_knr.py
@@ -1,0 +1,28 @@
+#!/usr/bin/env python3
+"""List .cpp files that appear to use K&R-style function definitions."""
+
+import os
+from pathlib import Path
+from classify_style import classify_file
+
+
+def scan(root: str) -> list[Path]:
+    knr_files = []
+    for dirpath, _, files in os.walk(root):
+        for name in files:
+            if name.endswith('.cpp'):
+                path = Path(dirpath) / name
+                if classify_file(str(path)) == 'K&R':
+                    knr_files.append(path)
+    return knr_files
+
+
+def main() -> None:
+    root = os.getcwd()
+    files = scan(root)
+    for p in files:
+        print(p)
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## Summary
- refine kernel fastpath model with configurable message register count
- add FastpathStats structure to collect execution metrics
- expose stats parameter to `execute_fastpath` and update unit test

## Testing
- `cmake -S . -B build -DBUILD_SYSTEM=OFF`
- `cmake --build build`
- `ctest --test-dir build --output-on-failure`


------
https://chatgpt.com/codex/tasks/task_e_683f9a6943f083319536138f32ffa552