### PR TITLE
Update gitignore for cache and backup files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,13 @@ cmake_install.cppmake
 *.tmp
 *.d
 __pycache__/
+
+# Ignore user cache directories and OS metadata
+/.cache/
+*.DS_Store
+
+# Ignore editor backup files
+*.idx
+*~
+*.swp
+*.bak


### PR DESCRIPTION
## Summary
- ignore `.cache/` directory and macOS `.DS_Store` files
- ignore common editor backup artifacts (`*.idx`, `*~`, `*.swp`, `*.bak`)

## Testing
- `make -C test file f=test1 LIB=` *(fails: missing headers/tools)*

------
https://chatgpt.com/codex/tasks/task_e_684e0f3d6c208331997698e20a632b96