### PR TITLE
Add semantic region helpers and document wormhole integration

### DIFF
--- a/include/psd/vm/semantic_memory.hpp
+++ b/include/psd/vm/semantic_memory.hpp
@@ -1,0 +1,109 @@
+#pragma once
+
+#include <array>
+#include <cstdint>
+#include <optional>
+#include <type_traits>
+
+namespace psd::vm {
+
+// Semantic domain tag types used with semantic_region.  Each tag
+// represents a logical memory purpose and drives compile-time
+// policy selection for the associated region.
+// Executable code memory.
+struct semantic_code_tag {};
+// Read/write data memory.
+struct semantic_data_tag {};
+// Process stack memory which grows downward.
+struct semantic_stack_tag {};
+// Dynamically allocated heap memory.
+struct semantic_heap_tag {};
+// Memory used for IPC message buffers.
+struct semantic_message_tag {};
+// Matrix or vector data with alignment requirements.
+struct semantic_matrix_tag {};
+
+// Trait template describing properties of a semantic domain.  Each
+// specialization encodes policies for memory protection and usage.
+template <typename Tag> struct semantic_traits {
+    static constexpr bool is_executable = false;        // region may contain code
+    static constexpr bool is_shareable = false;         // region can be shared
+    static constexpr bool is_zero_copy_capable = false; // zero-copy allowed
+    static constexpr bool grows_down = false;           // stack-like growth
+    static constexpr std::size_t alignment = 8;         // required byte alignment
+};
+
+// Code segment specialization.  Executable regions are shareable
+// and may be used with zero-copy mapping for efficient IPC.
+template <> struct semantic_traits<semantic_code_tag> {
+    static constexpr bool is_executable = true;
+    static constexpr bool is_shareable = true;
+    static constexpr bool is_zero_copy_capable = true;
+    static constexpr bool grows_down = false;
+    static constexpr std::size_t alignment = 16;
+};
+
+// Stack specialization.  Stacks grow downward and are never
+// executable or zero-copy capable.
+template <> struct semantic_traits<semantic_stack_tag> {
+    static constexpr bool is_executable = false;
+    static constexpr bool is_shareable = false;
+    static constexpr bool is_zero_copy_capable = false;
+    static constexpr bool grows_down = true;
+    static constexpr std::size_t alignment = 16;
+};
+
+// Message segment specialization used for IPC buffers.  Message
+// regions must support zero-copy and are typically shared.
+template <> struct semantic_traits<semantic_message_tag> {
+    static constexpr bool is_executable = false;
+    static constexpr bool is_shareable = true;
+    static constexpr bool is_zero_copy_capable = true;
+    static constexpr bool grows_down = false;
+    static constexpr std::size_t alignment = 64;
+};
+
+// semantic_region aligns memory ranges at compile time
+template <typename SemanticTag> class semantic_region {
+  public:
+    using tag_type = SemanticTag;
+    using traits = semantic_traits<SemanticTag>;
+
+    constexpr semantic_region(std::uintptr_t base, std::size_t size) noexcept
+        : base_{align_to(base, traits::alignment)}, size_{size} {
+        static_assert(traits::alignment > 0 && (traits::alignment & (traits::alignment - 1)) == 0,
+                      "Alignment must be a power of two");
+    }
+
+    // Zero-copy mapping only for capable domains
+    template <typename T = SemanticTag>
+    std::enable_if_t<semantic_traits<T>::is_zero_copy_capable, void *>
+    zero_copy_map() const noexcept {
+        return reinterpret_cast<void *>(base_);
+    }
+
+    // Standard mapping available for all domains
+    void *map() const noexcept { return reinterpret_cast<void *>(base_); }
+
+    constexpr std::uintptr_t base() const noexcept { return base_; }
+    constexpr std::size_t size() const noexcept { return size_; }
+
+    // Return true if the base address satisfies the required alignment.
+    constexpr bool aligned() const noexcept { return base_ % traits::alignment == 0; }
+
+    // Check whether the region contains the provided address.
+    constexpr bool contains(std::uintptr_t addr) const noexcept {
+        return addr >= base_ && addr < base_ + size_;
+    }
+
+  private:
+    // Utility rounding up "addr" to the specified power-of-two alignment.
+    static constexpr std::uintptr_t align_to(std::uintptr_t addr, std::size_t alignment) noexcept {
+        return (addr + alignment - 1) & ~(alignment - 1);
+    }
+
+    std::uintptr_t base_{}; // start address after alignment
+    std::size_t size_{};    // size in bytes of the region
+};
+
+} // namespace psd::vm

--- a/kernel/wormhole.cpp
+++ b/kernel/wormhole.cpp
@@ -1,12 +1,34 @@
 #include "wormhole.hpp"
 
+// Implementation of the fastpath "wormhole" IPC model used for
+// unit testing.  The code is intentionally simplified but mirrors the
+// semantics of the real kernel fastpath.
+
 #include <algorithm>
+#include <cassert>
 
 namespace fastpath {
 
+// Set the zero-copy message region for fastpath execution.  Compile-time
+// checks guarantee that the provided region type supports zero-copy
+// mappings.
+void set_message_region(State &state, const MessageRegion &region) {
+    static_assert(MessageRegion::traits::is_zero_copy_capable,
+                  "MessageRegion must support zero-copy");
+    assert(region.aligned());
+    state.msg_region = region;
+}
+
+// Verify that the message region can hold the requested message length.
+bool message_region_valid(const MessageRegion &region, size_t msg_len) {
+    return region.size() >= msg_len * sizeof(uint64_t) && region.aligned();
+}
+
 namespace detail {
 
-// --\tau_dequeue-- remove receiver from endpoint queue and adjust endpoint state
+// --\tau_dequeue-- remove receiver from endpoint queue and adjust
+// endpoint state.  When the queue becomes empty the endpoint returns to
+// the Idle state.
 inline void dequeue_receiver(State &state) {
     auto it =
         std::find(state.endpoint.queue.begin(), state.endpoint.queue.end(), state.receiver.tid);
@@ -18,34 +40,43 @@ inline void dequeue_receiver(State &state) {
     }
 }
 
-// --\tau_badge-- deliver badge from capability to receiver
+// --\tau_badge-- deliver badge from capability to receiver.
 inline void transfer_badge(State &state) { state.receiver.badge = state.cap.badge; }
 
-// --\tau_reply-- set up reply linkage from sender to receiver
+// --\tau_reply-- set up reply linkage from sender to receiver.
 inline void establish_reply(State &state) { state.sender.reply_to = state.receiver.tid; }
 
 // --\tau_mrs-- copy message registers from sender to receiver
 inline void copy_mrs(State &state) {
+    // Ensure the provided message region is large and aligned enough.
+    assert(message_region_valid(state.msg_region, state.msg_len));
+
+    // Use zero_copy_map to access the region without additional copies.
+    auto *buffer = static_cast<uint64_t *>(state.msg_region.zero_copy_map());
+
+    // Copy from sender to the shared region then into the receiver registers.
     for (size_t i = 0; i < state.msg_len && i < state.sender.mrs.size(); ++i) {
-        state.receiver.mrs[i] = state.sender.mrs[i];
+        buffer[i] = state.sender.mrs[i];
+        state.receiver.mrs[i] = buffer[i];
     }
 }
 
-// --\tau_state-- update scheduling state after IPC
+// --\tau_state-- update scheduling state after IPC.  The receiver
+// becomes runnable while the sender blocks waiting for a reply.
 inline void update_thread_state(State &state) {
     state.receiver.status = ThreadStatus::Running;
     state.sender.status = ThreadStatus::Blocked;
 }
 
-// --\tau_switch-- context switch to the receiver thread
+// --\tau_switch-- context switch to the receiver thread.
 inline void context_switch(State &state) { state.current_tid = state.receiver.tid; }
 
 } // namespace detail
 
-// helper to determine if capability conveys send rights
+// Helper to determine if a capability conveys send rights.
 static bool has_send_right(const CapRights &rights) { return rights.write; }
 
-// update statistics for a failed precondition
+// Helper for updating statistics when a precondition check fails.
 static bool check(bool condition, Precondition idx, FastpathStats *stats) {
     if (condition) {
         return true;
@@ -58,7 +89,7 @@ static bool check(bool condition, Precondition idx, FastpathStats *stats) {
     return false;
 }
 
-// evaluate all preconditions
+// Evaluate all preconditions for a fastpath execution attempt.
 static bool preconditions(const State &s, FastpathStats *stats) {
     return check(s.extra_caps == 0, Precondition::P1, stats) &&
            check(s.msg_len <= s.sender.mrs.size(), Precondition::P2, stats) &&
@@ -76,7 +107,8 @@ static bool preconditions(const State &s, FastpathStats *stats) {
 // convenient alias for transformation function pointer
 using Transformer = void (*)(State &);
 
-// main fastpath entry: apply transformations when allowed
+// Main fastpath entry: apply all transformation steps when the
+// preconditions hold.
 bool execute_fastpath(State &state, FastpathStats *stats) {
     if (!preconditions(state, stats)) {
         return false;

--- a/kernel/wormhole.hpp
+++ b/kernel/wormhole.hpp
@@ -6,7 +6,14 @@
 #include <optional>
 #include <vector>
 
+#include "../include/psd/vm/semantic_memory.hpp"
+
 namespace fastpath {
+
+// Alias simplifying access to message semantic region type.  The
+// wormhole relies on a zero-copy capable message region to move
+// data between threads efficiently.
+using MessageRegion = psd::vm::semantic_region<psd::vm::semantic_message_tag>;
 
 // State components as described in the formalization.
 
@@ -39,7 +46,9 @@ struct Capability {
     uint32_t badge{};   // badge value delivered to receiver
 };
 
-// Thread template provides configurable message register count.
+// Thread template provides configurable message register count.  In the
+// actual kernel MR_COUNT is architecture dependent.  Here we expose it
+// for testing and flexibility.
 template <size_t MR_COUNT = 8> struct ThreadTemplate {
     uint32_t tid{};                             // thread identifier
     ThreadStatus status{ThreadStatus::Blocked}; // scheduler state
@@ -61,21 +70,25 @@ template <size_t MR_COUNT = 8> struct ThreadTemplate {
 // Default thread type using eight message registers.
 using Thread = ThreadTemplate<>;
 
-// Endpoint structure holding a queue of waiting threads.
+// Endpoint structure holding a queue of waiting threads.  Only one
+// endpoint is modeled for this simplified fastpath implementation.
 struct Endpoint {
     uint32_t eid{};              // endpoint identifier
     std::vector<uint32_t> queue; // queued thread ids
     EndpointState state{EndpointState::Idle};
 };
 
-// Complete system state used by the fastpath.
+// Complete system state used by the fastpath.  Tests construct this
+// structure directly to model kernel behavior during IPC.
 struct State {
-    Thread sender;          // sending thread
-    Thread receiver;        // receiving thread
-    Endpoint endpoint;      // communication endpoint
-    Capability cap;         // capability used by sender
-    size_t msg_len{};       // message length
-    size_t extra_caps{};    // number of extra caps
+    Thread sender;       // sending thread
+    Thread receiver;     // receiving thread
+    Endpoint endpoint;   // communication endpoint
+    Capability cap;      // capability used by sender
+    size_t msg_len{};    // message length
+    size_t extra_caps{}; // number of extra caps
+    MessageRegion msg_region{0, 0};
+    // region used for zero-copy transfer of message registers
     uint32_t current_tid{}; // currently running thread id
 };
 
@@ -83,7 +96,8 @@ struct State {
 // Preconditions enumerated for statistic indexing.
 enum class Precondition : size_t { P1, P2, P3, P4, P5, P6, P7, P8, P9, Count };
 
-// Statistics collected from fastpath execution.
+// Statistics collected from fastpath execution.  They allow tests to
+// confirm that each precondition is checked correctly.
 struct FastpathStats {
     std::atomic<uint64_t> success_count{0}; // completed runs
     std::atomic<uint64_t> failure_count{0}; // failed runs
@@ -97,15 +111,30 @@ struct FastpathStats {
     }
 };
 
-// Fastpath operation modeled as a partial function on State.
+// Fastpath operation modeled as a partial function on State.  Returns
+// true on success and records statistics when provided.
 bool execute_fastpath(State &s, FastpathStats *stats = nullptr);
 
+// Assign a zero-copy message region to the fastpath state.  The
+// region must satisfy the alignment requirements of MessageRegion.
+void set_message_region(State &s, const MessageRegion &region);
+
+// Validate that a message region can hold the specified number of message
+// registers based on its size and alignment.
+bool message_region_valid(const MessageRegion &region, size_t msg_len);
+
 namespace detail {
+// Remove the receiver from the endpoint queue.
 void dequeue_receiver(State &s);
+// Transfer the sender's badge to the receiver.
 void transfer_badge(State &s);
+// Link the sender to the receiver for replies.
 void establish_reply(State &s);
+// Copy message registers using the configured message region.
 void copy_mrs(State &s);
+// Update thread states after IPC.
 void update_thread_state(State &s);
+// Switch execution to the receiver.
 void context_switch(State &s);
 } // namespace detail
 

--- a/lib/cleanup.cpp
+++ b/lib/cleanup.cpp
@@ -11,4 +11,4 @@ void _cleanup(void) {
             __fflush(_io_table[i]);
         }
     }
-
+}

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -26,7 +26,7 @@ target_include_directories(minix_test_syscall PUBLIC
 )
 add_test(NAME minix_test_syscall COMMAND minix_test_syscall)
 
-# Add Stream architecture tests
+#Add Stream architecture tests
 add_executable(minix_test_streams test_streams.cpp)
 target_link_libraries(minix_test_streams PRIVATE minix_libc)
 target_include_directories(minix_test_streams PUBLIC
@@ -43,3 +43,25 @@ target_include_directories(minix_test_fastpath PUBLIC
 )
 add_test(NAME minix_test_fastpath COMMAND minix_test_fastpath)
 
+#Semantic region unit test
+add_executable(minix_test_semantic_region test_semantic_region.cpp)
+target_include_directories(minix_test_semantic_region PUBLIC
+    "${CMAKE_SOURCE_DIR}/include"
+)
+add_test(NAME minix_test_semantic_region COMMAND minix_test_semantic_region)
+
+#Stream foundation verification test
+add_executable(minix_test_stream_foundation
+    test_stream_foundation.cpp
+    "${CMAKE_SOURCE_DIR}/lib/io/src/file_stream.cpp"
+    "${CMAKE_SOURCE_DIR}/lib/io/src/file_operations.cpp"
+    "${CMAKE_SOURCE_DIR}/lib/io/src/standard_streams.cpp"
+)
+set_target_properties(minix_test_stream_foundation PROPERTIES
+    CXX_STANDARD 20
+    CXX_STANDARD_REQUIRED ON
+)
+target_include_directories(minix_test_stream_foundation PUBLIC
+    "${CMAKE_SOURCE_DIR}/include"
+)
+add_test(NAME minix_test_stream_foundation COMMAND minix_test_stream_foundation)

--- a/tests/test_fastpath.cpp
+++ b/tests/test_fastpath.cpp
@@ -3,9 +3,11 @@
 
 using namespace fastpath;
 
-// Simple sanity test of the fastpath partial function.
+// Simple sanity test of the fastpath partial function with zero-copy buffer.
 int main() {
     State s{};
+    alignas(64) uint64_t buffer[8]{};
+    set_message_region(s, MessageRegion(reinterpret_cast<std::uintptr_t>(buffer), sizeof(buffer)));
     s.sender.tid = 1;
     s.sender.status = ThreadStatus::Running;
     s.sender.priority = 5;
@@ -42,6 +44,7 @@ int main() {
     assert(ok);
     assert(stats.success_count == 1);
     assert(s.receiver.mrs[0] == 42);
+    assert(buffer[0] == 42);
     assert(s.receiver.status == ThreadStatus::Running);
     assert(s.sender.status == ThreadStatus::Blocked);
     assert(s.receiver.badge == s.cap.badge);

--- a/tests/test_semantic_region.cpp
+++ b/tests/test_semantic_region.cpp
@@ -1,0 +1,10 @@
+#include "../include/psd/vm/semantic_memory.hpp"
+#include <cassert>
+
+int main() {
+    using namespace psd::vm;
+    semantic_region<semantic_code_tag> code_region(0x1001, 4096);
+    auto aligned = code_region.base() % semantic_traits<semantic_code_tag>::alignment == 0;
+    assert(aligned);
+    return 0;
+}

--- a/tests/test_stream_foundation.cpp
+++ b/tests/test_stream_foundation.cpp
@@ -1,0 +1,97 @@
+// tests/test_stream_foundation.cpp
+// Minimal Stream architecture verification
+
+#include "minix/io/file_operations.hpp" // open_stream declarations
+#include "minix/io/file_stream.hpp"     // FileStream definition
+#include "minix/io/standard_streams.hpp"
+#include <array>
+#include <cassert>
+#include <cstring>
+#include <iostream>
+
+// Helper for printing detailed failure messages
+static void report_error(const char *name, const std::error_code &ec) {
+    std::cerr << "\n" << name << " failed: " << ec.message() << '\n';
+}
+
+int main() {
+    std::cout << "=== MINIX Stream Foundation Verification ===\n";
+
+    // Test 1: Write to stdout using Stream interface
+    std::cout << "Test 1: stdout write... ";
+    {
+        const char *msg = "Hello from MINIX Stream!\n";
+        auto res = minix::io::stdout().write(std::as_bytes(std::span{msg, std::strlen(msg)}));
+        if (!res) {
+            report_error("stdout write", res.error);
+            return 1;
+        }
+        if (*res != std::strlen(msg)) {
+            std::cerr << "wrong byte count\n";
+            return 1;
+        }
+        std::cout << "OK" << std::endl;
+    }
+
+    // Test 2: Create a file and write data
+    std::cout << "Test 2: create file... ";
+    {
+        auto file = minix::io::open_stream("stream_test.txt", minix::io::OpenMode::write |
+                                                                  minix::io::OpenMode::create |
+                                                                  minix::io::OpenMode::truncate);
+        if (!file) {
+            report_error("file create", file.error);
+            return 1;
+        }
+        const char *content = "This file validates the Stream implementation.\n";
+        auto *s = file.value.value().get();
+        auto wr = s->write(std::as_bytes(std::span{content, std::strlen(content)}));
+        if (!wr) {
+            report_error("file write", wr.error);
+            return 1;
+        }
+        std::cout << "OK" << std::endl;
+    }
+
+    // Test 3: Read file back and verify contents
+    std::cout << "Test 3: read file... ";
+    {
+        auto file = minix::io::open_stream("stream_test.txt", minix::io::OpenMode::read);
+        if (!file) {
+            report_error("file open", file.error);
+            return 1;
+        }
+        auto *s = file.value.value().get();
+        std::array<std::byte, 256> buf{};
+        auto rd = s->read(buf);
+        if (!rd) {
+            report_error("file read", rd.error);
+            return 1;
+        }
+        std::string_view data(reinterpret_cast<const char *>(buf.data()), *rd);
+        if (data != "This file validates the Stream implementation.\n") {
+            std::cerr << "mismatched file content\n";
+            return 1;
+        }
+        std::cout << "OK" << std::endl;
+    }
+
+    // Test 4: Opening a non-existent file should return error
+    std::cout << "Test 4: missing file error... ";
+    {
+        auto file = minix::io::open_stream("no_such_file.abc", minix::io::OpenMode::read);
+        if (file) {
+            std::cerr << "unexpected success\n";
+            return 1;
+        }
+        if (file.error != std::errc::no_such_file_or_directory) {
+            std::cerr << "wrong error code\n";
+            return 1;
+        }
+        std::cout << "OK" << std::endl;
+    }
+
+    std::remove("stream_test.txt");
+    std::cout << "\nAll Stream foundation tests passed!\n";
+    return 0;
+}


### PR DESCRIPTION
## Summary
- enhance `semantic_memory.hpp` with helper methods and detailed comments
- integrate semantic region alignment checks in wormhole
- document wormhole structures and functions with additional comments

## Testing
- `cmake --build build --target minix_test_fastpath`
- `ctest --test-dir build -R minix_test_fastpath --output-on-failure`
- `cmake --build build --target minix_test_semantic_region`
- `ctest --test-dir build -R minix_test_semantic_region --output-on-failure`
- `cmake --build build --target minix_test_stream_foundation`
- `ctest --test-dir build -R minix_test_stream_foundation --output-on-failure`


------
https://chatgpt.com/codex/tasks/task_e_684052676b0c83319ba3c08040e04f60