### PR TITLE
Add wait-for graph structure

### DIFF
--- a/docs/sphinx/index.rst
+++ b/docs/sphinx/index.rst
@@ -16,6 +16,6 @@ The documentation is divided into several sections:
 
    lattice_ipc
    pq_crypto
+   scheduler
    precommit
    api
-

--- a/docs/sphinx/scheduler.rst
+++ b/docs/sphinx/scheduler.rst
@@ -1,0 +1,10 @@
+Scheduler == == == == =
+
+                          The scheduler manages cooperative multitasking inside the
+                              kernel.It exposes a FIFO run queue along with a direct yield primitive
+                                  .
+
+                                  ..doxygenclass::sched::Scheduler : project : XINIM : members :
+
+    The : cpp :`yield_to` method enables fast hand -
+                          off between communicating threads.

--- a/kernel/CMakeLists.txt
+++ b/kernel/CMakeLists.txt
@@ -8,7 +8,7 @@ endif()
 set(KERNEL_SRC
     clock.cpp dmp.cpp floppy.cpp main.cpp memory.cpp printer.cpp proc.cpp system.cpp
     table.cpp tty.cpp idt64.cpp mpx64.cpp klib64.cpp klib88.cpp mpx88.cpp paging.cpp
-    wormhole.cpp lattice_ipc.cpp pqcrypto.cpp syscall.cpp ${WINI_SRC})
+    wormhole.cpp lattice_ipc.cpp wait_graph.cpp pqcrypto.cpp syscall.cpp ${WINI_SRC})
 
 #Note : klib88.cpp and mpx88.cpp were added as they appear to be kernel related sources.
 #wini.cpp is a generic name, might be a common file or superseded by at_wini / xt_wini.

--- a/kernel/wait_graph.cpp
+++ b/kernel/wait_graph.cpp
@@ -1,0 +1,57 @@
+#include "wait_graph.hpp"
+#include <algorithm>
+
+namespace lattice {
+
+bool WaitForGraph::has_path(xinim::pid_t from, xinim::pid_t to,
+                            std::unordered_set<xinim::pid_t> &visited) const {
+    if (from == to) {
+        return true;
+    }
+    if (!visited.insert(from).second) {
+        return false;
+    }
+    auto it = edges_.find(from);
+    if (it == edges_.end()) {
+        return false;
+    }
+    for (xinim::pid_t next : it->second) {
+        if (has_path(next, to, visited)) {
+            return true;
+        }
+    }
+    return false;
+}
+
+bool WaitForGraph::add_edge(xinim::pid_t src, xinim::pid_t dst) {
+    edges_[src].push_back(dst);
+    std::unordered_set<xinim::pid_t> visited;
+    if (has_path(dst, src, visited)) {
+        auto &vec = edges_[src];
+        vec.erase(std::find(vec.begin(), vec.end(), dst));
+        return true;
+    }
+    return false;
+}
+
+void WaitForGraph::remove_edge(xinim::pid_t src, xinim::pid_t dst) noexcept {
+    auto it = edges_.find(src);
+    if (it == edges_.end()) {
+        return;
+    }
+    auto &vec = it->second;
+    vec.erase(std::remove(vec.begin(), vec.end(), dst), vec.end());
+    if (vec.empty()) {
+        edges_.erase(it);
+    }
+}
+
+void WaitForGraph::clear(xinim::pid_t pid) noexcept {
+    edges_.erase(pid);
+    for (auto &pair : edges_) {
+        auto &vec = pair.second;
+        vec.erase(std::remove(vec.begin(), vec.end(), pid), vec.end());
+    }
+}
+
+} // namespace lattice

--- a/kernel/wait_graph.hpp
+++ b/kernel/wait_graph.hpp
@@ -1,0 +1,48 @@
+#pragma once
+/**
+ * @file wait_graph.hpp
+ * @brief Directed wait-for graph for detecting process deadlocks.
+ */
+
+#include "../include/xinim/core_types.hpp"
+#include <unordered_map>
+#include <unordered_set>
+#include <vector>
+
+namespace lattice {
+
+/**
+ * @brief Wait-for graph manager storing blocking relationships.
+ */
+class WaitForGraph {
+  public:
+    /**
+     * @brief Add a dependency edge from @p src to @p dst.
+     *
+     * The function detects if inserting the edge would create a cycle. If so,
+     * the edge is not retained and the function returns @c true.
+     *
+     * @param src Process waiting.
+     * @param dst Process being waited on.
+     * @return @c true if a cycle was detected.
+     */
+    [[nodiscard]] bool add_edge(xinim::pid_t src, xinim::pid_t dst);
+
+    /**
+     * @brief Remove the dependency edge @p src -> @p dst if present.
+     */
+    void remove_edge(xinim::pid_t src, xinim::pid_t dst) noexcept;
+
+    /**
+     * @brief Remove all edges originating from or targeting @p pid.
+     */
+    void clear(xinim::pid_t pid) noexcept;
+
+  private:
+    bool has_path(xinim::pid_t from, xinim::pid_t to,
+                  std::unordered_set<xinim::pid_t> &visited) const;
+
+    std::unordered_map<xinim::pid_t, std::vector<xinim::pid_t>> edges_{};
+};
+
+} // namespace lattice

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,130 +1,187 @@
-# Unit tests for Minix library routines and basic system calls
+#Unit tests for Minix library routines and basic system calls
 
-# Library routine tests compile selected sources directly
-add_executable(minix_test_lib
-    test_lib.cpp
-    "${CMAKE_SOURCE_DIR}/lib/strlen.cpp"
-    "${CMAKE_SOURCE_DIR}/lib/strcmp.cpp"
-    "${CMAKE_SOURCE_DIR}/lib/rand.cpp"
-)
+#Library routine tests compile selected sources directly
+add_executable(minix_test_lib test_lib.cpp "${CMAKE_SOURCE_DIR}/lib/strlen.cpp"
+                                           "${CMAKE_SOURCE_DIR}/lib/strcmp.cpp"
+                                           "${CMAKE_SOURCE_DIR}/lib/rand.cpp")
 
-# Ensure lib_test can find necessary headers from the C library's public interface
-target_include_directories(minix_test_lib PUBLIC
-    "${CMAKE_SOURCE_DIR}/include"
-    "${CMAKE_SOURCE_DIR}/h"
-)
-target_compile_options(minix_test_lib PRIVATE -std=c++23 -fno-builtin)
-add_test(NAME minix_test_lib COMMAND minix_test_lib)
+#Ensure lib_test can find necessary headers from the C library's public interface
+    target_include_directories(
+        minix_test_lib PUBLIC
+        "${CMAKE_SOURCE_DIR}/include"
+        "${CMAKE_SOURCE_DIR}/h") target_compile_options(minix_test_lib PRIVATE - std =
+                                                            c++ 23 - fno -
+                                                            builtin) add_test(NAME minix_test_lib
+                                                                                  COMMAND
+                                                                                      minix_test_lib)
 
-# System call tests rely on the host C library only (or direct syscalls)
-add_executable(minix_test_syscall test_syscall.cpp)
-target_include_directories(minix_test_syscall PUBLIC
-    "${CMAKE_SOURCE_DIR}/include"
-    "${CMAKE_SOURCE_DIR}/h"
-)
-add_test(NAME minix_test_syscall COMMAND minix_test_syscall)
+#System call tests rely on the host C library only(or direct syscalls)
+        add_executable(minix_test_syscall test_syscall.cpp) target_include_directories(
+            minix_test_syscall PUBLIC
+            "${CMAKE_SOURCE_DIR}/include"
+            "${CMAKE_SOURCE_DIR}/h") add_test(NAME minix_test_syscall COMMAND minix_test_syscall)
 
-# Fastpath unit test
-# Add Stream architecture tests
-add_executable(minix_test_streams test_streams.cpp)
-target_link_libraries(minix_test_streams PRIVATE minix_libc)
-target_include_directories(minix_test_streams PUBLIC
-    "${CMAKE_SOURCE_DIR}/include"
-    "${CMAKE_SOURCE_DIR}/h"
-)
-set_target_properties(minix_test_streams PROPERTIES EXCLUDE_FROM_ALL TRUE)
-add_test(NAME minix_test_streams COMMAND minix_test_streams)
-set_tests_properties(minix_test_streams PROPERTIES DISABLED TRUE)
+#Fastpath unit test
+#Add Stream architecture tests
+            add_executable(minix_test_streams test_streams.cpp) target_link_libraries(
+                minix_test_streams PRIVATE
+                    minix_libc) target_include_directories(minix_test_streams PUBLIC
+                                                           "${CMAKE_SOURCE_DIR}/include"
+                                                           "${CMAKE_SOURCE_DIR}/h")
+                set_target_properties(minix_test_streams PROPERTIES EXCLUDE_FROM_ALL TRUE) add_test(
+                    NAME minix_test_streams COMMAND
+                        minix_test_streams) set_tests_properties(minix_test_streams PROPERTIES
+                                                                     DISABLED TRUE)
 
-# Wormhole unit test
-add_executable(minix_test_fastpath test_fastpath.cpp
-    "${CMAKE_SOURCE_DIR}/kernel/wormhole.cpp"
-    "${CMAKE_SOURCE_DIR}/kernel/schedule.cpp"
-)
-target_include_directories(minix_test_fastpath PUBLIC
-    "${CMAKE_SOURCE_DIR}/kernel"
-)
-add_test(NAME minix_test_fastpath COMMAND minix_test_fastpath)
+#Wormhole unit test
+                    add_executable(minix_test_fastpath test_fastpath.cpp
+                                   "${CMAKE_SOURCE_DIR}/kernel/wormhole.cpp"
+                                   "${CMAKE_SOURCE_DIR}/kernel/schedule.cpp")
+                        target_include_directories(
+                            minix_test_fastpath PUBLIC
+                            "${CMAKE_SOURCE_DIR}/kernel") add_test(NAME minix_test_fastpath COMMAND
+                                                                       minix_test_fastpath)
 
-# Scheduler unit test
-add_executable(minix_test_scheduler test_scheduler.cpp
-    "${CMAKE_SOURCE_DIR}/kernel/schedule.cpp"
-)
-target_include_directories(minix_test_scheduler PUBLIC
-    "${CMAKE_SOURCE_DIR}/kernel"
-    "${CMAKE_SOURCE_DIR}/include"
-)
-add_test(NAME minix_test_scheduler COMMAND minix_test_scheduler)
+#Scheduler unit test
+                            add_executable(minix_test_scheduler test_scheduler.cpp "${CMAKE_SOURCE_"
+                                                                                   "DIR}/kernel/"
+                                                                                   "schedule.cpp") target_include_directories(
+                                minix_test_scheduler PUBLIC
+                                "${CMAKE_SOURCE_DIR}/kernel"
+                                "${CMAKE_SOURCE_DIR}/include") add_test(NAME minix_test_scheduler
+                                                                            COMMAND
+                                                                                minix_test_scheduler)
 
-# Semantic region unit test
-add_executable(minix_test_semantic_region test_semantic_region.cpp)
-target_include_directories(minix_test_semantic_region PUBLIC
-    "${CMAKE_SOURCE_DIR}/include"
-)
-add_test(NAME minix_test_semantic_region COMMAND minix_test_semantic_region)
+#Semantic region unit test
+                                add_executable(minix_test_semantic_region test_semantic_region.cpp) target_include_directories(
+                                    minix_test_semantic_region PUBLIC
+                                    "${CMAKE_SOURCE_DIR}/include") add_test(NAME minix_test_semantic_region
+                                                                                COMMAND
+                                                                                    minix_test_semantic_region)
 
-# Stream foundation verification test
-add_executable(minix_test_stream_foundation
-    test_stream_foundation.cpp
-    "${CMAKE_SOURCE_DIR}/lib/io/src/file_stream.cpp"
-    "${CMAKE_SOURCE_DIR}/lib/io/src/file_operations.cpp"
-    "${CMAKE_SOURCE_DIR}/lib/io/src/standard_streams.cpp"
-)
-set_target_properties(minix_test_stream_foundation PROPERTIES
-    CXX_STANDARD 23
-    CXX_STANDARD_REQUIRED ON
-    EXCLUDE_FROM_ALL TRUE
-)
-target_include_directories(minix_test_stream_foundation PUBLIC
-    "${CMAKE_SOURCE_DIR}/include"
-)
-add_test(NAME minix_test_stream_foundation COMMAND minix_test_stream_foundation)
-set_tests_properties(minix_test_stream_foundation PROPERTIES DISABLED TRUE)
+#Stream foundation verification test
+                                    add_executable(
+                                        minix_test_stream_foundation test_stream_foundation.cpp
+                                        "${CMAKE_SOURCE_DIR}/lib/io/src/file_stream.cpp"
+                                        "${CMAKE_SOURCE_DIR}/lib/io/src/file_operations.cpp"
+                                        "${CMAKE_SOURCE_DIR}/lib/io/src/standard_streams.cpp")
+                                        set_target_properties(
+                                            minix_test_stream_foundation PROPERTIES
+                                                CXX_STANDARD 23 CXX_STANDARD_REQUIRED ON EXCLUDE_FROM_ALL
+                                                    TRUE) target_include_directories(minix_test_stream_foundation PUBLIC
+                                                                                     "${CMAKE_"
+                                                                                     "SOURCE_DIR}/"
+                                                                                     "include")
+                                            add_test(
+                                                NAME minix_test_stream_foundation COMMAND
+                                                    minix_test_stream_foundation) set_tests_properties(minix_test_stream_foundation
+                                                                                                           PROPERTIES DISABLED
+                                                                                                               TRUE)
 
-# MemoryStream unit test
-add_executable(minix_test_memory_stream
-    test_memory_stream.cpp
-    "${CMAKE_SOURCE_DIR}/lib/io/src/memory_stream.cpp"
-)
-set_target_properties(minix_test_memory_stream PROPERTIES
-    CXX_STANDARD 23
-    CXX_STANDARD_REQUIRED ON
-)
-target_include_directories(minix_test_memory_stream PUBLIC
-    "${CMAKE_SOURCE_DIR}/include"
-)
-add_test(NAME minix_test_memory_stream COMMAND minix_test_memory_stream)
+#MemoryStream unit test
+                                                add_executable(
+                                                    minix_test_memory_stream test_memory_stream.cpp
+                                                    "${CMAKE_SOURCE_DIR}/lib/io/src/"
+                                                    "memory_stream.cpp")
+                                                    set_target_properties(
+                                                        minix_test_memory_stream PROPERTIES
+                                                            CXX_STANDARD 23 CXX_STANDARD_REQUIRED
+                                                                ON)
+                                                        target_include_directories(
+                                                            minix_test_memory_stream PUBLIC
+                                                            "${CMAKE_SOURCE_DIR}/include") add_test(NAME
+                                                                                                        minix_test_memory_stream COMMAND minix_test_memory_stream)
 
-# Scheduler edge case unit test
-add_executable(minix_test_scheduler_edge
-    test_scheduler_edge.cpp
-    "${CMAKE_SOURCE_DIR}/kernel/schedule.cpp"
-)
-set_target_properties(minix_test_scheduler_edge PROPERTIES
-    CXX_STANDARD 23
-    CXX_STANDARD_REQUIRED ON
-)
-target_include_directories(minix_test_scheduler_edge PUBLIC
-    "${CMAKE_SOURCE_DIR}/kernel"
-    "${CMAKE_SOURCE_DIR}/include"
-)
-add_test(NAME minix_test_scheduler_edge COMMAND minix_test_scheduler_edge)
+#Scheduler edge case unit test
+                                                            add_executable(minix_test_scheduler_edge
+                                                                               test_scheduler_edge.cpp
+                                                                           "${CMAKE_SOURCE_DIR}/"
+                                                                           "kernel/schedule.cpp")
+                                                                set_target_properties(
+                                                                    minix_test_scheduler_edge
+                                                                        PROPERTIES CXX_STANDARD 23 CXX_STANDARD_REQUIRED
+                                                                            ON)
+                                                                    target_include_directories(
+                                                                        minix_test_scheduler_edge PUBLIC
+                                                                        "${CMAKE_SOURCE_DIR}/kernel"
+                                                                        "${CMAKE_SOURCE_DIR}/"
+                                                                        "include") add_test(NAME minix_test_scheduler_edge COMMAND minix_test_scheduler_edge)
 
-# Fastpath precondition unit test
-add_executable(minix_test_fastpath_preconditions
-    test_fastpath_preconditions.cpp
-    "${CMAKE_SOURCE_DIR}/kernel/wormhole.cpp"
-    "${CMAKE_SOURCE_DIR}/kernel/schedule.cpp"
-)
-set_target_properties(minix_test_fastpath_preconditions PROPERTIES
-    CXX_STANDARD 23
-    CXX_STANDARD_REQUIRED ON
-)
-target_include_directories(minix_test_fastpath_preconditions PUBLIC
-    "${CMAKE_SOURCE_DIR}/kernel"
-    "${CMAKE_SOURCE_DIR}/include"
-)
-add_test(NAME minix_test_fastpath_preconditions COMMAND minix_test_fastpath_preconditions)
+#Wait graph unit test
+                                                                        add_executable(
+                                                                            minix_test_wait_graph test_wait_graph
+                                                                                .cpp "${CMAKE_"
+                                                                                     "SOURCE_DIR}/"
+                                                                                     "kernel/"
+                                                                                     "wait_graph."
+                                                                                     "cpp")
+                                                                            set_target_properties(
+                                                                                minix_test_wait_graph PROPERTIES
+                                                                                    CXX_STANDARD 23 CXX_STANDARD_REQUIRED
+                                                                                        ON)
+                                                                                target_include_directories(
+                                                                                    minix_test_wait_graph PUBLIC
+                                                                                    "${CMAKE_"
+                                                                                    "SOURCE_DIR}/"
+                                                                                    "kernel"
+                                                                                    "${CMAKE_"
+                                                                                    "SOURCE_DIR}/"
+                                                                                    "include") add_test(NAME minix_test_wait_graph COMMAND minix_test_wait_graph)
 
-# Cryptography unit tests
-add_subdirectory(crypto)
+#Fastpath precondition unit test
+                                                                                    add_executable(
+                                                                                        minix_test_fastpath_preconditions test_fastpath_preconditions
+                                                                                            .cpp
+                                                                                        "${CMAKE_"
+                                                                                        "SOURCE_"
+                                                                                        "DIR}/"
+                                                                                        "kernel/"
+                                                                                        "wormhole."
+                                                                                        "cpp"
+                                                                                        "${CMAKE_"
+                                                                                        "SOURCE_"
+                                                                                        "DIR}/"
+                                                                                        "kernel/"
+                                                                                        "schedule."
+                                                                                        "cpp")
+                                                                                        set_target_properties(
+                                                                                            minix_test_fastpath_preconditions
+                                                                                                PROPERTIES CXX_STANDARD 23 CXX_STANDARD_REQUIRED
+                                                                                                    ON)
+                                                                                            target_include_directories(
+                                                                                                minix_test_fastpath_preconditions PUBLIC
+                                                                                                "${"
+                                                                                                "CM"
+                                                                                                "AK"
+                                                                                                "E_"
+                                                                                                "SO"
+                                                                                                "UR"
+                                                                                                "CE"
+                                                                                                "_D"
+                                                                                                "IR"
+                                                                                                "}/"
+                                                                                                "ke"
+                                                                                                "rn"
+                                                                                                "el"
+                                                                                                "${"
+                                                                                                "CM"
+                                                                                                "AK"
+                                                                                                "E_"
+                                                                                                "SO"
+                                                                                                "UR"
+                                                                                                "CE"
+                                                                                                "_D"
+                                                                                                "IR"
+                                                                                                "}/"
+                                                                                                "in"
+                                                                                                "cl"
+                                                                                                "ud"
+                                                                                                "e")
+                                                                                                add_test(
+                                                                                                    NAME minix_test_fastpath_preconditions
+                                                                                                        COMMAND
+                                                                                                            minix_test_fastpath_preconditions)
+
+#Cryptography unit tests
+                                                                                                    add_subdirectory(
+                                                                                                        crypto)

--- a/tests/test_wait_graph.cpp
+++ b/tests/test_wait_graph.cpp
@@ -1,0 +1,16 @@
+#include "../kernel/wait_graph.hpp"
+#include <cassert>
+
+int main() {
+    lattice::WaitForGraph g;
+    // Add edge 1->2
+    assert(!g.add_edge(1, 2));
+    // Add edge 2->3
+    assert(!g.add_edge(2, 3));
+    // Adding 3->1 should create a cycle
+    assert(g.add_edge(3, 1));
+    // Graph should not have kept the edge
+    g.remove_edge(1, 2);
+    g.clear(2);
+    return 0;
+}


### PR DESCRIPTION
## Summary
- implement a simple WaitForGraph class for deadlock detection
- add unit test for WaitForGraph
- document scheduler in Sphinx
- update CMake configuration

## Testing
- `make check` *(fails: No rule to make target 'obj/fsck.o')*

------
https://chatgpt.com/codex/tasks/task_e_684d089ef12483319a2d67acd2789ef2