### PR TITLE
Improve libc and add shared MessageBuffer

### DIFF
--- a/h/type.hpp
+++ b/h/type.hpp
@@ -5,10 +5,10 @@
 #define TYPE_H
 
 /* Pull in the fixed-width integer typedefs. */
-#include "../include/defs.hpp" // project-wide integer definitions
-#include <cstddef>             // for std::size_t
-#include <cstdint>             // for fixed-width integer types
-#include "../../include/xinim/core_types.hpp" // New include for xinim types
+#include "../include/defs.hpp"  // project-wide integer definitions
+#include <cstddef>              // for std::size_t
+#include <cstdint>              // for fixed-width integer types
+#include <xinim/core_types.hpp> // New include for xinim types
 
 // Utility functions -------------------------------------------------------*/
 /*!
@@ -25,16 +25,16 @@ template <typename T> constexpr T min(T a, T b) noexcept { return a < b ? a : b;
 // Minix specific types that don't directly map or are more granular than xinim::core_types
 // will remain for now. Types that have a direct xinim equivalent will be commented
 // out or aliased to the xinim type.
-using unshort = uint16_t;         /* must be 16-bit unsigned */
-using block_nr = uint16_t;               /* block number */
+using unshort = uint16_t;               /* must be 16-bit unsigned */
+using block_nr = uint16_t;              /* block number */
 inline constexpr block_nr kNoBlock = 0; /* absence of a block number */
 inline constexpr block_nr kMaxBlockNr = 0177777;
 
-using inode_nr = uint16_t;                        /* inode number */
+using inode_nr = uint16_t;                       /* inode number */
 inline constexpr inode_nr kNoEntry = 0;          /* absence of a dir entry */
 inline constexpr inode_nr kMaxInodeNr = 0177777; /* highest inode number */
 
-using zone_nr = uint16_t;              /* zone number */
+using zone_nr = uint16_t;             /* zone number */
 inline constexpr zone_nr kNoZone = 0; /* absence of a zone number */
 inline constexpr zone_nr kHighestZone = 0177777;
 
@@ -52,21 +52,25 @@ inline constexpr links kMaxLinks = 0177;
 // MODERNIZED: using real_time = int64_t;
 using real_time = xinim::time_t; // Maps to xinim::time_t (std::int64_t)
 
-using file_pos = int32_t;  /* position in, or length of, a file - Minix specific, smaller than off_t */
+using file_pos =
+    int32_t; /* position in, or length of, a file - Minix specific, smaller than off_t */
 inline constexpr file_pos kMaxFilePos = 017777777777;
-using file_pos64 = i64_t; /* 64-bit file positions - Minix specific, similar to xinim::off_t if that were defined */
+using file_pos64 = i64_t; /* 64-bit file positions - Minix specific, similar to xinim::off_t if that
+                             were defined */
 inline constexpr file_pos64 kMaxFilePos64 = I64_C(0x7fffffffffffffff);
 using uid = uint16_t; /* user id - Minix specific (xinim::uid_t is int32_t) */
-using gid = uint8_t;      /* group id - Minix specific (xinim::gid_t is int32_t) */
+using gid = uint8_t;  /* group id - Minix specific (xinim::gid_t is int32_t) */
 
 // Aliases to types defined in xinim::core_types.hpp
-using vir_bytes = xinim::vir_bytes_t;
+using vir_bytes = xinim::virt_bytes_t;
 using phys_bytes = xinim::phys_bytes_t;
-using vir_clicks = xinim::virt_addr_t;  // Representing a count/size related to virtual memory units based on address size
-using phys_clicks = xinim::phys_addr_t; // Representing a count/size related to physical memory units based on address size
+using vir_clicks = xinim::virt_addr_t;  // Representing a count/size related to virtual memory units
+                                        // based on address size
+using phys_clicks = xinim::phys_addr_t; // Representing a count/size related to physical memory
+                                        // units based on address size
 
-using signed_clicks = int64_t;    /* same length as phys_clicks, but signed - Minix specific */
-                                  // No direct xinim equivalent, related to Minix clicks.
+using signed_clicks = int64_t; /* same length as phys_clicks, but signed - Minix specific */
+                               // No direct xinim equivalent, related to Minix clicks.
 
 /* Types relating to messages. */
 inline constexpr int M1 = 1;         /* style of message with three ints and three pointers */
@@ -182,7 +186,7 @@ struct message {
     constexpr const int &m6_i3() const { return m_u.m_m6.m6i3; }
     constexpr int64_t &m6_l1() { return m_u.m_m6.m6l1; }
     constexpr const int64_t &m6_l1() const { return m_u.m_m6.m6l1; }
-    constexpr int (*&m6_f1())() { return m_u.m_m6.m6f1; } // Modern C-style: int(*)()
+    constexpr int (*&m6_f1())() { return m_u.m_m6.m6f1; }             // Modern C-style: int(*)()
     constexpr int (*const &m6_f1() const)() { return m_u.m_m6.m6f1; } // Modern C-style: int(*)()
 };
 

--- a/include/shared/stat_struct.hpp
+++ b/include/shared/stat_struct.hpp
@@ -3,18 +3,18 @@
 // Shared definition of the `stat` structure used by both the
 // kernel headers in `h/` and the user space headers in `include/`.
 // This matches the historical layout from MINIX.
-#include "../xinim/core_types.hpp" // For xinim::dev_t, xinim::ino_t etc.
+#include <xinim/core_types.hpp> // For xinim::dev_t, xinim::ino_t etc.
 
 struct stat {
-    xinim::dev_t   st_dev;     // Was short int
-    xinim::ino_t   st_ino;     // Was unsigned short
-    xinim::mode_t  st_mode;    // Was unsigned short
-    xinim::nlink_t st_nlink;   // Was short int
-    xinim::uid_t   st_uid;     // Was short int
-    xinim::gid_t   st_gid;     // Was short int
-    xinim::dev_t   st_rdev;    // Was short int (assuming device number)
-    xinim::off_t   st_size;    // Was long (xinim::off_t is std::int64_t)
-    xinim::time_t  st_atime;   // Was long (xinim::time_t is std::int64_t)
-    xinim::time_t  st_mtime;   // Was long
-    xinim::time_t  st_ctime;   // Was long
+    xinim::dev_t st_dev;     // Was short int
+    xinim::ino_t st_ino;     // Was unsigned short
+    xinim::mode_t st_mode;   // Was unsigned short
+    xinim::nlink_t st_nlink; // Was short int
+    xinim::uid_t st_uid;     // Was short int
+    xinim::gid_t st_gid;     // Was short int
+    xinim::dev_t st_rdev;    // Was short int (assuming device number)
+    xinim::off_t st_size;    // Was long (xinim::off_t is std::int64_t)
+    xinim::time_t st_atime;  // Was long (xinim::time_t is std::int64_t)
+    xinim::time_t st_mtime;  // Was long
+    xinim::time_t st_ctime;  // Was long
 };

--- a/include/stat.hpp
+++ b/include/stat.hpp
@@ -9,7 +9,7 @@
 // Shared stat structure used by user space. The layout is provided by the
 // common header to keep it consistent with the kernel version.
 #include "shared/stat_struct.hpp" // This now includes xinim::core_types.hpp
-#include "../xinim/core_types.hpp" // Ensure xinim::mode_t is directly available
+#include <xinim/core_types.hpp>   // Ensure xinim::mode_t is directly available
 
 /* Some common definitions. */
 // Converted to inline constexpr xinim::mode_t for type safety

--- a/kernel/CMakeLists.txt
+++ b/kernel/CMakeLists.txt
@@ -8,7 +8,7 @@ endif()
 set(KERNEL_SRC
     clock.cpp dmp.cpp floppy.cpp main.cpp memory.cpp printer.cpp proc.cpp system.cpp
     table.cpp tty.cpp idt64.cpp mpx64.cpp klib64.cpp klib88.cpp mpx88.cpp paging.cpp
-    wormhole.cpp syscall.cpp ${WINI_SRC})
+    wormhole.cpp syscall.cpp lattice_ipc.cpp ${WINI_SRC})
 #Note : klib88.cpp and mpx88.cpp were added as they appear to be kernel related sources.
 #wini.cpp is a generic name, might be a common file or superseded by at_wini / xt_wini.
 #For now, including specific at_wini / xt_wini based on WINI_DRIVER.

--- a/kernel/const.hpp
+++ b/kernel/const.hpp
@@ -3,15 +3,15 @@
 
 /* General constants used by the kernel. */
 
-#include "../../include/xinim/core_types.hpp" // For std::uint64_t, std::size_t, etc.
-#include <cstdint> // For uint64_t
-#include <cstddef> // For std::size_t
+#include <cstddef>              // For std::size_t
+#include <cstdint>              // For uint64_t
+#include <xinim/core_types.hpp> // For std::uint64_t, std::size_t, etc.
 
 /* 64-bit configuration constants */
 /* Register order: rax, rbx, rcx, rdx, rsi, rdi, rbp, r8, r9, r10, r11, r12, r13, r14, r15 */
 inline constexpr int NR_REGS = 15;
 inline constexpr int INIT_PSW = 0x0200;
-inline constexpr std::uint64_t* INIT_SP = nullptr; // Using std::uint64_t from core_types
+inline constexpr std::uint64_t *INIT_SP = nullptr; // Using std::uint64_t from core_types
 inline constexpr int ES_REG = 0;
 inline constexpr int DS_REG = 0;
 inline constexpr int CS_REG = 0;
@@ -40,8 +40,8 @@ inline constexpr int RET_REG = 0; /* system call return codes go in this reg */
 inline constexpr int IDLE = -999; /* 'cur_proc' = IDLE means nobody is running */
 
 /* Scheduler configuration */
-#define SCHED_ROUND_ROBIN 0 /* set to 1 for simple round-robin */
-inline constexpr int NR_CPUS = 1;           /* number of CPUs (SMP placeholder) */
+#define SCHED_ROUND_ROBIN 0       /* set to 1 for simple round-robin */
+inline constexpr int NR_CPUS = 1; /* number of CPUs (SMP placeholder) */
 
 #if SCHED_ROUND_ROBIN
 inline constexpr int NQ = 3;       /* # of scheduling queues */

--- a/kernel/lattice_ipc.cpp
+++ b/kernel/lattice_ipc.cpp
@@ -1,0 +1,65 @@
+/*
+ * @file lattice_ipc.cpp
+ * @brief Reference-counted message buffer for lattice IPC.
+ */
+
+#include <cstddef>
+#include <memory>
+#include <span>
+#include <vector>
+
+namespace lattice {
+/**
+ * @class MessageBuffer
+ * @brief Shared container for IPC message bytes.
+ *
+ * The buffer uses reference counting so multiple threads can access the same
+ * underlying storage without copying. Lifetime is automatically managed via
+ * std::shared_ptr.
+ */
+class MessageBuffer {
+  public:
+    using Byte = std::byte; ///< Convenience alias for byte type
+
+    /**
+     * @brief Construct an empty MessageBuffer.
+     */
+    MessageBuffer() = default;
+
+    /**
+     * @brief Construct buffer of given @p size in bytes.
+     * @param size Number of bytes to allocate.
+     */
+    explicit MessageBuffer(std::size_t size) : data_{std::make_shared<std::vector<Byte>>(size)} {}
+
+    /**
+     * @brief Obtain mutable view of the stored bytes.
+     * @return Span covering the buffer contents.
+     */
+    [[nodiscard]] std::span<Byte> span() noexcept {
+        return data_ ? std::span<Byte>{data_->data(), data_->size()} : std::span<Byte>{};
+    }
+
+    /**
+     * @brief Obtain const view of the stored bytes.
+     * @return Span over immutable bytes.
+     */
+    [[nodiscard]] std::span<const Byte> span() const noexcept {
+        return data_ ? std::span<const Byte>{data_->data(), data_->size()}
+                     : std::span<const Byte>{};
+    }
+
+    /**
+     * @brief Number of bytes in the buffer.
+     */
+    [[nodiscard]] std::size_t size() const noexcept { return data_ ? data_->size() : 0U; }
+
+    /**
+     * @brief Access underlying shared pointer for advanced sharing.
+     */
+    [[nodiscard]] std::shared_ptr<std::vector<Byte>> share() const noexcept { return data_; }
+
+  private:
+    std::shared_ptr<std::vector<Byte>> data_{}; ///< Shared data container
+};
+} // namespace lattice

--- a/kernel/type.hpp
+++ b/kernel/type.hpp
@@ -7,13 +7,12 @@
  * trap or interrupt, as well as for causing interrupts for signals.
  */
 
-#include "../include/defs.hpp" // Project-wide definitions
-#include "../../include/xinim/core_types.hpp" // For xinim::virt_addr_t and std::uint64_t
+#include "../include/defs.hpp"  // Project-wide definitions
+#include <xinim/core_types.hpp> // For xinim::virt_addr_t and std::uint64_t
 
 struct pc_psw {
-    xinim::virt_addr_t pc;  /* program counter */
-    std::uint64_t psw;      /* processor status word */
-
+    xinim::virt_addr_t pc; /* program counter */
+    std::uint64_t psw;     /* processor status word */
 };
 
 struct sig_info {

--- a/lib/call.cpp
+++ b/lib/call.cpp
@@ -3,12 +3,21 @@
 // Global storage for the most recent error number.
 int errno = 0; // accessed by system call wrappers
 
-// Send a message using the m1 layout.
-// Send a message using the m1 layout. The arguments represent the target
-// process, system call number, three integer parameters and up to three
-// pointer parameters.
-int callm1(int proc, int syscallnr, int int1, int int2, int int3,
-           char *ptr1, char *ptr2, char *ptr3) {
+/**
+ * @brief Send a message using the m1 layout.
+ *
+ * @param proc       Destination process.
+ * @param syscallnr  System call number.
+ * @param int1       First integer parameter.
+ * @param int2       Second integer parameter.
+ * @param int3       Third integer parameter.
+ * @param ptr1       First pointer parameter.
+ * @param ptr2       Second pointer parameter.
+ * @param ptr3       Third pointer parameter.
+ * @return Result of ::callx.
+ */
+int callm1(int proc, int syscallnr, int int1, int int2, int int3, char *ptr1, char *ptr2,
+           char *ptr3) noexcept {
     /* Send a message and get the response.  The 'M.m_type' field of the
      * reply contains a value (>= 0) or an error code (<0). Use message format m1.
      */
@@ -21,29 +30,41 @@ int callm1(int proc, int syscallnr, int int1, int int2, int int3,
     return callx(proc, syscallnr);
 }
 
-// Send a message containing one integer and a string.
-// Send a message containing one integer and a string parameter.
-int callm3(int proc, int syscallnr, int int1, char *name) {
+/**
+ * @brief Send a message containing one integer and a string.
+ *
+ * @param proc       Destination process.
+ * @param syscallnr  System call number.
+ * @param int1       Integer argument.
+ * @param name       Pointer to string argument.
+ * @return Result of ::callx.
+ */
+int callm3(int proc, int syscallnr, int int1, const char *name) noexcept {
     /* This form of system call is used for those calls that contain at most
      * one integer parameter along with a string.  If the string fits in the
      * message, it is copied there.  If not, a pointer to it is passed.
      */
-    register int k;
-    register char *rp;
-    k = len(name);
-    M.m3_i1() = k;
+    std::size_t k = len(name);
+    char *rp = &M.m3_ca1()[0];
+    const char *src = name;
+    M.m3_i1() = static_cast<int>(k);
     M.m3_i2() = int1;
-    M.m3_p1() = name;
-    rp = &M.m3_ca1()[0];
-    if (k <= M3_STRING)
+    M.m3_p1() = const_cast<char *>(name);
+    if (k <= M3_STRING) {
         while (k--)
-            *rp++ = *name++;
+            *rp++ = *src++;
+    }
     return callx(proc, syscallnr);
 }
 
-// Low-level send/receive wrapper.
-// Low-level send/receive wrapper.
-int callx(int proc, int syscallnr) {
+/**
+ * @brief Low-level send/receive wrapper.
+ *
+ * @param proc       Destination process.
+ * @param syscallnr  System call number.
+ * @return Kernel response value or error.
+ */
+int callx(int proc, int syscallnr) noexcept {
     /* Send a message and get the response.  The 'M.m_type' field of the
      * reply contains a value (>= 0) or an error code (<0).
      */
@@ -60,14 +81,18 @@ int callx(int proc, int syscallnr) {
     return (M.m_type);
 }
 
-// Return the length of a null-terminated string including the final null.
-// Return the length of a null-terminated string including the final null byte.
-int len(char *s) {
-    /* Return the length of a character string, including the 0 at the end. */
-    register int k;
-
-    k = 0;
-    while (*s++ != 0)
-        k++;
-    return (k + 1); /* return length including the 0-byte at end */
+/**
+ * @brief Return the length of a null-terminated string including the final null
+ *        byte.
+ *
+ * @param s Pointer to string.
+ * @return  Length in bytes including the terminator.
+ */
+std::size_t len(const char *s) noexcept {
+    // Return the length of a character string including the terminating null.
+    std::size_t k = 0;
+    while (*s++ != 0) {
+        ++k;
+    }
+    return k + 1U; // include the null terminator
 }

--- a/lib/catchsig.cpp
+++ b/lib/catchsig.cpp
@@ -1,8 +1,10 @@
 #include "../include/lib.hpp" // C++17 header
 
-/*
- * Entry point for signal trampolines.
- * Merely returns so the caller can resume execution.
+/**
+ * @brief Entry point for signal trampolines.
+ *
+ * This function merely returns so the caller can resume execution.
+ *
+ * @return Always zero.
  */
-// Entry point for signal trampolines. Merely returns so the caller can resume.
-int begsig() { return 0; }
+int begsig() noexcept { return 0; }

--- a/lib/fclose.cpp
+++ b/lib/fclose.cpp
@@ -2,8 +2,11 @@
 #include "../include/stdio.hpp"
 #include <unistd.h>
 
-/*
- * Close a stream and release its resources.
+/**
+ * @brief Close a stream and release its resources.
+ *
+ * @param fp Pointer to the FILE structure to close.
+ * @return 0 on success or EOF on failure.
  */
 int fclose(FILE *fp) {
     int i; /* index within _io_table */
@@ -15,7 +18,7 @@ int fclose(FILE *fp) {
         }
     }
     if (i >= NFILES)
-        return EOF;
+        return STDIO_EOF;
     fflush(fp);
     close(fp->_fd);
     if (testflag(fp, IOMYBUF) && fp->_buf)

--- a/lib/fflush.cpp
+++ b/lib/fflush.cpp
@@ -1,6 +1,11 @@
 #include "../include/stdio.hpp"
 
-// Flush the buffer associated with the given stream.
+/**
+ * @brief Flush the buffer associated with the given stream.
+ *
+ * @param iop Stream to flush.
+ * @return Bytes written or ::STDIO_EOF on error.
+ */
 int __fflush(FILE *iop) {
     int count;
 
@@ -19,8 +24,13 @@ int __fflush(FILE *iop) {
     }
 
     iop->_flags |= ERR;
-    return EOF;
+    return STDIO_EOF;
 }
 
-// Public interface wrapper.
+/**
+ * @brief Public interface wrapper for ::__fflush.
+ *
+ * @param stream Stream to flush.
+ * @return Bytes written or ::STDIO_EOF on error.
+ */
 int fflush(FILE *stream) { return __fflush(stream); }

--- a/lib/fgets.cpp
+++ b/lib/fgets.cpp
@@ -1,17 +1,23 @@
 #include "../include/stdio.hpp"
 
-
+/**
+ * @brief Read a line from a stream.
+ *
+ * @param str  Buffer to store the characters.
+ * @param n    Maximum number of characters to read including the terminator.
+ * @param file Input stream.
+ * @return @p str on success or @c nullptr on failure/end of file.
+ */
 char *fgets(char *str, unsigned n, FILE *file) {
     int ch;
     char *ptr = str;
-    while (--n > 0 && (ch = getc(file)) != EOF) {
+    while (--n > 0 && (ch = getc(file)) != STDIO_EOF) {
         *ptr++ = ch;
         if (ch == '\n')
             break;
     }
-    if (ch == EOF && ptr == str)
+    if (ch == STDIO_EOF && ptr == str)
         return nullptr;
     *ptr = '\0';
     return str;
 }
-

--- a/lib/fprintf.cpp
+++ b/lib/fprintf.cpp
@@ -1,11 +1,18 @@
 // clang-format off
 #include <cstdarg>  // va_list handling
-#include <cstdio>   // vsnprintf
 #include <vector>   // dynamic buffer
 #include "../include/stdio.hpp" // internal FILE definition
+
+extern "C" int vsnprintf(char *, std::size_t, const char *, va_list);
 // clang-format on
 
-// Write formatted data to the given file stream.
+/**
+ * @brief Write formatted data to the given file stream.
+ *
+ * @param file Target stream.
+ * @param fmt  Format string.
+ * @return Number of characters printed or -1 on error.
+ */
 int fprintf(FILE *file, const char *fmt, ...) {
     // Capture the variable arguments.
     va_list args;
@@ -37,7 +44,12 @@ int fprintf(FILE *file, const char *fmt, ...) {
     return count;
 }
 
-// Print formatted output to the standard output stream.
+/**
+ * @brief Print formatted output to the standard output stream.
+ *
+ * @param fmt Format string.
+ * @return Number of characters printed or -1 on error.
+ */
 int printf(const char *fmt, ...) {
     va_list args;
     va_start(args, fmt);

--- a/lib/fputs.cpp
+++ b/lib/fputs.cpp
@@ -1,9 +1,14 @@
 // clang-format off
-#include <cstdio>
 #include "../include/stdio.hpp"
 // clang-format on
 
-// Write a string to the specified file stream.
+/**
+ * @brief Write a string to the specified file stream.
+ *
+ * @param s    Null-terminated string to write.
+ * @param file Target stream.
+ * @return Always 0 on success.
+ */
 int fputs(const char *s, FILE *file) {
     while (*s != '\0') {
         putc(*s++, file);

--- a/lib/fread.cpp
+++ b/lib/fread.cpp
@@ -1,16 +1,23 @@
 // clang-format off
-#include <cstdio>
 #include "../include/stdio.hpp"
 // clang-format on
 
-// Read elements from a stream into the provided buffer.
+/**
+ * @brief Read elements from a stream into the provided buffer.
+ *
+ * @param ptr   Destination buffer.
+ * @param size  Size of each element.
+ * @param count Number of elements to read.
+ * @param file  Source stream.
+ * @return Number of elements successfully read.
+ */
 size_t fread(void *ptr, size_t size, size_t count, FILE *file) {
     auto *bytes = static_cast<char *>(ptr);
     size_t total = size * count;
     size_t read_bytes = 0;
     while (read_bytes < total) {
         int c = getc(file);
-        if (c == EOF)
+        if (c == STDIO_EOF)
             break;
         bytes[read_bytes++] = static_cast<char>(c);
     }

--- a/lib/fwrite.cpp
+++ b/lib/fwrite.cpp
@@ -1,14 +1,21 @@
 // clang-format off
-#include <cstdio>
 #include "../include/stdio.hpp"
 // clang-format on
 
-// Write elements from buffer to the specified stream.
+/**
+ * @brief Write elements from buffer to the specified stream.
+ *
+ * @param ptr   Source data buffer.
+ * @param size  Size of each element.
+ * @param count Number of elements to write.
+ * @param file  Destination stream.
+ * @return Number of elements successfully written.
+ */
 size_t fwrite(const void *ptr, size_t size, size_t count, FILE *file) {
     const char *bytes = static_cast<const char *>(ptr);
     size_t total = size * count;
     for (size_t i = 0; i < total; ++i) {
-        if (putc(bytes[i], file) == EOF)
+        if (putc(bytes[i], file) == STDIO_EOF)
             return i / size;
     }
     return count;

--- a/lib/getpass.cpp
+++ b/lib/getpass.cpp
@@ -1,13 +1,22 @@
 #include "../include/sgtty.hpp"
+#include "../include/stdio.hpp"
+#include <unistd.h>
+
+extern "C" int ioctl(int fd, int request, ...);
 
 static char pwdbuf[9];
 
-// Read a password from the terminal without echoing input
+/**
+ * @brief Read a password from the terminal without echoing input.
+ *
+ * @param prompt Prompt string displayed before reading.
+ * @return Pointer to an internal static buffer containing the password.
+ */
 char *getpass(const char *prompt) {
     int i = 0;
     struct sgttyb tty;
 
-    prints(prompt);
+    fputs(prompt, stdout);
     ioctl(0, TIOCGETP, &tty);
     tty.sg_flags = 06020;
     ioctl(0, TIOCSETP, &tty);
@@ -17,6 +26,6 @@ char *getpass(const char *prompt) {
     pwdbuf[i - 1] = '\0';
     tty.sg_flags = 06030;
     ioctl(0, TIOCSETP, &tty);
-    prints("\n");
+    fputs("\n", stdout);
     return pwdbuf;
 }

--- a/lib/safe_alloc.cpp
+++ b/lib/safe_alloc.cpp
@@ -2,8 +2,13 @@
 #include <stdio.h>
 #include <stdlib.h>
 
-/* Allocate memory and abort on failure. */
-void *safe_malloc(size_t size) {
+/**
+ * @brief Allocate memory and abort on failure.
+ *
+ * @param size Number of bytes to allocate.
+ * @return Pointer to allocated memory.
+ */
+void *safe_malloc(size_t size) noexcept {
     void *ptr = malloc(size);
     if (ptr == NULL) {
         fprintf(stderr, "out of memory\n");
@@ -12,8 +17,12 @@ void *safe_malloc(size_t size) {
     return ptr;
 }
 
-/* Free memory if pointer not NULL. */
-void safe_free(void *ptr) {
+/**
+ * @brief Free memory if pointer not @c nullptr.
+ *
+ * @param ptr Pointer previously allocated with ::safe_malloc.
+ */
+void safe_free(void *ptr) noexcept {
     if (ptr != NULL) {
         free(ptr);
     }

--- a/lib/sendrec.cpp
+++ b/lib/sendrec.cpp
@@ -3,20 +3,35 @@
 #include "../include/lib.hpp" // C++17 header
 #include <unistd.h>
 
-/*
- * Send a message to a destination process.
+/**
+ * @brief Send a message to a destination process.
+ *
+ * @param dst  Destination process identifier.
+ * @param m_ptr Pointer to the message structure.
+ * @return Result of the system call.
  */
-// Send a message to a destination process.
-int send(int dst, message *m_ptr) { return static_cast<int>(syscall(0, dst, m_ptr, SEND)); }
+int send(int dst, message *m_ptr) noexcept {
+    return static_cast<int>(syscall(0, dst, m_ptr, SEND));
+}
 
-/*
- * Receive a message from a source process.
+/**
+ * @brief Receive a message from a source process.
+ *
+ * @param src   Source process identifier.
+ * @param m_ptr Pointer to the message structure.
+ * @return Result of the system call.
  */
-// Receive a message from a source process.
-int receive(int src, message *m_ptr) { return static_cast<int>(syscall(0, src, m_ptr, RECEIVE)); }
+int receive(int src, message *m_ptr) noexcept {
+    return static_cast<int>(syscall(0, src, m_ptr, RECEIVE));
+}
 
-/*
- * Atomically send a message and wait for the reply.
+/**
+ * @brief Atomically send a message and wait for the reply.
+ *
+ * @param srcdest Destination/source process identifier.
+ * @param m_ptr   Pointer to the message structure.
+ * @return Result of the system call.
  */
-// Atomically send a message and wait for the reply.
-int sendrec(int srcdest, message *m_ptr) { return static_cast<int>(syscall(0, srcdest, m_ptr, BOTH)); }
+int sendrec(int srcdest, message *m_ptr) noexcept {
+    return static_cast<int>(syscall(0, srcdest, m_ptr, BOTH));
+}

--- a/lib/syscall_x86_64.cpp
+++ b/lib/syscall_x86_64.cpp
@@ -3,8 +3,14 @@
 #include "../h/const.hpp"
 #include "../h/type.hpp"
 
-// x86_64 syscall wrapper for sending a message.
-int send(int dst, message *m_ptr) {
+/**
+ * @brief x86_64 syscall wrapper for sending a message.
+ *
+ * @param dst   Destination process identifier.
+ * @param m_ptr Pointer to message structure.
+ * @return Result of the system call.
+ */
+int send(int dst, message *m_ptr) noexcept {
     register long rax __asm__("rax") = 0;
     register long rdi __asm__("rdi") = dst;
     register message *rsi __asm__("rsi") = m_ptr;
@@ -16,8 +22,14 @@ int send(int dst, message *m_ptr) {
     return (int)rax;
 }
 
-// x86_64 syscall wrapper for receiving a message.
-int receive(int src, message *m_ptr) {
+/**
+ * @brief x86_64 syscall wrapper for receiving a message.
+ *
+ * @param src   Source process identifier.
+ * @param m_ptr Pointer to message structure.
+ * @return Result of the system call.
+ */
+int receive(int src, message *m_ptr) noexcept {
     register long rax __asm__("rax") = 0;
     register long rdi __asm__("rdi") = src;
     register message *rsi __asm__("rsi") = m_ptr;
@@ -29,8 +41,14 @@ int receive(int src, message *m_ptr) {
     return (int)rax;
 }
 
-// x86_64 syscall wrapper for sending a message and waiting for reply.
-int sendrec(int srcdest, message *m_ptr) {
+/**
+ * @brief x86_64 syscall wrapper for sending a message and waiting for reply.
+ *
+ * @param srcdest Destination/source identifier.
+ * @param m_ptr   Pointer to message structure.
+ * @return Result of the system call.
+ */
+int sendrec(int srcdest, message *m_ptr) noexcept {
     register long rax __asm__("rax") = 0;
     register long rdi __asm__("rdi") = srcdest;
     register message *rsi __asm__("rsi") = m_ptr;


### PR DESCRIPTION
## Summary
- implement reference-counted `MessageBuffer` for kernel IPC
- add Doxygen comments and noexcept specifiers across libc helpers
- modernize libc implementations (fopen/fclose/fgets/fputs etc.)
- fix include paths and provide declarations in `stdio.hpp`

## Testing
- `cmake -B build`
- `cmake --build build` *(fails: unresolved libc compile errors)*
- `ctest --test-dir build` *(fails: executables missing)*

------
https://chatgpt.com/codex/tasks/task_e_684cee93f9c883318b35cd6f07acd4bb

## Summary by Sourcery

Add a shared, reference-counted MessageBuffer for lattice IPC and modernize the libc and kernel interfaces by introducing Doxygen comments, noexcept annotations, C++17 idioms, and consistent xinim::core_types usage.

New Features:
- Introduce a reference-counted MessageBuffer class for shared IPC data in the kernel

Enhancements:
- Add Doxygen-style comments and noexcept specifiers to libc and syscall wrappers
- Modernize libc I/O routines (e.g., fprintf, fgets, fread, fwrite, fputs) using C++17 features and improve error handling
- Update type definitions and include directives to use xinim::core_types across user and kernel code

Build:
- Include lattice_ipc.cpp in the kernel CMakeLists

Documentation:
- Add Doxygen documentation to stdio, syscall, and signal trampoline functions

Chores:
- Fix include paths and declarations in stdio.hpp for fputs