### PR TITLE
Implement lattice IPC with PQ crypto

### DIFF
--- a/h/type.hpp
+++ b/h/type.hpp
@@ -5,10 +5,10 @@
 #define TYPE_H
 
 /* Pull in the fixed-width integer typedefs. */
-#include "../include/defs.hpp" // project-wide integer definitions
-#include <cstddef>             // for std::size_t
-#include <cstdint>             // for fixed-width integer types
-#include "../../include/xinim/core_types.hpp" // New include for xinim types
+#include "../include/defs.hpp"             // project-wide integer definitions
+#include "../include/xinim/core_types.hpp" // New include for xinim types
+#include <cstddef>                         // for std::size_t
+#include <cstdint>                         // for fixed-width integer types
 
 // Utility functions -------------------------------------------------------*/
 /*!
@@ -25,16 +25,16 @@ template <typename T> constexpr T min(T a, T b) noexcept { return a < b ? a : b;
 // Minix specific types that don't directly map or are more granular than xinim::core_types
 // will remain for now. Types that have a direct xinim equivalent will be commented
 // out or aliased to the xinim type.
-using unshort = uint16_t;         /* must be 16-bit unsigned */
-using block_nr = uint16_t;               /* block number */
+using unshort = uint16_t;               /* must be 16-bit unsigned */
+using block_nr = uint16_t;              /* block number */
 inline constexpr block_nr kNoBlock = 0; /* absence of a block number */
 inline constexpr block_nr kMaxBlockNr = 0177777;
 
-using inode_nr = uint16_t;                        /* inode number */
+using inode_nr = uint16_t;                       /* inode number */
 inline constexpr inode_nr kNoEntry = 0;          /* absence of a dir entry */
 inline constexpr inode_nr kMaxInodeNr = 0177777; /* highest inode number */
 
-using zone_nr = uint16_t;              /* zone number */
+using zone_nr = uint16_t;             /* zone number */
 inline constexpr zone_nr kNoZone = 0; /* absence of a zone number */
 inline constexpr zone_nr kHighestZone = 0177777;
 
@@ -52,21 +52,25 @@ inline constexpr links kMaxLinks = 0177;
 // MODERNIZED: using real_time = int64_t;
 using real_time = xinim::time_t; // Maps to xinim::time_t (std::int64_t)
 
-using file_pos = int32_t;  /* position in, or length of, a file - Minix specific, smaller than off_t */
+using file_pos =
+    int32_t; /* position in, or length of, a file - Minix specific, smaller than off_t */
 inline constexpr file_pos kMaxFilePos = 017777777777;
-using file_pos64 = i64_t; /* 64-bit file positions - Minix specific, similar to xinim::off_t if that were defined */
+using file_pos64 = i64_t; /* 64-bit file positions - Minix specific, similar to xinim::off_t if that
+                             were defined */
 inline constexpr file_pos64 kMaxFilePos64 = I64_C(0x7fffffffffffffff);
 using uid = uint16_t; /* user id - Minix specific (xinim::uid_t is int32_t) */
-using gid = uint8_t;      /* group id - Minix specific (xinim::gid_t is int32_t) */
+using gid = uint8_t;  /* group id - Minix specific (xinim::gid_t is int32_t) */
 
 // Aliases to types defined in xinim::core_types.hpp
-using vir_bytes = xinim::vir_bytes_t;
+using vir_bytes = xinim::virt_bytes_t;
 using phys_bytes = xinim::phys_bytes_t;
-using vir_clicks = xinim::virt_addr_t;  // Representing a count/size related to virtual memory units based on address size
-using phys_clicks = xinim::phys_addr_t; // Representing a count/size related to physical memory units based on address size
+using vir_clicks = xinim::virt_addr_t;  // Representing a count/size related to virtual memory units
+                                        // based on address size
+using phys_clicks = xinim::phys_addr_t; // Representing a count/size related to physical memory
+                                        // units based on address size
 
-using signed_clicks = int64_t;    /* same length as phys_clicks, but signed - Minix specific */
-                                  // No direct xinim equivalent, related to Minix clicks.
+using signed_clicks = int64_t; /* same length as phys_clicks, but signed - Minix specific */
+                               // No direct xinim equivalent, related to Minix clicks.
 
 /* Types relating to messages. */
 inline constexpr int M1 = 1;         /* style of message with three ints and three pointers */
@@ -182,7 +186,7 @@ struct message {
     constexpr const int &m6_i3() const { return m_u.m_m6.m6i3; }
     constexpr int64_t &m6_l1() { return m_u.m_m6.m6l1; }
     constexpr const int64_t &m6_l1() const { return m_u.m_m6.m6l1; }
-    constexpr int (*&m6_f1())() { return m_u.m_m6.m6f1; } // Modern C-style: int(*)()
+    constexpr int (*&m6_f1())() { return m_u.m_m6.m6f1; }             // Modern C-style: int(*)()
     constexpr int (*const &m6_f1() const)() { return m_u.m_m6.m6f1; } // Modern C-style: int(*)()
 };
 

--- a/include/minix/io/file_stream.hpp
+++ b/include/minix/io/file_stream.hpp
@@ -20,10 +20,10 @@ class FileStream : public Stream {
     explicit FileStream(int fd, bool write) : fd_(fd), writable_(write) {}
     ~FileStream() override = default;
 
-    /// Read data from the file descriptor.
-    Result<size_t> read(std::span<std::byte> buffer) override;
-    /// Write data to the file descriptor.
-    Result<size_t> write(std::span<const std::byte> buffer) override;
+    /// Read data from the file descriptor into @p buffer.
+    Result<size_t> read(std::byte *buffer, size_t length) override;
+    /// Write data from @p buffer to the file descriptor.
+    Result<size_t> write(const std::byte *buffer, size_t length) override;
     /// Close the file descriptor if owned.
     std::error_code close() override;
     /// Access the underlying descriptor.

--- a/kernel/CMakeLists.txt
+++ b/kernel/CMakeLists.txt
@@ -8,7 +8,7 @@ endif()
 set(KERNEL_SRC
     clock.cpp dmp.cpp floppy.cpp main.cpp memory.cpp printer.cpp proc.cpp system.cpp
     table.cpp tty.cpp idt64.cpp mpx64.cpp klib64.cpp klib88.cpp mpx88.cpp paging.cpp
-    wormhole.cpp syscall.cpp ${WINI_SRC})
+    wormhole.cpp lattice_ipc.cpp pqcrypto.cpp syscall.cpp ${WINI_SRC})
 #Note : klib88.cpp and mpx88.cpp were added as they appear to be kernel related sources.
 #wini.cpp is a generic name, might be a common file or superseded by at_wini / xt_wini.
 #For now, including specific at_wini / xt_wini based on WINI_DRIVER.

--- a/kernel/const.hpp
+++ b/kernel/const.hpp
@@ -3,15 +3,15 @@
 
 /* General constants used by the kernel. */
 
-#include "../../include/xinim/core_types.hpp" // For std::uint64_t, std::size_t, etc.
-#include <cstdint> // For uint64_t
-#include <cstddef> // For std::size_t
+#include "../include/xinim/core_types.hpp" // For std::uint64_t, std::size_t, etc.
+#include <cstddef>                         // For std::size_t
+#include <cstdint>                         // For uint64_t
 
 /* 64-bit configuration constants */
 /* Register order: rax, rbx, rcx, rdx, rsi, rdi, rbp, r8, r9, r10, r11, r12, r13, r14, r15 */
 inline constexpr int NR_REGS = 15;
 inline constexpr int INIT_PSW = 0x0200;
-inline constexpr std::uint64_t* INIT_SP = nullptr; // Using std::uint64_t from core_types
+inline constexpr std::uint64_t *INIT_SP = nullptr; // Using std::uint64_t from core_types
 inline constexpr int ES_REG = 0;
 inline constexpr int DS_REG = 0;
 inline constexpr int CS_REG = 0;
@@ -40,8 +40,8 @@ inline constexpr int RET_REG = 0; /* system call return codes go in this reg */
 inline constexpr int IDLE = -999; /* 'cur_proc' = IDLE means nobody is running */
 
 /* Scheduler configuration */
-#define SCHED_ROUND_ROBIN 0 /* set to 1 for simple round-robin */
-inline constexpr int NR_CPUS = 1;           /* number of CPUs (SMP placeholder) */
+#define SCHED_ROUND_ROBIN 0       /* set to 1 for simple round-robin */
+inline constexpr int NR_CPUS = 1; /* number of CPUs (SMP placeholder) */
 
 #if SCHED_ROUND_ROBIN
 inline constexpr int NQ = 3;       /* # of scheduling queues */

--- a/kernel/lattice_ipc.cpp
+++ b/kernel/lattice_ipc.cpp
@@ -1,0 +1,114 @@
+#include "lattice_ipc.hpp"
+#include "glo.hpp"
+#include "proc.hpp"
+#include <algorithm>
+
+namespace lattice {
+
+Graph g_graph{};
+
+/**
+ * @brief Create or retrieve a channel between two processes.
+ */
+Channel &Graph::connect(int s, int d) {
+    auto &vec = edges[s];
+    auto it = std::find_if(vec.begin(), vec.end(), [d](const Channel &c) { return c.dst == d; });
+    if (it != vec.end()) {
+        return *it;
+    }
+    pqcrypto::KeyPair a = pqcrypto::generate_keypair();
+    pqcrypto::KeyPair b = pqcrypto::generate_keypair();
+    Channel ch{.src = s, .dst = d};
+    ch.secret = pqcrypto::establish_secret(a, b);
+    vec.push_back(ch);
+    return vec.back();
+}
+
+/**
+ * @brief Locate an existing channel.
+ */
+Channel *Graph::find(int s, int d) noexcept {
+    auto it = edges.find(s);
+    if (it == edges.end()) {
+        return nullptr;
+    }
+    auto &vec = it->second;
+    auto vit = std::find_if(vec.begin(), vec.end(), [d](const Channel &c) { return c.dst == d; });
+    if (vit == vec.end()) {
+        return nullptr;
+    }
+    return &*vit;
+}
+
+/**
+ * @brief Check whether a process is waiting for a message.
+ */
+bool Graph::is_listening(int pid) const noexcept {
+    auto it = listening.find(pid);
+    return it != listening.end() && it->second;
+}
+
+/**
+ * @brief Wrapper around Graph::connect for external consumers.
+ */
+int lattice_connect(int src, int dst) {
+    g_graph.connect(src, dst);
+    return OK;
+}
+
+/**
+ * @brief Register a process as listening for a message.
+ */
+void lattice_listen(int pid) { g_graph.set_listening(pid, true); }
+
+/**
+ * @brief Helper to switch execution to another process.
+ */
+static void yield_to(int pid) {
+    proc_ptr = proc_addr(pid);
+    cur_proc = pid;
+}
+
+/**
+ * @brief Send a message across a channel.
+ */
+int lattice_send(int src, int dst, const message &msg) {
+    Channel *ch = g_graph.find(src, dst);
+    if (ch == nullptr) {
+        ch = &g_graph.connect(src, dst);
+    }
+    if (g_graph.is_listening(dst)) {
+        g_graph.inbox[dst] = msg;
+        g_graph.set_listening(dst, false);
+        yield_to(dst);
+    } else {
+        ch->queue.push_back(msg);
+    }
+    return OK;
+}
+
+/**
+ * @brief Receive a message destined for a process.
+ */
+int lattice_recv(int pid, message *msg) {
+    auto it = g_graph.inbox.find(pid);
+    if (it != g_graph.inbox.end()) {
+        *msg = it->second;
+        g_graph.inbox.erase(it);
+        return OK;
+    }
+    for (auto &[src, vec] : g_graph.edges) {
+        auto vit = std::find_if(vec.begin(), vec.end(), [pid](const Channel &c) {
+            return c.dst == pid && !c.queue.empty();
+        });
+        if (vit != vec.end()) {
+            *msg = vit->queue.front();
+            vit->queue.erase(vit->queue.begin());
+            return OK;
+        }
+    }
+    lattice_listen(pid);
+    return static_cast<int>(ErrorCode::E_NO_MESSAGE);
+}
+
+} // namespace lattice

--- a/kernel/lattice_ipc.hpp
+++ b/kernel/lattice_ipc.hpp
@@ -1,0 +1,96 @@
+#pragma once
+/**
+ * @file lattice_ipc.hpp
+ * @brief Directed acyclic graph based IPC primitives.
+ */
+
+#include "pqcrypto.hpp"
+#include "proc.hpp"
+#include <unordered_map>
+#include <vector>
+
+namespace lattice {
+
+/** Forward declaration of message structure. */
+struct message;
+
+/**
+ * @brief Channel connecting two processes.
+ */
+struct Channel {
+    int src;                             //!< Source process id
+    int dst;                             //!< Destination process id
+    std::vector<message> queue;          //!< Pending messages
+    std::array<std::uint8_t, 32> secret; //!< Shared secret derived by PQ crypto
+};
+
+/**
+ * @brief Graph storing channels as adjacency lists.
+ */
+class Graph {
+  public:
+    /** Add an edge between @p s and @p d creating a channel if absent. */
+    Channel &connect(int s, int d);
+    /** Find an existing channel or return nullptr. */
+    Channel *find(int s, int d) noexcept;
+    /** Mark @p pid as waiting for a message. */
+    void set_listening(int pid, bool flag) noexcept { listening[pid] = flag; }
+    /** Check if @p pid is currently waiting for a message. */
+    [[nodiscard]] bool is_listening(int pid) const noexcept;
+
+    std::unordered_map<int, std::vector<Channel>> edges; //!< adjacency list
+    std::unordered_map<int, bool> listening;             //!< listen state per pid
+    std::unordered_map<int, message> inbox;              //!< ready messages
+};
+
+extern Graph g_graph; //!< Global DAG instance
+
+/**
+ * @brief Establish a channel between two processes.
+ *
+ * If the channel does not yet exist it is created and a shared
+ * secret derived using the PQ cryptography routines.
+ *
+ * @param src Source process identifier.
+ * @param dst Destination process identifier.
+ * @return Always returns ::OK for now.
+ */
+int lattice_connect(int src, int dst);
+
+/**
+ * @brief Mark a process as waiting for an incoming message.
+ *
+ * When a subsequent send targets this process the message will be
+ * delivered immediately and control transferred to the receiver.
+ *
+ * @param pid Process identifier.
+ */
+void lattice_listen(int pid);
+
+/**
+ * @brief Send a message over an established channel.
+ *
+ * If the destination is listening the message is delivered and the
+ * scheduler yields directly to the receiver.
+ * Otherwise the message is queued on the channel.
+ *
+ * @param src Sending process identifier.
+ * @param dst Receiving process identifier.
+ * @param msg Message to send.
+ * @return ::OK on success.
+ */
+int lattice_send(int src, int dst, const message &msg);
+
+/**
+ * @brief Receive a message for a process.
+ *
+ * If no message is pending the process is marked as listening and
+ * ::E_NO_MESSAGE is returned.
+ *
+ * @param pid Process identifier.
+ * @param msg Buffer to store the received message.
+ * @return ::OK on success or ::E_NO_MESSAGE when no message is available.
+ */
+int lattice_recv(int pid, message *msg);
+
+} // namespace lattice

--- a/kernel/pqcrypto.cpp
+++ b/kernel/pqcrypto.cpp
@@ -1,0 +1,29 @@
+#include "pqcrypto.hpp"
+#include <random>
+
+namespace pqcrypto {
+
+KeyPair generate_keypair() noexcept {
+    std::random_device rd;
+    std::mt19937 gen(rd());
+    std::uniform_int_distribution<std::uint16_t> dist(0, 255);
+
+    KeyPair kp{};
+    for (auto &b : kp.public_key) {
+        b = static_cast<std::uint8_t>(dist(gen));
+    }
+    for (auto &b : kp.private_key) {
+        b = static_cast<std::uint8_t>(dist(gen));
+    }
+    return kp;
+}
+
+std::array<std::uint8_t, 32> establish_secret(const KeyPair &local, const KeyPair &peer) noexcept {
+    std::array<std::uint8_t, 32> secret{};
+    for (std::size_t i = 0; i < secret.size(); ++i) {
+        secret[i] = static_cast<std::uint8_t>(local.private_key[i] ^ peer.public_key[i]);
+    }
+    return secret;
+}
+
+} // namespace pqcrypto

--- a/kernel/pqcrypto.hpp
+++ b/kernel/pqcrypto.hpp
@@ -1,0 +1,43 @@
+#pragma once
+/**
+ * @file pqcrypto.hpp
+ * @brief Minimal post-quantum cryptography interface used by the lattice IPC layer.
+ */
+#include <array>
+#include <cstdint>
+
+namespace pqcrypto {
+
+/**
+ * @brief Simple key pair for establishing a shared secret.
+ */
+struct KeyPair {
+    std::array<std::uint8_t, 32> public_key;  //!< Public component
+    std::array<std::uint8_t, 32> private_key; //!< Private component
+};
+
+/**
+ * @brief Generate a new post-quantum key pair.
+ *
+ * The implementation uses a pseudo random number generator and does
+ * not provide real security. It simply mimics an API expected by the
+ * lattice IPC channel setup.
+ *
+ * @return Newly generated key pair.
+ */
+[[nodiscard]] KeyPair generate_keypair() noexcept;
+
+/**
+ * @brief Derive a shared secret from two key pairs.
+ *
+ * The operation XORs bytes from the caller's private key with the peer's
+ * public key to produce a placeholder secret.
+ *
+ * @param local Local key pair.
+ * @param peer Peer key pair.
+ * @return Derived shared secret.
+ */
+[[nodiscard]] std::array<std::uint8_t, 32> establish_secret(const KeyPair &local,
+                                                            const KeyPair &peer) noexcept;
+
+} // namespace pqcrypto

--- a/kernel/type.hpp
+++ b/kernel/type.hpp
@@ -7,13 +7,12 @@
  * trap or interrupt, as well as for causing interrupts for signals.
  */
 
-#include "../include/defs.hpp" // Project-wide definitions
-#include "../../include/xinim/core_types.hpp" // For xinim::virt_addr_t and std::uint64_t
+#include "../include/defs.hpp"             // Project-wide definitions
+#include "../include/xinim/core_types.hpp" // For xinim::virt_addr_t and std::uint64_t
 
 struct pc_psw {
-    xinim::virt_addr_t pc;  /* program counter */
-    std::uint64_t psw;      /* processor status word */
-
+    xinim::virt_addr_t pc; /* program counter */
+    std::uint64_t psw;     /* processor status word */
 };
 
 struct sig_info {

--- a/lib/io/src/file_stream.cpp
+++ b/lib/io/src/file_stream.cpp
@@ -2,31 +2,32 @@
 
 #include <cerrno>
 #include <cstring>
-#include <fcntl.h>
-#include <span>
-#include <unistd.h>
 #include <expected> // For std::unexpected
+#include <fcntl.h>
+#include <unistd.h>
 
 namespace minix::io {
 
-/// Read from the underlying file descriptor into the supplied span.
+/// Read from the underlying file descriptor into the supplied buffer.
 ///
-/// \param buffer Destination span for file data.
+/// \param buffer Destination for file data.
+/// \param length Maximum number of bytes to read.
 /// \return       Number of bytes read or an error code.
-Result<size_t> FileStream::read(std::span<std::byte> buffer) {
-    ssize_t ret = ::read(fd_, buffer.data(), buffer.size());
+Result<size_t> FileStream::read(std::byte *buffer, size_t length) {
+    ssize_t ret = ::read(fd_, buffer, length);
     if (ret < 0) {
         return std::unexpected(std::error_code(errno, std::generic_category()));
     }
     return static_cast<size_t>(ret);
 }
 
-/// Write the given span to the underlying file descriptor.
+/// Write the given data to the underlying file descriptor.
 ///
 /// \param buffer Data to write.
+/// \param length Number of bytes to write.
 /// \return       Number of bytes written or an error code.
-Result<size_t> FileStream::write(std::span<const std::byte> buffer) {
-    ssize_t ret = ::write(fd_, buffer.data(), buffer.size());
+Result<size_t> FileStream::write(const std::byte *buffer, size_t length) {
+    ssize_t ret = ::write(fd_, buffer, length);
     if (ret < 0) {
         return std::unexpected(std::error_code(errno, std::generic_category()));
     }


### PR DESCRIPTION
## Summary
- introduce basic PQ crypto module
- implement DAG-based lattice IPC with connect/listen/send/recv
- expose new kernel sources in build
- update includes for xinim/core_types path
- make FileStream derive correctly from Stream

## Testing
- `cmake -B build`
- `cmake --build build -j$(nproc)` *(fails: missing header and specifier mismatches)*

------
https://chatgpt.com/codex/tasks/task_e_684cee81c9cc8331a25b9a72dbfaafe0

## Summary by Sourcery

Introduce a post-quantum cryptography API and use it to implement a DAG-based lattice IPC layer in the kernel; update core type definitions and I/O interfaces to align with xinim types; add new sources to the build.

New Features:
- Provide a post-quantum cryptography module for generating key pairs and deriving shared secrets
- Add a directed acyclic graph–based lattice IPC mechanism with connect, listen, send, and receive primitives

Enhancements:
- Update type headers and include paths to use xinim::core_types and correct type aliases
- Revise FileStream to properly derive from Stream and switch from std::span to raw buffer and length parameters

Build:
- Include lattice_ipc.cpp and pqcrypto.cpp in the kernel CMakeLists