### PR TITLE
Add Doxygen docs for MM functions

### DIFF
--- a/include/vm.hpp
+++ b/include/vm.hpp
@@ -10,74 +10,60 @@
 #include "../h/const.hpp"
 #include "paging.hpp"
 
-/* Flags for virtual memory regions. Converted from macros to a typesafe
- * enumeration so that the values can be combined with the usual bitwise
- * operators. */
+/**
+ * @brief Flags describing permissions and properties for a virtual memory region.
+ */
 enum class VmFlags : int {
-    Read = 0x1,
-    Write = 0x2,
-    Exec = 0x4,
-    Private = 0x8,
-    Shared = 0x10,
-    Anon = 0x20
+    VM_READ = 0x1,    /**< Region is readable. */
+    VM_WRITE = 0x2,   /**< Region is writable. */
+    VM_EXEC = 0x4,    /**< Region is executable. */
+    VM_PRIVATE = 0x8, /**< Region is private. */
+    VM_SHARED = 0x10, /**< Region is shared. */
+    VM_ANON = 0x20    /**< Region is anonymous. */
 };
 
-/* Enable bitwise operations on VmFlags. */
+/// Enable bitwise OR for VmFlags.
 inline constexpr VmFlags operator|(VmFlags l, VmFlags r) {
     return static_cast<VmFlags>(static_cast<int>(l) | static_cast<int>(r));
 }
+/// Enable bitwise AND for VmFlags.
 inline constexpr VmFlags operator&(VmFlags l, VmFlags r) {
     return static_cast<VmFlags>(static_cast<int>(l) & static_cast<int>(r));
-    /* Enumerates flags describing permissions and properties for a
-     * virtual memory region.  The values are kept compatible with the
-     * original macro definitions.
-     */
-    enum class VmFlags : int {
-        VM_READ = 0x1,    /* region is readable */
-        VM_WRITE = 0x2,   /* region is writable */
-        VM_EXEC = 0x4,    /* region is executable */
-        VM_PRIVATE = 0x8, /* region is private */
-        VM_SHARED = 0x10, /* region is shared */
-        VM_ANON = 0x20    /* region is anonymous */
-    };
+}
 
-    /* Enable bitwise operations for VmFlags. */
-    inline constexpr VmFlags operator|(VmFlags lhs, VmFlags rhs) {
-        return static_cast<VmFlags>(static_cast<int>(lhs) | static_cast<int>(rhs));
-    }
-    inline constexpr VmFlags operator&(VmFlags lhs, VmFlags rhs) {
-        return static_cast<VmFlags>(static_cast<int>(lhs) & static_cast<int>(rhs));
-    }
-    inline VmFlags &operator|=(VmFlags &lhs, VmFlags rhs) {
-        lhs = lhs | rhs;
-        return lhs;
-    }
-    inline VmFlags &operator&=(VmFlags &lhs, VmFlags rhs) {
-        lhs = lhs & rhs;
-        return lhs;
-    }
+inline VmFlags &operator|=(VmFlags &l, VmFlags r) {
+    l = l | r;
+    return l;
+}
+inline VmFlags &operator&=(VmFlags &l, VmFlags r) {
+    l = l & r;
+    return l;
+}
 
-    /* Maximum number of areas that can be tracked for a process. */
-    inline constexpr int VM_MAX_AREAS = 16;
+/// Maximum number of areas tracked for a process.
+inline constexpr int VM_MAX_AREAS = 16;
 
-    /* Describes a contiguous range of virtual addresses with associated
-     * protection flags. */
-    /* Describes a contiguous virtual memory area owned by a process. */
-    struct vm_area {
-        virt_addr64 start; /* inclusive start address */
-        virt_addr64 end;   /* exclusive end address */
-        VmFlags flags;     /* protection flags */
-    };
+/**
+ * @brief Contiguous virtual memory area owned by a process.
+ */
+struct vm_area {
+    virt_addr64 start; ///< Inclusive start address.
+    virt_addr64 end;   ///< Exclusive end address.
+    VmFlags flags;     ///< Protection flags.
+};
 
-    struct vm_proc {
-        struct vm_area areas[VM_MAX_AREAS]; /* list of owned areas */
-        int area_count;                     /* number of valid entries */
-    };
+/**
+ * @brief Per-process bookkeeping of virtual memory areas.
+ */
+struct vm_proc {
+    struct vm_area areas[VM_MAX_AREAS]; ///< List of owned areas.
+    int area_count;                     ///< Number of valid entries.
+};
 
-    void vm_init(void);
-    void *vm_alloc(u64_t bytes, VmFlags flags);
-    void vm_handle_fault(int proc, virt_addr64 addr);
-    int vm_fork(int parent, int child);
-    void *vm_mmap(int proc, void *addr, u64_t length, VmFlags flags);
+void vm_init(void);
+void *vm_alloc(u64_t bytes, VmFlags flags);
+void vm_handle_fault(int proc, virt_addr64 addr);
+int vm_fork(int parent, int child);
+void *vm_mmap(int proc, void *addr, u64_t length, VmFlags flags);
 
 #endif /* VM_H */

--- a/mm/break.cpp
+++ b/mm/break.cpp
@@ -22,10 +22,10 @@
 #include "../h/type.hpp" // Defines vir_bytes, vir_clicks, CLICK_SIZE, CLICK_SHIFT
 #include "const.hpp"
 #include "glo.hpp"
-#include <cstddef>   // For std::size_t
-#include <cstdint>   // For int64_t
 #include "mproc.hpp"
 #include "param.hpp"
+#include <cstddef> // For std::size_t
+#include <cstdint> // For int64_t
 
 constexpr int DATA_CHANGED = 1;  /* flag value when data segment size changed */
 constexpr int STACK_CHANGED = 2; /* flag value when stack size changed */
@@ -33,6 +33,14 @@ constexpr int STACK_CHANGED = 2; /* flag value when stack size changed */
 /*===========================================================================*
  *				do_brk  				     *
  *===========================================================================*/
+/**
+ * @brief Handle the BRK/SBRK system call.
+ *
+ * Resizes the data segment according to the address supplied via the incoming message. The stack
+ * pointer is validated so that the stack and data segments do not collide.
+ *
+ * @return ::OK on success or an ::ErrorCode value otherwise.
+ */
 PUBLIC int do_brk() {
     /* Perform the brk(addr) system call.
      *
@@ -46,15 +54,16 @@ PUBLIC int do_brk() {
 
     register struct mproc *rmp;
     int r;
-    std::size_t v, new_sp; // vir_bytes -> std::size_t
+    std::size_t v, new_sp;  // vir_bytes -> std::size_t
     std::size_t new_clicks; // vir_clicks -> std::size_t
 
     rmp = mp;
     // Assuming addr (char*) can be meaningfully converted to a size/offset.
-    // The original cast to vir_bytes (unsigned) then to long could lose info if pointers are > long.
-    // Prefer casting directly to size_t if it's an offset, or uintptr_t if it's an address value.
-    // For this specific formula, using v directly as size_t should be fine if it represents a segment size.
-    v = reinterpret_cast<std::size_t>(addr); /* 'addr' is the new data segment size */
+    // The original cast to vir_bytes (unsigned) then to long could lose info if pointers are >
+    // long. Prefer casting directly to size_t if it's an offset, or uintptr_t if it's an address
+    // value. For this specific formula, using v directly as size_t should be fine if it represents
+    // a segment size.
+    v = reinterpret_cast<std::size_t>(addr);          /* 'addr' is the new data segment size */
     new_clicks = (v + CLICK_SIZE - 1) >> CLICK_SHIFT; // Simplified calculation
     sys_getsp(who, &new_sp); /* ask kernel for current sp value, new_sp is std::size_t* */
     r = adjust(rmp, new_clicks, new_sp);
@@ -65,7 +74,17 @@ PUBLIC int do_brk() {
 /*===========================================================================*
  *				adjust  				     *
  *===========================================================================*/
-[[nodiscard]] PUBLIC int adjust(struct mproc *rmp, std::size_t data_clicks, std::size_t sp) { // vir_clicks, vir_bytes -> std::size_t
+/**
+ * @brief Adjust the data and stack segments of a process.
+ *
+ * @param rmp        Process descriptor for the process being adjusted.
+ * @param data_clicks Desired new data segment size in clicks.
+ * @param sp         Current stack pointer value.
+ *
+ * @return ::OK if the new layout fits or ::ErrorCode::ENOMEM otherwise.
+ */
+[[nodiscard]] PUBLIC int adjust(struct mproc *rmp, std::size_t data_clicks,
+                                std::size_t sp) { // vir_clicks, vir_bytes -> std::size_t
     /* See if data and stack segments can coexist, adjusting them if need be.
      * Memory is never allocated or freed.  Instead it is added or removed from the
      * gap between data segment and stack segment.  If the gap size becomes
@@ -86,7 +105,7 @@ PUBLIC int do_brk() {
     base_of_stack = static_cast<int64_t>(mem_sp->mem_vir) + static_cast<int64_t>(mem_sp->mem_len);
     sp_click = sp >> CLICK_SHIFT; /* click containing sp (sp is std::size_t) */
     if (sp_click >= static_cast<std::size_t>(base_of_stack)) // Compare compatible types
-        return (ErrorCode::ENOMEM); /* sp too high */
+        return (ErrorCode::ENOMEM);                          /* sp too high */
 
     /* Compute size of gap between stack and data segments. */
     delta = static_cast<int64_t>(mem_sp->mem_vir) - static_cast<int64_t>(sp_click);
@@ -135,6 +154,18 @@ PUBLIC int do_brk() {
 /*===========================================================================*
  *				size_ok  				     *
  *===========================================================================*/
+/**
+ * @brief Validate whether proposed segment sizes fit in memory.
+ *
+ * @param file_type  Indicates whether text and data are separate.
+ * @param tc         Text size in clicks.
+ * @param dc         Data size in clicks.
+ * @param sc         Stack size in clicks.
+ * @param dvir       Data segment virtual origin.
+ * @param s_vir      Stack segment virtual origin.
+ *
+ * @return ::OK if the configuration fits, otherwise ::ErrorCode::ENOMEM.
+ */
 [[nodiscard]] PUBLIC int size_ok(int file_type, std::size_t tc, std::size_t dc, std::size_t sc,
                                  std::size_t dvir, std::size_t s_vir) { // vir_clicks -> std::size_t
     /* Check to see if the sizes are feasible and enough segmentation registers
@@ -149,9 +180,12 @@ PUBLIC int do_brk() {
     // PAGE_SIZE is from mm/const.hpp (was int, ideally std::size_t)
     // Assuming PAGE_SIZE is compatible or made std::size_t.
     // tc, dc, sc are std::size_t. CLICK_SHIFT is int.
-    pt = ((tc << CLICK_SHIFT) + static_cast<std::size_t>(PAGE_SIZE) - 1) / static_cast<std::size_t>(PAGE_SIZE);
-    pd = ((dc << CLICK_SHIFT) + static_cast<std::size_t>(PAGE_SIZE) - 1) / static_cast<std::size_t>(PAGE_SIZE);
-    ps = ((sc << CLICK_SHIFT) + static_cast<std::size_t>(PAGE_SIZE) - 1) / static_cast<std::size_t>(PAGE_SIZE);
+    pt = ((tc << CLICK_SHIFT) + static_cast<std::size_t>(PAGE_SIZE) - 1) /
+         static_cast<std::size_t>(PAGE_SIZE);
+    pd = ((dc << CLICK_SHIFT) + static_cast<std::size_t>(PAGE_SIZE) - 1) /
+         static_cast<std::size_t>(PAGE_SIZE);
+    ps = ((sc << CLICK_SHIFT) + static_cast<std::size_t>(PAGE_SIZE) - 1) /
+         static_cast<std::size_t>(PAGE_SIZE);
 
     if (file_type == SEPARATE) {
         if (pt > MAX_PAGES || pd + ps > MAX_PAGES)
@@ -170,6 +204,15 @@ PUBLIC int do_brk() {
 /*===========================================================================*
  *				stack_fault  				     *
  *===========================================================================*/
+/**
+ * @brief Grow the stack segment to satisfy a fault.
+ *
+ * Invoked when a process faults on its stack. The stack is expanded until the
+ * supplied stack pointer lies within the segment. If growth is impossible, the
+ * process is terminated with SIGSEGV.
+ *
+ * @param proc_nr Index of the faulting process.
+ */
 PRIVATE void stack_fault(int proc_nr) {
     /* Handle a stack fault by growing the stack segment until sp is inside of it.
      * If this is impossible because data segment is in the way, kill the process.

--- a/mm/mproc.hpp
+++ b/mm/mproc.hpp
@@ -1,43 +1,46 @@
 #pragma once
 // Modernized for C++17
 
-/* This table has one slot per process.  It contains all the memory management
- * information for each process.  Among other things, it defines the text, data
- * and stack segments, uids and gids, and various flags.  The kernel and file
- * systems have tables that are also indexed by process, with the contents
- * of corresponding slots referring to the same process in all three.
+/**
+ * @brief Per-process memory management information.
+ *
+ * Each entry describes a single process and stores segment descriptors,
+ * credentials and various status flags.  The kernel and file system maintain
+ * parallel tables indexed by process number.
  */
 
 #include "../h/type.hpp" // For uid, gid, unshort, mem_map
-#include <cstdint>       // For explicit use of uint16_t, uint8_t if not via type.hpp
 #include <cstddef>       // For std::size_t if not via type.hpp
+#include <cstdint>       // For explicit use of uint16_t, uint8_t if not via type.hpp
 
 EXTERN struct mproc {
-    struct mem_map mp_seg[NR_SEGS]; /* points to text, data, stack */
-    char mp_exitstatus;             /* storage for status when process exits */
-    char mp_sigstatus;              /* storage for signal # for killed processes */
-    int mp_pid;                     /* process id */
-    int mp_parent;                  /* index of parent process */
-    int mp_procgrp;                 /* process group (used for signals) */
+    struct mem_map mp_seg[NR_SEGS]; /**< Segment descriptors for text, data and stack. */
+    char mp_exitstatus;             /**< Status code when the process exits. */
+    char mp_sigstatus;              /**< Signal number that caused termination. */
+    int mp_pid;                     /**< Process identifier. */
+    int mp_parent;                  /**< Index of parent process. */
+    int mp_procgrp;                 /**< Process group used for signals. */
 
     /* Real and effective uids and gids. */
-    uid mp_realuid; /* process' real uid */
-    uid mp_effuid;  /* process' effective uid */
-    gid mp_realgid; /* process' real gid */
-    gid mp_effgid;  /* process' effective gid */
+    uid mp_realuid; /**< Process real user id. */
+    uid mp_effuid;  /**< Process effective user id. */
+    gid mp_realgid; /**< Process real group id. */
+    gid mp_effgid;  /**< Process effective group id. */
 
     /* Bit maps for signals. */
-    unshort mp_ignore; /* 1 means ignore the signal, 0 means don't */
-    unshort mp_catch;  /* 1 means catch the signal, 0 means don't */
-    int (*mp_func)();  /* all signals vectored to a single user fcn */
+    unshort mp_ignore; /**< Non-zero to ignore the signal. */
+    unshort mp_catch;  /**< Non-zero to catch the signal. */
+    int (*mp_func)();  /**< User function handling all signals. */
 
-    unsigned mp_flags; /* flag bits */
+    unsigned mp_flags; /**< Process flags. */
 } mproc[NR_PROCS];
 
-/* Flag values */
-inline constexpr unsigned int IN_USE = 001;   /* set when 'mproc' slot in use */
-inline constexpr unsigned int WAITING = 002;  /* set by WAIT system call */
-inline constexpr unsigned int HANGING = 004;  /* set by EXIT system call */
-inline constexpr unsigned int PAUSED = 010;   /* set by PAUSE system call */
-inline constexpr unsigned int ALARM_ON = 020; /* set when SIGALRM timer started */
-inline constexpr unsigned int SEPARATE = 040; /* set if file is separate I & D space */
+/**
+ * @brief Values for ::mproc::mp_flags.
+ */
+inline constexpr unsigned int IN_USE = 001;   /**< Slot is currently in use. */
+inline constexpr unsigned int WAITING = 002;  /**< Set by the WAIT system call. */
+inline constexpr unsigned int HANGING = 004;  /**< Set by the EXIT system call. */
+inline constexpr unsigned int PAUSED = 010;   /**< Set by the PAUSE system call. */
+inline constexpr unsigned int ALARM_ON = 020; /**< Set when the SIGALRM timer is active. */
+inline constexpr unsigned int SEPARATE = 040; /**< Process has separate I&D space. */

--- a/mm/vm.cpp
+++ b/mm/vm.cpp
@@ -20,6 +20,11 @@ PRIVATE unsigned long rng_state = 1;
 /* Generate a pseudo random number.
  * no parameters.
  */
+/**
+ * @brief Generate a pseudo random number used for address randomisation.
+ *
+ * @return Next pseudo random value.
+ */
 PRIVATE unsigned long next_rand(void) {
     rng_state = rng_state * 1103515245 + 12345;
     return rng_state;
@@ -30,6 +35,9 @@ PRIVATE unsigned long next_rand(void) {
  *===========================================================================*/
 /* Initialise the virtual memory subsystem.
  * no parameters.
+ */
+/**
+ * @brief Initialise the virtual memory subsystem.
  */
 PUBLIC void vm_init(void) {
     int i;
@@ -45,6 +53,14 @@ PUBLIC void vm_init(void) {
 /* Allocate virtual address space with ASLR.
  * bytes: size in bytes to allocate.
  * flags: protection flags (unused).
+ */
+/**
+ * @brief Allocate a region of virtual memory with simple ASLR.
+ *
+ * @param bytes Number of bytes to allocate.
+ * @param flags Protection flags (currently unused).
+ *
+ * @return Base address of the allocated region.
  */
 PUBLIC void *vm_alloc(u64_t bytes, VmFlags flags) {
     virt_addr64 base;
@@ -64,6 +80,12 @@ PUBLIC void *vm_alloc(u64_t bytes, VmFlags flags) {
  * proc: process index causing the fault.
  * addr: faulting virtual address.
  */
+/**
+ * @brief Record a page fault within a process.
+ *
+ * @param proc Index of the faulting process.
+ * @param addr Faulting virtual address.
+ */
 PUBLIC void vm_handle_fault(int proc, virt_addr64 addr) {
     /* This routine would allocate a page frame and map it.  Here it is
      * recorded only for bookkeeping.
@@ -80,9 +102,13 @@ PUBLIC void vm_handle_fault(int proc, virt_addr64 addr) {
 /*===========================================================================*
  *                              vm_fork                                      *
  *===========================================================================*/
-/* Duplicate parent's memory bookkeeping for a child process.
- * parent: index of the parent process.
- * child: index of the child process.
+/**
+ * @brief Duplicate a parent's virtual memory bookkeeping for a child.
+ *
+ * @param parent Index of the parent process.
+ * @param child  Index of the child process.
+ *
+ * @return ::OK on success.
  */
 PUBLIC int vm_fork(int parent, int child) {
     vm_proc_table[child] = vm_proc_table[parent];
@@ -92,11 +118,15 @@ PUBLIC int vm_fork(int parent, int child) {
 /*===========================================================================*
  *                              vm_mmap                                      *
  *===========================================================================*/
-/* Map a region of memory into a process.
- * proc:   process index to map into.
- * addr:   desired base address or NULL.
- * length: length of mapping in bytes.
- * flags:  mapping flags.
+/**
+ * @brief Map a region of memory into a process.
+ *
+ * @param proc   Process index to map into.
+ * @param addr   Desired base address or nullptr for automatic placement.
+ * @param length Length of the mapping in bytes.
+ * @param flags  Mapping flags.
+ *
+ * @return Base address of the mapped region.
  */
 PUBLIC void *vm_mmap(int proc, void *addr, u64_t length, VmFlags flags) {
     struct vm_proc *p = &vm_proc_table[proc];


### PR DESCRIPTION
## Summary
- document mm/break.cpp helpers with brief and params
- clean up vm.cpp comments
- refine memory process structure docs
- rewrite vm.hpp header with Doxygen

## Testing
- `make check` *(fails: No rule to make target 'obj/fsck.o')*
- `ctest --output-on-failure`

------
https://chatgpt.com/codex/tasks/task_e_684e0f3aaf748331b7dbe7754f4a14ca