### PR TITLE
Document scheduler yield integration

### DIFF
--- a/docs/sphinx/scheduler.rst
+++ b/docs/sphinx/scheduler.rst
@@ -1,15 +1,28 @@
 Scheduler
 =========
 
-The scheduler manages cooperative multitasking inside the
-kernel.It exposes a FIFO run queue along with a direct yield primitive
-                                  .
+The scheduler manages cooperative multitasking inside the kernel. It exposes a
+FIFO run queue along with a direct yield primitive for fast context switches.
 
-The implementation also integrates deadlock detection. Threads may block on
-one another through :cpp:`block_on` and :cpp:`unblock`. Blocking relationships
-are tracked in a wait-for graph and cycles trigger immediate failure.
+Blocking
+--------
 
-                                  ..doxygenclass::sched::Scheduler : project : XINIM : members :
+The implementation integrates deadlock detection. Threads may block on one
+another through :cpp:`sched::Scheduler::block_on` and
+:cpp:`sched::Scheduler::unblock`. Blocking relationships are tracked in a
+wait-for graph and cycles trigger immediate failure.
 
+.. doxygenclass:: sched::Scheduler
+   :project: XINIM
+   :members:
 
-The ``yield_to`` method enables fast hand-off between communicating threads.
+Message Hand-off
+----------------
+
+Calling :cpp:`lattice::lattice_send` delivers a message immediately when the
+receiver is already waiting. In that case execution yields directly to the
+receiver via :cpp:`sched::Scheduler::yield_to` so the message handler runs
+without delay.
+
+.. doxygenfunction:: sched::Scheduler::yield_to
+   :project: XINIM

--- a/kernel/lattice_ipc.hpp
+++ b/kernel/lattice_ipc.hpp
@@ -71,8 +71,10 @@ void lattice_listen(int pid);
  * @brief Send a message over an established channel.
  *
  * If the destination is listening the message is delivered and the
- * scheduler yields directly to the receiver.
+ * scheduler yields directly to the receiver via ::sched::Scheduler::yield_to.
  * Otherwise the message is queued on the channel.
+ *
+ * @see sched::Scheduler::yield_to
  *
  * @param src Sending process identifier.
  * @param dst Receiving process identifier.


### PR DESCRIPTION
## Summary
- document how `lattice_send` triggers `Scheduler::yield_to`
- cross-reference the scheduler API in IPC docs

## Testing
- `make check` *(fails: No rule to make target 'obj/fsck.o', needed by 'bin/fsck')*

------
https://chatgpt.com/codex/tasks/task_e_684e6202c7648331bab2d61002524ca2