### PR TITLE
Add service manager for automatic restarts

### DIFF
--- a/docs/sphinx/index.rst
+++ b/docs/sphinx/index.rst
@@ -17,5 +17,6 @@ The documentation is divided into several sections:
    lattice_ipc
    pq_crypto
    scheduler
+   service
    precommit
    api

--- a/docs/sphinx/service.rst
+++ b/docs/sphinx/service.rst
@@ -1,0 +1,11 @@
+Service Manager
+===============
+
+The service manager maintains critical user-space services and their
+dependencies.  Services are registered with a dependency list forming a
+directed acyclic graph.  If a service crashes the manager restarts it
+along with all dependents.
+
+.. doxygenclass:: svc::ServiceManager
+   :project: XINIM
+   :members:

--- a/kernel/CMakeLists.txt
+++ b/kernel/CMakeLists.txt
@@ -8,7 +8,7 @@ endif()
 set(KERNEL_SRC
     clock.cpp dmp.cpp floppy.cpp main.cpp memory.cpp printer.cpp proc.cpp system.cpp
     table.cpp tty.cpp idt64.cpp mpx64.cpp klib64.cpp klib88.cpp mpx88.cpp paging.cpp
-    wormhole.cpp lattice_ipc.cpp wait_graph.cpp pqcrypto.cpp syscall.cpp ${WINI_SRC})
+    wormhole.cpp lattice_ipc.cpp wait_graph.cpp pqcrypto.cpp syscall.cpp service.cpp ${WINI_SRC})
 
 #Note : klib88.cpp and mpx88.cpp were added as they appear to be kernel related sources.
 #wini.cpp is a generic name, might be a common file or superseded by at_wini / xt_wini.

--- a/kernel/schedule.cpp
+++ b/kernel/schedule.cpp
@@ -1,4 +1,5 @@
 #include "schedule.hpp"
+#include "service.hpp"
 
 namespace sched {
 
@@ -63,5 +64,7 @@ void Scheduler::unblock(xinim::pid_t pid) {
 }
 
 bool Scheduler::is_blocked(xinim::pid_t pid) const noexcept { return blocked_.contains(pid); }
+
+void Scheduler::crash(xinim::pid_t pid) { svc::service_manager.handle_crash(pid); }
 
 } // namespace sched

--- a/kernel/schedule.hpp
+++ b/kernel/schedule.hpp
@@ -34,6 +34,15 @@ class Scheduler {
      */
     void yield_to(xinim::pid_t target);
 
+    /**
+     * @brief Notify the scheduler that a service crashed.
+     *
+     * The scheduler delegates restart handling to the global service manager.
+     *
+     * @param pid Identifier of the crashed service.
+     */
+    void crash(xinim::pid_t pid);
+
     /// Currently running thread identifier.
     [[nodiscard]] xinim::pid_t current() const noexcept { return current_; }
 

--- a/kernel/service.cpp
+++ b/kernel/service.cpp
@@ -1,0 +1,67 @@
+#include "service.hpp"
+#include "schedule.hpp"
+
+namespace svc {
+
+bool ServiceManager::has_path(xinim::pid_t start, xinim::pid_t target,
+                              std::unordered_set<xinim::pid_t> &visited) const {
+    if (start == target) {
+        return true;
+    }
+    if (!visited.insert(start).second) {
+        return false;
+    }
+    auto it = services_.find(start);
+    if (it == services_.end()) {
+        return false;
+    }
+    for (xinim::pid_t dep : it->second.deps) {
+        if (has_path(dep, target, visited)) {
+            return true;
+        }
+    }
+    return false;
+}
+
+void ServiceManager::register_service(xinim::pid_t pid, const std::vector<xinim::pid_t> &deps) {
+    auto &info = services_[pid];
+    for (xinim::pid_t dep : deps) {
+        std::unordered_set<xinim::pid_t> visited;
+        if (!has_path(dep, pid, visited)) {
+            info.deps.push_back(dep);
+        }
+    }
+    info.running = true;
+    sched::scheduler.enqueue(pid);
+}
+
+void ServiceManager::restart_tree(xinim::pid_t pid, std::unordered_set<xinim::pid_t> &visited) {
+    if (!visited.insert(pid).second) {
+        return;
+    }
+    auto it = services_.find(pid);
+    if (it == services_.end()) {
+        return;
+    }
+    it->second.running = true;
+    sched::scheduler.enqueue(pid);
+    for (auto &[other_pid, info] : services_) {
+        if (std::find(info.deps.begin(), info.deps.end(), pid) != info.deps.end()) {
+            restart_tree(other_pid, visited);
+        }
+    }
+}
+
+void ServiceManager::handle_crash(xinim::pid_t pid) {
+    auto it = services_.find(pid);
+    if (it == services_.end()) {
+        return;
+    }
+    it->second.running = false;
+    std::unordered_set<xinim::pid_t> visited;
+    restart_tree(pid, visited);
+}
+
+ServiceManager service_manager{};
+
+} // namespace svc

--- a/kernel/service.hpp
+++ b/kernel/service.hpp
@@ -1,0 +1,57 @@
+#pragma once
+/**
+ * @file service.hpp
+ * @brief Simple service manager for restarting crashed services.
+ */
+
+#include "../include/xinim/core_types.hpp"
+#include <unordered_map>
+#include <unordered_set>
+#include <vector>
+
+namespace sched {
+class Scheduler;
+} // namespace sched
+
+namespace svc {
+
+/**
+ * @brief Manages kernel service processes and their dependencies.
+ *
+ * The manager stores a dependency DAG between services. When a service
+ * crashes, the manager restarts it along with any dependents.
+ */
+class ServiceManager {
+  public:
+    /**
+     * @brief Register a service with optional dependencies.
+     *
+     * @param pid Identifier of the service process.
+     * @param deps List of services @p pid depends on.
+     */
+    void register_service(xinim::pid_t pid, const std::vector<xinim::pid_t> &deps = {});
+
+    /**
+     * @brief Restart a crashed service and its dependents.
+     *
+     * @param pid Identifier of the crashed service.
+     */
+    void handle_crash(xinim::pid_t pid);
+
+  private:
+    struct ServiceInfo {
+        bool running{false};            ///< Whether the service is active
+        std::vector<xinim::pid_t> deps; ///< Services this one depends on
+    };
+
+    bool has_path(xinim::pid_t start, xinim::pid_t target,
+                  std::unordered_set<xinim::pid_t> &visited) const;
+    void restart_tree(xinim::pid_t pid, std::unordered_set<xinim::pid_t> &visited);
+
+    std::unordered_map<xinim::pid_t, ServiceInfo> services_{}; ///< Registered services
+};
+
+/// Global instance used by the kernel.
+extern ServiceManager service_manager;
+
+} // namespace svc


### PR DESCRIPTION
## Summary
- create service management module to restart crashed services
- hook restart logic into scheduler
- compile new service module in the kernel
- document service manager usage in Sphinx docs

## Testing
- `cmake -B build` *(fails: Parse error in tests/CMakeLists.txt)*
- `ctest --output-on-failure`

------
https://chatgpt.com/codex/tasks/task_e_684e61c5ea508331a1d84679bdba3ea0