### PR TITLE
Integrate Kyber KEM for lattice IPC

### DIFF
--- a/docs/sphinx/pq_crypto.rst
+++ b/docs/sphinx/pq_crypto.rst
@@ -1,23 +1,27 @@
-Post-Quantum Cryptography
-=========================
+Post - Quantum Cryptography == == == == == == == == == == == ==
+    =
 
-XINIM includes an experimental post-quantum cryptography layer. It demonstrates
-lattice-based key exchange using a minimal API defined in
-:file:`include/pqcrypto.hpp`.
+        XINIM includes an experimental post - quantum cryptography layer.It demonstrates lattice -
+        based key exchange using the Kyber512 key encapsulation mechanism with a minimal API defined
+                in : file :`include /
+    pqcrypto.hpp`
+        .
 
-.. doxygenfile:: pqcrypto.hpp
-   :project: XINIM
+        ..doxygenfile::pqcrypto
+        .hpp : project : XINIM
 
-.. doxygenstruct:: pqcrypto::KeyPair
-   :project: XINIM
+        .
+        .doxygenstruct::pqcrypto::KeyPair : project : XINIM
 
-.. doxygenfunction:: pqcrypto::generate_keypair
-   :project: XINIM
+        .
+        .doxygenfunction::pqcrypto::generate_keypair : project : XINIM
 
-.. doxygenfunction:: pqcrypto::compute_shared_secret
-   :project: XINIM
+        .
+        .doxygenfunction::pqcrypto::compute_shared_secret : project : XINIM
 
-``pqcrypto::compute_shared_secret`` derives a 32-byte session secret by XORing
-the remote party's public key with the caller's secret key.  The helper is
-implemented in ``crypto/pqcrypto_shared.cpp`` and mirrors the kernel side
-exchange primitive used for lattice IPC setup.
+        ..doxygenfunction::pqcrypto::establish_secret : project : XINIM
+
+``pqcrypto::compute_shared_secret`` derives a 32 -
+        byte session secret using the Kyber512 encapsulation routine
+            .The helper mirrors the kernel side
+``pqcrypto::establish_secret`` used during lattice IPC setup.

--- a/include/pqcrypto.hpp
+++ b/include/pqcrypto.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "kyber_impl/api.h"
 #include <array>
 #include <cstdint>
 #include <span>
@@ -10,16 +11,17 @@ namespace pqcrypto {
  * @brief Key pair for lattice-based cryptography.
  */
 struct KeyPair {
-    std::array<std::uint8_t, 32> public_key; ///< Public portion
-    std::array<std::uint8_t, 32> secret_key; ///< Secret portion
+    std::array<std::uint8_t, pqcrystals_kyber512_PUBLICKEYBYTES> public_key; ///< Kyber public key
+    std::array<std::uint8_t, pqcrystals_kyber512_SECRETKEYBYTES> secret_key; ///< Kyber private key
 };
 
 /**
  * @brief Generate a new lattice-based key pair.
  *
- * This is a placeholder demonstrating the PQ interface.
+ * The generated keys use the Kyber512 parameter set and are compatible
+ * with the establish and compute routines provided by this header.
  *
- * @return Newly created key pair.
+ * @return Newly created key pair containing Kyber public and private data.
  */
 [[nodiscard]] KeyPair generate_keypair();
 
@@ -27,11 +29,11 @@ struct KeyPair {
  * @brief Derive a shared secret using key exchange.
  *
  * @param public_key Remote party public key.
- * @param secret_key Local secret key.
- * @return Derived shared secret bytes.
+ * @param secret_key Local private key.
+ * @return Derived 32-byte shared secret.
  */
-[[nodiscard]] std::array<std::uint8_t, 32>
-compute_shared_secret(std::span<const std::uint8_t, 32> public_key,
-                      std::span<const std::uint8_t, 32> secret_key);
+[[nodiscard]] std::array<std::uint8_t, pqcrystals_kyber512_BYTES>
+compute_shared_secret(std::span<const std::uint8_t, pqcrystals_kyber512_PUBLICKEYBYTES> public_key,
+                      std::span<const std::uint8_t, pqcrystals_kyber512_SECRETKEYBYTES> secret_key);
 
 } // namespace pqcrypto

--- a/kernel/pqcrypto.hpp
+++ b/kernel/pqcrypto.hpp
@@ -3,6 +3,7 @@
  * @file pqcrypto.hpp
  * @brief Minimal post-quantum cryptography interface used by the lattice IPC layer.
  */
+#include "../crypto/kyber_impl/api.h"
 #include <array>
 #include <cstdint>
 
@@ -12,32 +13,31 @@ namespace pqcrypto {
  * @brief Simple key pair for establishing a shared secret.
  */
 struct KeyPair {
-    std::array<std::uint8_t, 32> public_key;  //!< Public component
-    std::array<std::uint8_t, 32> private_key; //!< Private component
+    std::array<std::uint8_t, pqcrystals_kyber512_PUBLICKEYBYTES> public_key;  //!< Kyber public key
+    std::array<std::uint8_t, pqcrystals_kyber512_SECRETKEYBYTES> private_key; //!< Kyber private key
 };
 
 /**
  * @brief Generate a new post-quantum key pair.
  *
- * The implementation uses a pseudo random number generator and does
- * not provide real security. It simply mimics an API expected by the
- * lattice IPC channel setup.
+ * The generated key pair follows the Kyber512 specification used for
+ * deriving channel secrets in the lattice IPC layer.
  *
- * @return Newly generated key pair.
+ * @return Newly generated Kyber key pair.
  */
 [[nodiscard]] KeyPair generate_keypair() noexcept;
 
 /**
  * @brief Derive a shared secret from two key pairs.
  *
- * The operation XORs bytes from the caller's private key with the peer's
- * public key to produce a placeholder secret.
+ * The secret is computed via Kyber512 encapsulation using @p peer 's public
+ * key and decapsulation with @p local 's private key.
  *
- * @param local Local key pair.
- * @param peer Peer key pair.
- * @return Derived shared secret.
+ * @param local Local key pair owning the private component.
+ * @param peer  Remote key pair providing the public component.
+ * @return Derived 32-byte shared secret.
  */
-[[nodiscard]] std::array<std::uint8_t, 32> establish_secret(const KeyPair &local,
-                                                            const KeyPair &peer) noexcept;
+[[nodiscard]] std::array<std::uint8_t, pqcrystals_kyber512_BYTES>
+establish_secret(const KeyPair &local, const KeyPair &peer) noexcept;
 
 } // namespace pqcrypto

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,191 +1,221 @@
-#Unit tests for Minix library routines and basic system calls
+#CMake configuration for XINIM unit tests
 
-#Library routine tests compile selected sources directly
 add_executable(minix_test_lib test_lib.cpp "${CMAKE_SOURCE_DIR}/lib/strlen.cpp"
                                            "${CMAKE_SOURCE_DIR}/lib/strcmp.cpp"
                                            "${CMAKE_SOURCE_DIR}/lib/rand.cpp")
 
-#Ensure lib_test can find necessary headers from the C library's public interface
-    target_include_directories(
-        minix_test_lib PUBLIC
-        "${CMAKE_SOURCE_DIR}/include"
-        "${CMAKE_SOURCE_DIR}/h") target_compile_options(minix_test_lib PRIVATE - std =
-                                                            c++ 23 - fno -
-                                                            builtin) add_test(NAME minix_test_lib
-                                                                                  COMMAND
-                                                                                      minix_test_lib)
+    target_include_directories(minix_test_lib PUBLIC "${CMAKE_SOURCE_DIR}/include"
+                                                     "${CMAKE_SOURCE_DIR}/h")
 
-#System call tests rely on the host C library only(or direct syscalls)
-        add_executable(minix_test_syscall test_syscall.cpp) target_include_directories(
-            minix_test_syscall PUBLIC
-            "${CMAKE_SOURCE_DIR}/include"
-            "${CMAKE_SOURCE_DIR}/h") add_test(NAME minix_test_syscall COMMAND minix_test_syscall)
+        target_compile_options(minix_test_lib PRIVATE - std = c++ 23 - fno - builtin)
 
-#Fastpath unit test
-#Add Stream architecture tests
-            add_executable(minix_test_streams test_streams.cpp) target_link_libraries(
-                minix_test_streams PRIVATE
-                    minix_libc) target_include_directories(minix_test_streams PUBLIC
-                                                           "${CMAKE_SOURCE_DIR}/include"
-                                                           "${CMAKE_SOURCE_DIR}/h")
-                set_target_properties(minix_test_streams PROPERTIES EXCLUDE_FROM_ALL TRUE) add_test(
-                    NAME minix_test_streams COMMAND
-                        minix_test_streams) set_tests_properties(minix_test_streams PROPERTIES
-                                                                     DISABLED TRUE)
+            add_test(NAME minix_test_lib COMMAND minix_test_lib)
 
-#Wormhole unit test
-add_executable(minix_test_fastpath test_fastpath.cpp
-                                   "${CMAKE_SOURCE_DIR}/kernel/wormhole.cpp"
-                                   "${CMAKE_SOURCE_DIR}/kernel/schedule.cpp"
-                                   "${CMAKE_SOURCE_DIR}/kernel/wait_graph.cpp")
-                        target_include_directories(
-                            minix_test_fastpath PUBLIC
-                            "${CMAKE_SOURCE_DIR}/kernel") add_test(NAME minix_test_fastpath COMMAND
-                                                                       minix_test_fastpath)
+                add_executable(minix_test_syscall test_syscall.cpp)
 
-#Scheduler unit test
-add_executable(minix_test_scheduler test_scheduler.cpp
-               "${CMAKE_SOURCE_DIR}/kernel/schedule.cpp"
-               "${CMAKE_SOURCE_DIR}/kernel/wait_graph.cpp")
-target_include_directories(
-    minix_test_scheduler PUBLIC
-    "${CMAKE_SOURCE_DIR}/kernel"
-    "${CMAKE_SOURCE_DIR}/include")
-add_test(NAME minix_test_scheduler COMMAND minix_test_scheduler)
+                    target_include_directories(minix_test_syscall PUBLIC
+                                               "${CMAKE_SOURCE_DIR}/include"
+                                               "${CMAKE_SOURCE_DIR}/h")
 
-#Semantic region unit test
-                                add_executable(minix_test_semantic_region test_semantic_region.cpp) target_include_directories(
-                                    minix_test_semantic_region PUBLIC
-                                    "${CMAKE_SOURCE_DIR}/include") add_test(NAME minix_test_semantic_region
-                                                                                COMMAND
-                                                                                    minix_test_semantic_region)
+                        add_test(NAME minix_test_syscall COMMAND minix_test_syscall)
 
-#Stream foundation verification test
-                                    add_executable(
-                                        minix_test_stream_foundation test_stream_foundation.cpp
-                                        "${CMAKE_SOURCE_DIR}/lib/io/src/file_stream.cpp"
-                                        "${CMAKE_SOURCE_DIR}/lib/io/src/file_operations.cpp"
-                                        "${CMAKE_SOURCE_DIR}/lib/io/src/standard_streams.cpp")
+                            add_executable(minix_test_streams test_streams.cpp)
+
+                                target_link_libraries(minix_test_streams PRIVATE minix_libc)
+
+                                    target_include_directories(minix_test_streams PUBLIC
+                                                               "${CMAKE_SOURCE_DIR}/include"
+                                                               "${CMAKE_SOURCE_DIR}/h")
+
                                         set_target_properties(
-                                            minix_test_stream_foundation PROPERTIES
-                                                CXX_STANDARD 23 CXX_STANDARD_REQUIRED ON EXCLUDE_FROM_ALL
-                                                    TRUE) target_include_directories(minix_test_stream_foundation PUBLIC
-                                                                                     "${CMAKE_"
-                                                                                     "SOURCE_DIR}/"
-                                                                                     "include")
+                                            minix_test_streams PROPERTIES EXCLUDE_FROM_ALL TRUE)
                                             add_test(
-                                                NAME minix_test_stream_foundation COMMAND
-                                                    minix_test_stream_foundation) set_tests_properties(minix_test_stream_foundation
-                                                                                                           PROPERTIES DISABLED
-                                                                                                               TRUE)
+                                                NAME minix_test_streams COMMAND minix_test_streams)
+                                                set_tests_properties(
+                                                    minix_test_streams PROPERTIES DISABLED TRUE)
 
-#MemoryStream unit test
-                                                add_executable(
-                                                    minix_test_memory_stream test_memory_stream.cpp
-                                                    "${CMAKE_SOURCE_DIR}/lib/io/src/"
-                                                    "memory_stream.cpp")
-                                                    set_target_properties(
-                                                        minix_test_memory_stream PROPERTIES
-                                                            CXX_STANDARD 23 CXX_STANDARD_REQUIRED
-                                                                ON)
+                                                    add_executable(
+                                                        minix_test_fastpath test_fastpath.cpp
+                                                        "${CMAKE_SOURCE_DIR}/kernel/wormhole.cpp"
+                                                        "${CMAKE_SOURCE_DIR}/kernel/schedule.cpp"
+                                                        "${CMAKE_SOURCE_DIR}/kernel/wait_graph.cpp")
+
                                                         target_include_directories(
-                                                            minix_test_memory_stream PUBLIC
-                                                            "${CMAKE_SOURCE_DIR}/include") add_test(NAME
-                                                                                                        minix_test_memory_stream COMMAND minix_test_memory_stream)
+                                                            minix_test_fastpath PUBLIC
+                                                            "${CMAKE_SOURCE_DIR}/kernel")
 
-#Scheduler edge case unit test
-add_executable(minix_test_scheduler_edge
-               test_scheduler_edge.cpp
-               "${CMAKE_SOURCE_DIR}/kernel/schedule.cpp"
-               "${CMAKE_SOURCE_DIR}/kernel/wait_graph.cpp")
-                                                                set_target_properties(
-                                                                    minix_test_scheduler_edge
-                                                                        PROPERTIES CXX_STANDARD 23 CXX_STANDARD_REQUIRED
-                                                                            ON)
+                                                            add_test(
+                                                                NAME minix_test_fastpath COMMAND
+                                                                    minix_test_fastpath)
+
+                                                                add_executable(
+                                                                    minix_test_scheduler
+                                                                        test_scheduler.cpp
+                                                                    "${CMAKE_SOURCE_DIR}/kernel/"
+                                                                    "schedule.cpp"
+                                                                    "${CMAKE_SOURCE_DIR}/kernel/"
+                                                                    "wait_graph.cpp")
+
                                                                     target_include_directories(
-                                                                        minix_test_scheduler_edge PUBLIC
+                                                                        minix_test_scheduler PUBLIC
                                                                         "${CMAKE_SOURCE_DIR}/kernel"
                                                                         "${CMAKE_SOURCE_DIR}/"
-                                                                        "include") add_test(NAME minix_test_scheduler_edge COMMAND minix_test_scheduler_edge)
+                                                                        "include")
 
-#Wait graph unit test
-                                                                        add_executable(
-                                                                            minix_test_wait_graph test_wait_graph
-                                                                                .cpp "${CMAKE_"
-                                                                                     "SOURCE_DIR}/"
-                                                                                     "kernel/"
-                                                                                     "wait_graph."
-                                                                                     "cpp")
-                                                                            set_target_properties(
-                                                                                minix_test_wait_graph PROPERTIES
-                                                                                    CXX_STANDARD 23 CXX_STANDARD_REQUIRED
-                                                                                        ON)
+                                                                        add_test(
+                                                                            NAME minix_test_scheduler
+                                                                                COMMAND
+                                                                                    minix_test_scheduler)
+
+                                                                            add_executable(
+                                                                                minix_test_semantic_region
+                                                                                    test_semantic_region
+                                                                                        .cpp)
+
                                                                                 target_include_directories(
-                                                                                    minix_test_wait_graph PUBLIC
+                                                                                    minix_test_semantic_region PUBLIC
                                                                                     "${CMAKE_"
                                                                                     "SOURCE_DIR}/"
-                                                                                    "kernel"
-                                                                                    "${CMAKE_"
-                                                                                    "SOURCE_DIR}/"
-            "include") add_test(NAME minix_test_wait_graph COMMAND minix_test_wait_graph)
+                                                                                    "include")
 
-#Scheduler deadlock detection unit test
-add_executable(minix_test_scheduler_deadlock test_scheduler_deadlock.cpp
-               "${CMAKE_SOURCE_DIR}/kernel/schedule.cpp"
-               "${CMAKE_SOURCE_DIR}/kernel/wait_graph.cpp")
-set_target_properties(
-    minix_test_scheduler_deadlock PROPERTIES
-    CXX_STANDARD 23 CXX_STANDARD_REQUIRED ON)
-target_include_directories(
-    minix_test_scheduler_deadlock PUBLIC
-    "${CMAKE_SOURCE_DIR}/kernel"
-    "${CMAKE_SOURCE_DIR}/include")
-add_test(NAME minix_test_scheduler_deadlock COMMAND minix_test_scheduler_deadlock)
+                                                                                    add_test(
+                                                                                        NAME minix_test_semantic_region
+                                                                                            COMMAND
+                                                                                                minix_test_semantic_region)
 
-#Fastpath precondition unit test
-    add_executable(
-        minix_test_fastpath_preconditions test_fastpath_preconditions.cpp
-        "${CMAKE_SOURCE_DIR}/kernel/wormhole.cpp"
-        "${CMAKE_SOURCE_DIR}/kernel/schedule.cpp"
-        "${CMAKE_SOURCE_DIR}/kernel/wait_graph.cpp")
-                                                                                        set_target_properties(
-                                                                                            minix_test_fastpath_preconditions
-                                                                                                PROPERTIES CXX_STANDARD 23 CXX_STANDARD_REQUIRED
-                                                                                                    ON)
-                                                                                            target_include_directories(
-                                                                                                minix_test_fastpath_preconditions PUBLIC
-                                                                                                "${"
-                                                                                                "CM"
-                                                                                                "AK"
-                                                                                                "E_"
-                                                                                                "SO"
-                                                                                                "UR"
-                                                                                                "CE"
-                                                                                                "_D"
-                                                                                                "IR"
-                                                                                                "}/"
-                                                                                                "ke"
-                                                                                                "rn"
-                                                                                                "el"
-                                                                                                "${"
-                                                                                                "CM"
-                                                                                                "AK"
-                                                                                                "E_"
-                                                                                                "SO"
-                                                                                                "UR"
-                                                                                                "CE"
-                                                                                                "_D"
-                                                                                                "IR"
-                                                                                                "}/"
-                                                                                                "in"
-                                                                                                "cl"
-                                                                                                "ud"
-                                                                                                "e")
-                                                                                                add_test(
-                                                                                                    NAME minix_test_fastpath_preconditions
-                                                                                                        COMMAND
-                                                                                                            minix_test_fastpath_preconditions)
+                                                                                        add_executable(
+                                                                                            minix_test_stream_foundation
+                                                                                                test_stream_foundation
+                                                                                                    .cpp
+                                                                                            "${"
+                                                                                            "CMAKE_"
+                                                                                            "SOURCE"
+                                                                                            "_DIR}/"
+                                                                                            "lib/"
+                                                                                            "io/"
+                                                                                            "src/"
+                                                                                            "file_"
+                                                                                            "stream"
+                                                                                            ".cpp"
+                                                                                            "${"
+                                                                                            "CMAKE_"
+                                                                                            "SOURCE"
+                                                                                            "_DIR}/"
+                                                                                            "lib/"
+                                                                                            "io/"
+                                                                                            "src/"
+                                                                                            "file_"
+                                                                                            "operat"
+                                                                                            "ions."
+                                                                                            "cpp"
+                                                                                            "${"
+                                                                                            "CMAKE_"
+                                                                                            "SOURCE"
+                                                                                            "_DIR}/"
+                                                                                            "lib/"
+                                                                                            "io/"
+                                                                                            "src/"
+                                                                                            "standa"
+                                                                                            "rd_"
+                                                                                            "stream"
+                                                                                            "s.cpp")
 
-#Cryptography unit tests
-                                                                                                    add_subdirectory(
-                                                                                                        crypto)
+                                                                                            set_target_properties(
+                                                                                                minix_test_stream_foundation PROPERTIES
+                                                                                                    CXX_STANDARD 23 CXX_STANDARD_REQUIRED
+                                                                                                        ON EXCLUDE_FROM_ALL
+                                                                                                            TRUE)
+
+                                                                                                target_include_directories(
+                                                                                                    minix_test_stream_foundation PUBLIC
+                                                                                                    "${CMAKE_SOURCE_DIR}/include")
+
+                                                                                                    add_test(
+                                                                                                        NAME minix_test_stream_foundation
+                                                                                                            COMMAND
+                                                                                                                minix_test_stream_foundation)
+                                                                                                        set_tests_properties(
+                                                                                                            minix_test_stream_foundation
+                                                                                                                PROPERTIES DISABLED
+                                                                                                                    TRUE)
+
+                                                                                                            add_executable(
+                                                                                                                minix_test_memory_stream
+                                                                                                                    test_memory_stream
+                                                                                                                        .cpp
+                                                                                                                "${CMAKE_SOURCE_DIR}/lib/io/src/memory_stream.cpp")
+
+                                                                                                                set_target_properties(
+                                                                                                                    minix_test_memory_stream
+                                                                                                                        PROPERTIES
+                                                                                                                            CXX_STANDARD 23 CXX_STANDARD_REQUIRED
+                                                                                                                                ON)
+
+                                                                                                                    target_include_directories(
+                                                                                                                        minix_test_memory_stream PUBLIC
+                                                                                                                        "${CMAKE_SOURCE_DIR}/include")
+
+                                                                                                                        add_test(
+                                                                                                                            NAME minix_test_memory_stream
+                                                                                                                                COMMAND
+                                                                                                                                    minix_test_memory_stream)
+
+                                                                                                                            add_executable(
+                                                                                                                                minix_test_scheduler_edge
+                                                                                                                                    test_scheduler_edge
+                                                                                                                                        .cpp
+                                                                                                                                "${CMAKE_SOURCE_DIR}/kernel/schedule.cpp"
+                                                                                                                                "${CMAKE_SOURCE_DIR}/kernel/wait_graph.cpp")
+
+                                                                                                                                set_target_properties(
+                                                                                                                                    minix_test_scheduler_edge
+                                                                                                                                        PROPERTIES
+                                                                                                                                            CXX_STANDARD 23 CXX_STANDARD_REQUIRED
+                                                                                                                                                ON)
+
+                                                                                                                                    target_include_directories(
+                                                                                                                                        minix_test_scheduler_edge PUBLIC
+                                                                                                                                        "${CMAKE_SOURCE_DIR}/kernel"
+                                                                                                                                        "${CMAKE_SOURCE_DIR}/include")
+
+                                                                                                                                        add_test(
+                                                                                                                                            NAME minix_test_scheduler_edge
+                                                                                                                                                COMMAND
+                                                                                                                                                    minix_test_scheduler_edge)
+
+                                                                                                                                            add_executable(
+                                                                                                                                                minix_test_wait_graph
+                                                                                                                                                    test_wait_graph
+                                                                                                                                                        .cpp "${CMAKE_SOURCE_DIR}/kernel/wait_graph.cpp")
+
+                                                                                                                                                set_target_properties(
+                                                                                                                                                    minix_test_wait_graph PROPERTIES
+                                                                                                                                                        CXX_STANDARD 23 CXX_STANDARD_REQUIRED
+                                                                                                                                                            ON)
+
+                                                                                                                                                    target_include_directories(
+                                                                                                                                                        minix_test_wait_graph PUBLIC
+                                                                                                                                                        "${CMAKE_SOURCE_DIR}/kernel"
+                                                                                                                                                        "${CMAKE_SOURCE_DIR}/include")
+
+                                                                                                                                                        add_test(
+                                                                                                                                                            NAME minix_test_wait_graph
+                                                                                                                                                                COMMAND
+                                                                                                                                                                    minix_test_wait_graph)
+
+                                                                                                                                                            add_executable(
+                                                                                                                                                                minix_test_fastpath_preconditions
+                                                                                                                                                                    test_fastpath_preconditions
+                                                                                                                                                                        .cpp)
+
+                                                                                                                                                                target_include_directories(
+                                                                                                                                                                    minix_test_fastpath_preconditions PUBLIC
+                                                                                                                                                                    "${CMAKE_SOURCE_DIR}/include")
+
+                                                                                                                                                                    add_test(
+                                                                                                                                                                        NAME minix_test_fastpath_preconditions
+                                                                                                                                                                            COMMAND
+                                                                                                                                                                                minix_test_fastpath_preconditions)
+
+                                                                                                                                                                        add_subdirectory(
+                                                                                                                                                                            crypto)


### PR DESCRIPTION
## Summary
- implement Kyber-based routines in kernel/pqcrypto
- derive channel secrets through a Kyber handshake in lattice IPC
- expose new KEM-based API in headers
- document PQ crypto API updates
- clean up tests build scripts

## Testing
- `cmake -B build -DBUILD_SYSTEM=OFF` *(pass)*
- `cmake --build build -- -j$(nproc)` *(fail: linker errors)*
- `ctest --test-dir build --output-on-failure` *(fail: test executable missing)*


------
https://chatgpt.com/codex/tasks/task_e_684e61c202808331b5f2180c893b97bb