### PR TITLE
Add clang-format pre-commit hook

### DIFF
--- a/README.md
+++ b/README.md
@@ -269,7 +269,8 @@ make gdb
 
 ### Contributing
 
-1. **Code Style**: Run `make format` before committing
+1. **Code Style**: Run `make format` before committing or enable the
+   `tools/pre-commit-clang-format.sh` hook for automatic formatting
 2. **Testing**: Ensure `make check` passes
 3. **Documentation**: Update documentation for new features
 4. **Performance**: Profile critical code paths

--- a/docs/sphinx/index.rst
+++ b/docs/sphinx/index.rst
@@ -6,3 +6,4 @@ XINIM Documentation
    :caption: Contents:
 
    api
+   precommit

--- a/docs/sphinx/precommit.rst
+++ b/docs/sphinx/precommit.rst
@@ -1,0 +1,12 @@
+Pre-commit Hook
+===============
+
+The repository provides a `pre-commit` script to automatically run
+``clang-format`` on staged C++ files. Enable it by linking the script
+into your Git hooks directory:
+
+.. code-block:: bash
+
+   ln -s ../../tools/pre-commit-clang-format.sh .git/hooks/pre-commit
+
+This ensures consistent style before every commit.

--- a/tools/pre-commit-clang-format.sh
+++ b/tools/pre-commit-clang-format.sh
@@ -1,0 +1,20 @@
+#!/bin/sh
+## \file pre-commit-clang-format.sh
+## \brief Git pre-commit hook to format staged C++ files with clang-format.
+##
+## This hook formats any staged `.cpp` or `.hpp` files using clang-format
+## and re-adds them to the commit. It prevents committing improperly
+## formatted code and keeps style consistent across contributions.
+##
+## Usage:
+##     ln -s ../../tools/pre-commit-clang-format.sh .git/hooks/pre-commit
+##
+## \author Auto-generated
+
+FILES=$(git diff --cached --name-only --diff-filter=ACM | grep -E '\.(cpp|hpp)$')
+if [ -n "$FILES" ]; then
+    clang-format -i $FILES
+    git add $FILES
+fi
+
+exit 0


### PR DESCRIPTION
## Summary
- add `pre-commit-clang-format.sh` in tools for automatic formatting
- document the hook in README
- mention the hook in Sphinx documentation

## Testing
- `clang-format -i $(find kernel mm lib include -name '*.cpp' -o -name '*.hpp')`


------
https://chatgpt.com/codex/tasks/task_e_684cee71b0e4833185580a7c4a12c659