### PR TITLE
Add lattice IPC unit test

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -189,3 +189,15 @@ add_test(NAME minix_test_scheduler_deadlock COMMAND minix_test_scheduler_deadloc
 #Cryptography unit tests
                                                                                                     add_subdirectory(
                                                                                                         crypto)
+
+# Lattice IPC unit test
+add_executable(minix_test_lattice test_lattice.cpp
+               "${CMAKE_SOURCE_DIR}/kernel/lattice_ipc.cpp"
+               "${CMAKE_SOURCE_DIR}/kernel/pqcrypto.cpp"
+               "${CMAKE_SOURCE_DIR}/kernel/table.cpp")
+set_target_properties(minix_test_lattice PROPERTIES CXX_STANDARD 23 CXX_STANDARD_REQUIRED ON)
+target_include_directories(minix_test_lattice PUBLIC
+    "${CMAKE_SOURCE_DIR}/kernel"
+    "${CMAKE_SOURCE_DIR}/include"
+    "${CMAKE_SOURCE_DIR}/h")
+add_test(NAME minix_test_lattice COMMAND minix_test_lattice)

--- a/tests/test_lattice.cpp
+++ b/tests/test_lattice.cpp
@@ -1,0 +1,55 @@
+/**
+ * @file test_lattice.cpp
+ * @brief Unit tests for lattice IPC primitives.
+ */
+
+#include "../h/error.hpp"
+#include "../h/type.hpp"
+#include "../kernel/lattice_ipc.hpp"
+#include "../kernel/pqcrypto.hpp"
+#include <cassert>
+
+/**
+ * @brief Validate queuing behavior and PQ secret negotiation.
+ */
+int main() {
+    using namespace lattice;
+
+    g_graph = Graph{}; // reset global state
+
+    message msg{};
+    msg.m_type = 42;
+
+    assert(lattice_connect(1, 2) == OK);
+    assert(g_graph.find(1, 2) != nullptr);
+
+    // Destination not listening -> message enqueued
+    assert(lattice_send(1, 2, msg) == OK);
+    auto *ch = g_graph.find(1, 2);
+    assert(ch && ch->queue.size() == 1);
+
+    message out{};
+    assert(lattice_recv(2, &out) == OK);
+    assert(out.m_type == 42);
+    assert(ch->queue.empty());
+
+    // Listening destination -> direct handoff
+    lattice_listen(2);
+    msg.m_type = 99;
+    assert(lattice_send(1, 2, msg) == OK);
+    assert(g_graph.inbox.find(2) != g_graph.inbox.end());
+    message out2{};
+    assert(lattice_recv(2, &out2) == OK);
+    assert(out2.m_type == 99);
+
+    // PQ crypto negotiation
+    auto a = pqcrypto::generate_keypair();
+    auto b = pqcrypto::generate_keypair();
+    auto s1 = pqcrypto::establish_secret(a, b);
+    auto s2 = pqcrypto::establish_secret(b, a);
+    for (std::size_t i = 0; i < s1.size(); ++i) {
+        assert(s1[i] == s2[i]);
+    }
+
+    return 0;
+}


### PR DESCRIPTION
## Summary
- add a lattice IPC regression test
- compile lattice IPC sources for the new test

## Testing
- `cmake -B build` *(fails: Parse error in tests/CMakeLists.txt)*

------
https://chatgpt.com/codex/tasks/task_e_684e61ca234c8331abcc52df4c794a16

## Summary by Sourcery

Add a regression test for lattice IPC primitives and configure CMake to build and run the new minix_test_lattice executable

Build:
- Update tests/CMakeLists.txt to add the minix_test_lattice target compiling lattice_ipc.cpp, pqcrypto.cpp, and table.cpp with C++23 and appropriate include directories

Tests:
- Introduce test_lattice.cpp with assertions covering lattice_connect, message queuing, direct handoff, and PQ crypto secret negotiation