### PR TITLE
Remove macro accessors

### DIFF
--- a/fs/device.cpp
+++ b/fs/device.cpp
@@ -186,7 +186,7 @@ message *mess_ptr; /* pointer to message for task */
 
     major_device = (fp->fs_tty >> MAJOR) & BYTE;
     task_nr = dmap[major_device].dmap_task; /* task for controlling tty */
-    mess_ptr->DEVICE = (fp->fs_tty >> MINOR) & BYTE;
+    device(*mess_ptr) = (fp->fs_tty >> MINOR) & BYTE;
     rw_dev(task_nr, mess_ptr);
 }
 

--- a/fs/time.cpp
+++ b/fs/time.cpp
@@ -82,7 +82,7 @@ PUBLIC int do_stime() {
     if (!super_user)
         return (ErrorCode::EPERM);
     clock_mess.m_type = SET_TIME;
-    clock_mess.NEW_TIME = (long)tp;
+    new_time(clock_mess) = static_cast<long>(tp);
     if ((k = sendrec(CLOCK, &clock_mess)) != OK)
         panic("do_stime error", k);
     return (OK);

--- a/fs/utility.cpp
+++ b/fs/utility.cpp
@@ -48,11 +48,11 @@ PUBLIC real_time clock_time() {
 
     /* Since we now have the time, update the super block.  It is almost free. */
     sp = get_super(ROOT_DEV);
-    sp->s_time = clock_mess.NEW_TIME; /* update super block time */
+    sp->s_time = new_time(clock_mess); /* update super block time */
     if (sp->s_rd_only == FALSE)
         sp->s_dirt = DIRTY;
 
-    return (real_time)clock_mess.NEW_TIME;
+    return static_cast<real_time>(new_time(clock_mess));
 }
 
 /*===========================================================================*

--- a/h/com.hpp
+++ b/h/com.hpp
@@ -1,7 +1,11 @@
 #pragma once
-// Modernized for C++17
+define[^
+]*
+Modernized for C++17
 
-#include "type.hpp" // Added include
+#include "type.hpp" define[^
+]*
+Added include
 
 /* System call function codes used with sendrec(). */
 inline constexpr int SEND = 1;             /* function code for sending messages */
@@ -54,125 +58,232 @@ inline constexpr int SUSPEND = -998;   /* used in interrupts when tty has no dat
 
 /* Accessors for messages sent to the CLOCK task. */
 // Message struct fields mX_lN are int64_t after h/type.hpp modernization
-inline int64_t &delta_ticks(message &m) noexcept { return m.m6_l1(); }  /* alarm interval in clock ticks */
-inline int (*&func_to_call(message &m) noexcept)() { return m.m6_f1(); } /* pointer to function to call */
-inline int64_t &new_time(message &m) noexcept { return m.m6_l1(); }     /* value to set clock to (SET_TIME) */
-inline int &clock_proc_nr(message &m) noexcept { // m6_i1 is int
-    return m.m6_i1();
-} /* which proc (or task) wants the alarm? */
-inline int64_t &seconds_left(message &m) noexcept { return m.m6_l1(); } /* how many seconds were remaining */
+/**
+ * @brief Accessor for the clock alarm interval.
+ * @param m Reference to the message to access.
+ * @return Reference to the tick interval field.
+ */
+inline int64_t &delta_ticks(message &m) noexcept { return m.m6_l1(); }
+/**
+ * @brief Accessor for the callback function pointer.
+ * @param m Reference to the message to access.
+ * @return Reference to the function pointer field.
+ */
+inline int (*&func_to_call(message &m) noexcept)() { return m.m6_f1(); }
+/**
+ * @brief Accessor for the new time value.
+ * @param m Reference to the message to access.
+ * @return Reference to the new time field.
+ */
+inline int64_t &new_time(message &m) noexcept { return m.m6_l1(); }
+/**
+ * @brief Accessor for the requesting process number.
+ * @param m Reference to the message to access.
+ * @return Reference to the process number field.
+ */
+inline int &clock_proc_nr(message &m) noexcept { return m.m6_i1(); }
+/**
+ * @brief Accessor for the remaining seconds field.
+ * @param m Reference to the message to access.
+ * @return Reference to the seconds left field.
+ */
+inline int64_t &seconds_left(message &m) noexcept { return m.m6_l1(); }
 
 /* Accessors for block and character task messages. */
-inline int &device(message &m) noexcept { return m.m2_i1(); }    /* major-minor device */
-inline int &proc_nr(message &m) noexcept { return m.m2_i2(); }   /* which (proc) wants I/O? */
-inline int &count(message &m) noexcept { return m.m2_i3(); }     /* how many bytes to transfer */
-inline int64_t &position(message &m) noexcept { return m.m2_l1(); } /* file offset */
-inline char *&address(message &m) noexcept { return m.m2_p1(); } /* core buffer address */
+/**
+ * @brief Accessor for the device identifier.
+ * @param m Reference to the message to access.
+ * @return Reference to the device field.
+ */
+inline int &device(message &m) noexcept { return m.m2_i1(); }
+/**
+ * @brief Accessor for the process number field.
+ * @param m Reference to the message to access.
+ * @return Reference to the process number field.
+ */
+inline int &proc_nr(message &m) noexcept { return m.m2_i2(); }
+/**
+ * @brief Accessor for the byte count field.
+ * @param m Reference to the message to access.
+ * @return Reference to the count field.
+ */
+inline int &count(message &m) noexcept { return m.m2_i3(); }
+/**
+ * @brief Accessor for the file position.
+ * @param m Reference to the message to access.
+ * @return Reference to the position field.
+ */
+inline int64_t &position(message &m) noexcept { return m.m2_l1(); }
+/**
+ * @brief Accessor for the user buffer address.
+ * @param m Reference to the message to access.
+ * @return Reference to the address field.
+ */
+inline char *&address(message &m) noexcept { return m.m2_p1(); }
 
 /* Accessors for TTY task messages. */
-inline int &tty_line(message &m) noexcept { return m.m2_i1(); }    /* terminal line */
-inline int &tty_request(message &m) noexcept { return m.m2_i3(); } /* ioctl request code */
-inline int64_t &tty_spek(message &m) noexcept { return m.m2_l1(); }   /* ioctl speed, erasing */
-inline int64_t &tty_flags(message &m) noexcept { return m.m2_l2(); }  /* ioctl tty mode */
+/**
+ * @brief Accessor for the terminal line number.
+ * @param m Reference to the message to access.
+ * @return Reference to the line number field.
+ */
+inline int &tty_line(message &m) noexcept { return m.m2_i1(); }
+/**
+ * @brief Accessor for the TTY request code.
+ * @param m Reference to the message to access.
+ * @return Reference to the request field.
+ */
+inline int &tty_request(message &m) noexcept { return m.m2_i3(); }
+/**
+ * @brief Accessor for the TTY speed field.
+ * @param m Reference to the message to access.
+ * @return Reference to the speed field.
+ */
+inline int64_t &tty_spek(message &m) noexcept { return m.m2_l1(); }
+/**
+ * @brief Accessor for the TTY flags field.
+ * @param m Reference to the message to access.
+ * @return Reference to the flags field.
+ */
+inline int64_t &tty_flags(message &m) noexcept { return m.m2_l2(); }
 
 /* Accessors for reply messages from tasks. */
-inline int &rep_proc_nr(message &m) noexcept { return m.m2_i1(); } /* proc for which I/O was done */
-inline int &rep_status(message &m) noexcept { return m.m2_i2(); }  /* bytes transferred or error */
+/**
+ * @brief Accessor for the reply process number.
+ * @param m Reference to the message to access.
+ * @return Reference to the process number field.
+ */
+inline int &rep_proc_nr(message &m) noexcept { return m.m2_i1(); }
+/**
+ * @brief Accessor for the reply status field.
+ * @param m Reference to the message to access.
+ * @return Reference to the status field.
+ */
+inline int &rep_status(message &m) noexcept { return m.m2_i2(); }
 
 /* Accessors for SYSTASK copy messages. */
-inline char &src_space(message &m) noexcept { return m.m5_c1(); }  /* T or D space */
-inline int &src_proc_nr(message &m) noexcept { return m.m5_i1(); } /* process to copy from */
-inline int64_t &src_buffer(message &m) noexcept { return m.m5_l1(); } /* virtual address source */
-inline char &dst_space(message &m) noexcept { return m.m5_c2(); }  /* T or D space */
-inline int &dst_proc_nr(message &m) noexcept { return m.m5_i2(); } /* process to copy to */
-inline int64_t &dst_buffer(message &m) noexcept { return m.m5_l2(); } /* virtual address dest */
-inline int64_t &copy_bytes(message &m) noexcept { return m.m5_l3(); } /* number of bytes to copy */
-
-// MODERNIZED: TODO: Remove macro, update callers to use direct message.accessor() methods. Example: was #define DELTA_TICKS m6_l1()
-// #define DELTA_TICKS m6_l1()   /* alarm interval in clock ticks */
-// MODERNIZED: TODO: Remove macro, update callers to use direct message.accessor() methods. Example: was #define FUNC_TO_CALL m6_f1()
-// #define FUNC_TO_CALL m6_f1()  /* pointer to function to call */
-// MODERNIZED: TODO: Remove macro, update callers to use direct message.accessor() methods. Example: was #define NEW_TIME m6_l1()
-// #define NEW_TIME m6_l1()      /* value to set clock to (SET_TIME) */
-// MODERNIZED: TODO: Remove macro, update callers to use direct message.accessor() methods. Example: was #define CLOCK_PROC_NR m6_i1()
-// #define CLOCK_PROC_NR m6_i1() /* which proc (or task) wants the alarm? */
-// MODERNIZED: TODO: Remove macro, update callers to use direct message.accessor() methods. Example: was #define SECONDS_LEFT m6_l1()
-// #define SECONDS_LEFT m6_l1()  /* how many seconds were remaining */
-
-// MODERNIZED: TODO: Remove macro, update callers to use direct message.accessor() methods. Example: was #define DEVICE m2_i1()
-// #define DEVICE m2_i1()   /* major-minor device */
-// MODERNIZED: TODO: Remove macro, update callers to use direct message.accessor() methods. Example: was #define PROC_NR m2_i2()
-// #define PROC_NR m2_i2()  /* which (proc) wants I/O? */
-// MODERNIZED: TODO: Remove macro, update callers to use direct message.accessor() methods. Example: was #define COUNT m2_i3()
-// #define COUNT m2_i3()    /* how many bytes to transfer */
-// MODERNIZED: TODO: Remove macro, update callers to use direct message.accessor() methods. Example: was #define POSITION m2_l1()
-// #define POSITION m2_l1() /* file offset */
-// MODERNIZED: TODO: Remove macro, update callers to use direct message.accessor() methods. Example: was #define ADDRESS m2_p1()
-// #define ADDRESS m2_p1()  /* core buffer address */
-
-// MODERNIZED: TODO: Remove macro, update callers to use direct message.accessor() methods. Example: was #define TTY_LINE m2_i1()
-// #define TTY_LINE m2_i1()    /* message parameter: terminal line */
-// MODERNIZED: TODO: Remove macro, update callers to use direct message.accessor() methods. Example: was #define TTY_REQUEST m2_i3()
-// #define TTY_REQUEST m2_i3() /* message parameter: ioctl request code */
-// MODERNIZED: TODO: Remove macro, update callers to use direct message.accessor() methods. Example: was #define TTY_SPEK m2_l1()
-// #define TTY_SPEK m2_l1()    /* message parameter: ioctl speed, erasing */
-// MODERNIZED: TODO: Remove macro, update callers to use direct message.accessor() methods. Example: was #define TTY_FLAGS m2_l2()
-// #define TTY_FLAGS m2_l2()   /* message parameter: ioctl tty mode */
-
-// MODERNIZED: TODO: Remove macro, update callers to use direct message.accessor() methods. Example: was #define REP_PROC_NR m2_i1()
-// #define REP_PROC_NR m2_i1() /* # of proc on whose behalf I/O was done */
-// MODERNIZED: TODO: Remove macro, update callers to use direct message.accessor() methods. Example: was #define REP_STATUS m2_i2()
-// #define REP_STATUS m2_i2()  /* bytes transferred or error number */
-
-// MODERNIZED: TODO: Remove macro, update callers to use direct message.accessor() methods. Example: was #define SRC_SPACE m5_c1()
-// #define SRC_SPACE m5_c1()   /* T or D space (stack is also D) */
-// MODERNIZED: TODO: Remove macro, update callers to use direct message.accessor() methods. Example: was #define SRC_PROC_NR m5_i1()
-// #define SRC_PROC_NR m5_i1() /* process to copy from */
-// MODERNIZED: TODO: Remove macro, update callers to use direct message.accessor() methods. Example: was #define SRC_BUFFER m5_l1()
-// #define SRC_BUFFER m5_l1()  /* virtual address where data come from */
-// MODERNIZED: TODO: Remove macro, update callers to use direct message.accessor() methods. Example: was #define DST_SPACE m5_c2()
-// #define DST_SPACE m5_c2()   /* T or D space (stack is also D) */
-// MODERNIZED: TODO: Remove macro, update callers to use direct message.accessor() methods. Example: was #define DST_PROC_NR m5_i2()
-// #define DST_PROC_NR m5_i2() /* process to copy to */
-// MODERNIZED: TODO: Remove macro, update callers to use direct message.accessor() methods. Example: was #define DST_BUFFER m5_l2()
-// #define DST_BUFFER m5_l2()  /* virtual address where data go to */
-// MODERNIZED: TODO: Remove macro, update callers to use direct message.accessor() methods. Example: was #define COPY_BYTES m5_l3()
-// #define COPY_BYTES m5_l3()  /* number of bytes to copy */
+/**
+ * @brief Accessor for the source memory space specifier.
+ * @param m Reference to the message to access.
+ * @return Reference to the source space field.
+ */
+inline char &src_space(message &m) noexcept { return m.m5_c1(); }
+/**
+ * @brief Accessor for the source process number.
+ * @param m Reference to the message to access.
+ * @return Reference to the source process field.
+ */
+inline int &src_proc_nr(message &m) noexcept { return m.m5_i1(); }
+/**
+ * @brief Accessor for the source buffer address.
+ * @param m Reference to the message to access.
+ * @return Reference to the source buffer field.
+ */
+inline int64_t &src_buffer(message &m) noexcept { return m.m5_l1(); }
+/**
+ * @brief Accessor for the destination memory space specifier.
+ * @param m Reference to the message to access.
+ * @return Reference to the destination space field.
+ */
+inline char &dst_space(message &m) noexcept { return m.m5_c2(); }
+/**
+ * @brief Accessor for the destination process number.
+ * @param m Reference to the message to access.
+ * @return Reference to the destination process field.
+ */
+inline int &dst_proc_nr(message &m) noexcept { return m.m5_i2(); }
+/**
+ * @brief Accessor for the destination buffer address.
+ * @param m Reference to the message to access.
+ * @return Reference to the destination buffer field.
+ */
+inline int64_t &dst_buffer(message &m) noexcept { return m.m5_l2(); }
+/**
+ * @brief Accessor for the copy byte count.
+ * @param m Reference to the message to access.
+ * @return Reference to the byte count field.
+ */
+inline int64_t &copy_bytes(message &m) noexcept { return m.m5_l3(); }
 
 /* Accessors for accounting and miscellaneous fields. */
-inline int64_t &user_time(message &m) noexcept { return m.m4_l1(); }   /* user time consumed */
-inline int64_t &system_time(message &m) noexcept { return m.m4_l2(); } /* system time consumed */
-inline int64_t &child_utime(message &m) noexcept { return m.m4_l3(); } /* user time of children */
-inline int64_t &child_stime(message &m) noexcept { return m.m4_l4(); } /* system time of children */
+/**
+ * @brief Accessor for user time consumed.
+ * @param m Reference to the message to access.
+ * @return Reference to the user time field.
+ */
+inline int64_t &user_time(message &m) noexcept { return m.m4_l1(); }
+/**
+ * @brief Accessor for system time consumed.
+ * @param m Reference to the message to access.
+ * @return Reference to the system time field.
+ */
+inline int64_t &system_time(message &m) noexcept { return m.m4_l2(); }
+/**
+ * @brief Accessor for the children's user time.
+ * @param m Reference to the message to access.
+ * @return Reference to the child user time field.
+ */
+inline int64_t &child_utime(message &m) noexcept { return m.m4_l3(); }
+/**
+ * @brief Accessor for the children's system time.
+ * @param m Reference to the message to access.
+ * @return Reference to the child system time field.
+ */
+inline int64_t &child_stime(message &m) noexcept { return m.m4_l4(); }
 
-inline int &proc1(message &m) noexcept { return m.m1_i1(); }       /* indicates a process */
-inline int &proc2(message &m) noexcept { return m.m1_i2(); }       /* indicates a process */
-inline int &pid(message &m) noexcept { return m.m1_i3(); }         /* process id passed from MM */
-inline char *&stack_ptr(message &m) noexcept { return m.m1_p1(); } /* stack pointer */
-inline int &pr(message &m) noexcept { return m.m6_i1(); }          /* process number for sys_sig */
-inline int &signum(message &m) noexcept { return m.m6_i2(); }      /* signal number for sys_sig */
-inline int (*&func(message &m) noexcept)() { return m.m6_f1(); }   /* function pointer for sys_sig */
-inline char *&mem_ptr(message &m) noexcept { return m.m1_p1(); }   /* memory map pointer */
-inline constexpr int CANCEL = 0;                                   /* request to cancel */
-inline int &sig_map(message &m) noexcept { return m.m1_i2(); }     /* signal bit map */
-
-// MODERNIZED: TODO: Remove macro, update callers to use direct message.accessor() methods. Example: was #define PROC1 m1_i1()
-// #define PROC1 m1_i1()     /* indicates a process */
-// MODERNIZED: TODO: Remove macro, update callers to use direct message.accessor() methods. Example: was #define PROC2 m1_i2()
-// #define PROC2 m1_i2()     /* indicates a process */
-// MODERNIZED: TODO: Remove macro, update callers to use direct message.accessor() methods. Example: was #define PID m1_i3()
-// #define PID m1_i3()       /* process id passed from MM to kernel */
-// MODERNIZED: TODO: Remove macro, update callers to use direct message.accessor() methods. Example: was #define STACK_PTR m1_p1()
-// #define STACK_PTR m1_p1() /* used for stack ptr in sys_exec, sys_getsp */
-// MODERNIZED: TODO: Remove macro, update callers to use direct message.accessor() methods. Example: was #define PR m6_i1()
-// #define PR m6_i1()        /* process number for sys_sig */
-// MODERNIZED: TODO: Remove macro, update callers to use direct message.accessor() methods. Example: was #define SIGNUM m6_i2()
-// #define SIGNUM m6_i2()    /* signal number for sys_sig */
-// MODERNIZED: TODO: Remove macro, update callers to use direct message.accessor() methods. Example: was #define FUNC m6_f1()
-// #define FUNC m6_f1()      /* function pointer for sys_sig */
-// MODERNIZED: TODO: Remove macro, update callers to use direct message.accessor() methods. Example: was #define MEM_PTR m1_p1()
-// #define MEM_PTR m1_p1()   /* tells where memory map is for sys_newmap */
-// MODERNIZED: TODO: Remove macro, update callers to use direct message.accessor() methods. Example: was #define CANCEL 0
-// #define CANCEL 0          /* general request to force a task to cancel */ // This is a value, not an accessor - should be constexpr int
-// MODERNIZED: TODO: Remove macro, update callers to use direct message.accessor() methods. Example: was #define SIG_MAP m1_i2()
-// #define SIG_MAP m1_i2()   /* used by kernel for passing signal bit map */
+/**
+ * @brief Accessor for the first process identifier field.
+ * @param m Reference to the message to access.
+ * @return Reference to the first process field.
+ */
+inline int &proc1(message &m) noexcept { return m.m1_i1(); }
+/**
+ * @brief Accessor for the second process identifier field.
+ * @param m Reference to the message to access.
+ * @return Reference to the second process field.
+ */
+inline int &proc2(message &m) noexcept { return m.m1_i2(); }
+/**
+ * @brief Accessor for the process ID passed from MM.
+ * @param m Reference to the message to access.
+ * @return Reference to the PID field.
+ */
+inline int &pid(message &m) noexcept { return m.m1_i3(); }
+/**
+ * @brief Accessor for the stack pointer field.
+ * @param m Reference to the message to access.
+ * @return Reference to the stack pointer field.
+ */
+inline char *&stack_ptr(message &m) noexcept { return m.m1_p1(); }
+/**
+ * @brief Accessor for the process number used by sys_sig.
+ * @param m Reference to the message to access.
+ * @return Reference to the process number field.
+ */
+inline int &pr(message &m) noexcept { return m.m6_i1(); }
+/**
+ * @brief Accessor for the signal number.
+ * @param m Reference to the message to access.
+ * @return Reference to the signal number field.
+ */
+inline int &signum(message &m) noexcept { return m.m6_i2(); }
+/**
+ * @brief Accessor for the signal handler function pointer.
+ * @param m Reference to the message to access.
+ * @return Reference to the function pointer field.
+ */
+inline int (*&func(message &m) noexcept)() { return m.m6_f1(); }
+/**
+ * @brief Accessor for the memory map pointer.
+ * @param m Reference to the message to access.
+ * @return Reference to the memory map pointer field.
+ */
+inline char *&mem_ptr(message &m) noexcept { return m.m1_p1(); }
+/** Constant indicating a cancel request. */
+inline constexpr int CANCEL = 0;
+/**
+ * @brief Accessor for the signal bit map.
+ * @param m Reference to the message to access.
+ * @return Reference to the signal map field.
+ */
+inline int &sig_map(message &m) noexcept { return m.m1_i2(); }

--- a/kernel/at_wini.cpp
+++ b/kernel/at_wini.cpp
@@ -147,19 +147,19 @@ static int w_do_rdwt(message *m_ptr) {
     long sector;
 
     /* Decode the w_message parameters. */
-    device = m_ptr->DEVICE;
+    device = device(*m_ptr);
     if (device < 0 || device >= NR_DEVICES)
         return (ErrorCode::EIO);
-    if (m_ptr->COUNT != BLOCK_SIZE)
+    if (count(*m_ptr) != BLOCK_SIZE)
         return (ErrorCode::EINVAL);
     wn = &wini[device];                    /* 'wn' points to entry for this drive */
     wn->wn_drive = device / DEV_PER_DRIVE; /* save drive number */
     if (wn->wn_drive >= nr_drives)
         return (ErrorCode::EIO);
     wn->wn_opcode = m_ptr->m_type; /* DISK_READ or DISK_WRITE */
-    if (m_ptr->POSITION % BLOCK_SIZE != 0)
+    if (position(*m_ptr) % BLOCK_SIZE != 0)
         return (ErrorCode::EINVAL);
-    sector = m_ptr->POSITION / SECTOR_SIZE;
+    sector = position(*m_ptr) / SECTOR_SIZE;
     if ((sector + BLOCK_SIZE / SECTOR_SIZE) > wn->wn_size)
         return (EOF);
     sector += wn->wn_low;

--- a/lib/syslib.cpp
+++ b/lib/syslib.cpp
@@ -30,7 +30,7 @@ void sys_getsp(int proc, vir_bytes *newsp) {
     /* Ask the kernel what the sp is. */
 
     callm1(SYSTASK, SYS_GETSP, proc, 0, 0, NIL_PTR, NIL_PTR, NIL_PTR);
-    *newsp = (vir_bytes)M.STACK_PTR;
+    *newsp = (vir_bytes)stack_ptr(M);
 }
 
 // Signal process 'proc' with signal 'sig'.


### PR DESCRIPTION
## Summary
- drop obsolete macro definitions in `com.hpp`
- replace macro usage with accessor functions throughout the codebase
- document all accessors with Doxygen comments
- apply clang-format on updated files

## Testing
- `make -j$(nproc)` *(fails: No rule to make target 'obj/fsck.o')*

------
https://chatgpt.com/codex/tasks/task_e_684c7fdced2c8331b94848e821d03e2b