### PR TITLE
Add shared secret helper

### DIFF
--- a/crypto/CMakeLists.txt
+++ b/crypto/CMakeLists.txt
@@ -11,7 +11,7 @@ set(KYBER_IMPL_SOURCES
     kyber_impl/symmetric-shake.c
     kyber_impl/verify.c)
 
-add_library(pqcrypto STATIC kyber.cpp ${KYBER_IMPL_SOURCES})
+add_library(pqcrypto STATIC kyber.cpp pqcrypto_shared.cpp ${KYBER_IMPL_SOURCES})
 
 find_package(OpenSSL REQUIRED)
 find_package(PkgConfig REQUIRED)

--- a/crypto/pqcrypto_shared.cpp
+++ b/crypto/pqcrypto_shared.cpp
@@ -1,0 +1,37 @@
+/**
+ * @file pqcrypto_shared.cpp
+ * @brief Simple key exchange helper for deriving a shared secret.
+ */
+
+#include "pqcrypto.hpp"
+
+#include <array>
+#include <cstdint>
+#include <ranges>
+#include <span>
+
+namespace pqcrypto {
+
+/**
+ * @brief Compute a shared secret using a naive XOR key exchange.
+ *
+ * This routine XORs the given public key with the provided secret key to
+ * produce a 32-byte shared secret. The logic mirrors the kernel's
+ * pqcrypto::establish_secret used during lattice IPC setup but lives in the
+ * standalone crypto library.
+ *
+ * @param public_key Remote party's public key span.
+ * @param secret_key Local secret key span.
+ * @return Derived shared secret.
+ */
+[[nodiscard]] std::array<std::uint8_t, 32>
+compute_shared_secret(std::span<const std::uint8_t, 32> public_key,
+                      std::span<const std::uint8_t, 32> secret_key) {
+    std::array<std::uint8_t, 32> secret{};
+    std::ranges::for_each(std::views::iota(std::size_t{0}, secret.size()), [&](std::size_t i) {
+        secret[i] = static_cast<std::uint8_t>(public_key[i] ^ secret_key[i]);
+    });
+    return secret;
+}
+
+} // namespace pqcrypto

--- a/docs/sphinx/pq_crypto.rst
+++ b/docs/sphinx/pq_crypto.rst
@@ -16,3 +16,8 @@ lattice-based key exchange using a minimal API defined in
 
 .. doxygenfunction:: pqcrypto::compute_shared_secret
    :project: XINIM
+
+``pqcrypto::compute_shared_secret`` derives a 32-byte session secret by XORing
+the remote party's public key with the caller's secret key.  The helper is
+implemented in ``crypto/pqcrypto_shared.cpp`` and mirrors the kernel side
+exchange primitive used for lattice IPC setup.


### PR DESCRIPTION
## Summary
- implement `pqcrypto::compute_shared_secret` to derive a XOR-based session secret
- export new file in `crypto/CMakeLists.txt`
- document the helper in `pq_crypto.rst`

## Testing
- `clang-format -i crypto/pqcrypto_shared.cpp`
- `ctest --output-on-failure` *(fails: No tests were found)*
- `cmake -S . -B build` *(fails: missing libsodium)*

------
https://chatgpt.com/codex/tasks/task_e_684e0f2dd6e48331bb4a4d82e7b34557