### PR TITLE
Fix README license badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ into a cohesive educational system.
 
 ![Build Status](https://img.shields.io/badge/build-passing-brightgreen)
 ![C++23](https://img.shields.io/badge/C%2B%2B-23-blue.svg)
-![License](https://img.shields.io/badge/license-MIT-blue.svg)
+![License](https://img.shields.io/badge/license-BSD%203--Clause-blue.svg)
 ![Documentation](https://img.shields.io/badge/docs-doxygen-blue.svg)
 
 Modern C++23 implementation of the entire MINIX 1 codebase with enhanced type


### PR DESCRIPTION
## Summary
- replace MIT license badge with BSD-3-Clause badge
- clarify license reference

## Testing
- `make check` *(fails: No rule to make target 'obj/fsck.o')*

------
https://chatgpt.com/codex/tasks/task_e_684d002fa34c83319a3ff5a9de5e6660

## Summary by Sourcery

Documentation:
- Replace MIT license badge with BSD-3-Clause badge in README