### PR TITLE
Refine scheduler and fastpath helpers

### DIFF
--- a/kernel/pqcrypto.cpp
+++ b/kernel/pqcrypto.cpp
@@ -10,28 +10,24 @@
 
 namespace pqcrypto {
 
-/**
- * @brief Generate a Kyber key pair for kernel use.
- *
- * @return Newly created key pair.
- */
+/// Generate a Kyber key pair for kernel use.
+///
+/// @return Newly created key pair.
 KeyPair generate_keypair() noexcept {
     KeyPair kp{};
     pqcrystals_kyber512_ref_keypair(kp.public_key.data(), kp.private_key.data());
     return kp;
 }
 
-/**
- * @brief Establish a shared secret via Kyber encapsulation.
- *
- * The routine encapsulates to @p peer using its public key and decapsulates
- * with the peer's private key to yield a symmetric secret. The @p local key
- * pair is reserved for future protocol extensions and is currently unused.
- *
- * @param local Local key pair (unused).
- * @param peer  Remote key pair providing the public component.
- * @return Derived shared secret.
- */
+/// Establish a shared secret via Kyber encapsulation.
+///
+/// The routine encapsulates to @p peer using its public key and decapsulates
+/// with the peer's private key to yield a symmetric secret. The @p local key
+/// pair is reserved for future protocol extensions and is currently unused.
+///
+/// @param local Local key pair (unused).
+/// @param peer Remote key pair providing the public component.
+/// @return Derived shared secret.
 std::array<std::uint8_t, pqcrystals_kyber512_BYTES> establish_secret(const KeyPair &local,
                                                                      const KeyPair &peer) noexcept {
     (void)local;

--- a/kernel/schedule.cpp
+++ b/kernel/schedule.cpp
@@ -5,6 +5,9 @@ namespace sched {
 
 Scheduler scheduler{}; ///< Global instance used by kernel tests
 
+/// Preempt the current thread and schedule the next ready thread.
+///
+/// @return PID of the thread now running or std::nullopt when none are ready.
 std::optional<xinim::pid_t> Scheduler::preempt() {
     if (ready_.empty()) {
         current_ = -1;
@@ -20,18 +23,25 @@ std::optional<xinim::pid_t> Scheduler::preempt() {
     return current_;
 }
 
+/// Yield execution directly to a specific thread if it is runnable.
+///
+/// @param target Thread identifier to switch to.
+/// @return void
 void Scheduler::yield_to(xinim::pid_t target) {
-    auto it = std::find(ready_.begin(), ready_.end(), target);
-    if (it == ready_.end()) {
+    if (!std::erase(ready_, target)) {
         return; // target not runnable
     }
     if (current_ != -1) {
         ready_.push_back(current_);
     }
-    ready_.erase(it);
     current_ = target;
 }
 
+/// Block @p src until @p dst is unblocked.
+///
+/// @param src Blocking thread identifier.
+/// @param dst Thread being waited on.
+/// @return True if blocking succeeds without creating a cycle.
 bool Scheduler::block_on(xinim::pid_t src, xinim::pid_t dst) {
     if (graph_.add_edge(src, dst)) {
         return false;
@@ -40,10 +50,7 @@ bool Scheduler::block_on(xinim::pid_t src, xinim::pid_t dst) {
     waiting_[src] = dst;
     blocked_.insert(src);
 
-    auto it = std::find(ready_.begin(), ready_.end(), src);
-    if (it != ready_.end()) {
-        ready_.erase(it);
-    }
+    std::erase(ready_, src);
 
     if (current_ == src) {
         preempt();
@@ -51,20 +58,31 @@ bool Scheduler::block_on(xinim::pid_t src, xinim::pid_t dst) {
     return true;
 }
 
+/// Unblock the given thread and make it runnable again.
+///
+/// @param pid Identifier to unblock.
+/// @return void
 void Scheduler::unblock(xinim::pid_t pid) {
-    auto it = waiting_.find(pid);
-    if (it != waiting_.end()) {
+    if (auto it = waiting_.find(pid); it != waiting_.end()) {
         graph_.remove_edge(pid, it->second);
         waiting_.erase(it);
     }
 
-    if (blocked_.erase(pid) > 0) {
+    if (blocked_.erase(pid)) {
         ready_.push_back(pid);
     }
 }
 
+/// Query whether a thread is currently blocked.
+///
+/// @param pid Identifier to test.
+/// @return True if the thread is blocked.
 bool Scheduler::is_blocked(xinim::pid_t pid) const noexcept { return blocked_.contains(pid); }
 
+/// Delegate crash handling for @p pid to the service manager.
+///
+/// @param pid Identifier of the crashed service.
+/// @return void
 void Scheduler::crash(xinim::pid_t pid) { svc::service_manager.handle_crash(pid); }
 
 } // namespace sched

--- a/kernel/wormhole.cpp
+++ b/kernel/wormhole.cpp
@@ -15,6 +15,11 @@
 namespace fastpath {
 
 // Moved set_message_region and message_region_valid to the outer fastpath namespace
+/// Set the region used for message transfer.
+///
+/// @param state Fastpath state to modify.
+/// @param region Memory region describing the message buffer.
+/// @return void
 void set_message_region(State &state, const MessageRegion &region) noexcept {
     static_assert(MessageRegion::traits::is_zero_copy_capable,
                   "MessageRegion must support zero-copy");
@@ -22,6 +27,11 @@ void set_message_region(State &state, const MessageRegion &region) noexcept {
     state.msg_region = region;
 }
 
+/// Determine whether a message region can hold a given number of words.
+///
+/// @param region Memory region to validate.
+/// @param msg_len Number of message words required.
+/// @return True if the region is suitably sized and aligned.
 bool message_region_valid(const MessageRegion &region, size_t msg_len) noexcept {
     return region.size() >= msg_len * sizeof(uint64_t) && region.aligned();
 }
@@ -39,35 +49,40 @@ namespace detail {
 // namespace detail { // This was the beginning of the second, nested detail. Consolidating.
 
 /// Remove the receiver from the endpoint queue and update endpoint state.
+///
+/// @param state Fastpath state holding endpoint data.
+/// @return void
 inline void dequeue_receiver(State &state) noexcept {
-    auto it =
-        std::find(state.endpoint.queue.begin(), state.endpoint.queue.end(), state.receiver.tid);
-    if (it != state.endpoint.queue.end()) {
-        state.endpoint.queue.erase(it);
-    }
+    std::erase(state.endpoint.queue, state.receiver.tid);
     if (state.endpoint.queue.empty()) {
         state.endpoint.state = EndpointState::Idle;
     }
 }
 
 /// Deliver the sender's badge to the receiver.
+///
+/// @param state Fastpath state referencing sender and receiver.
+/// @return void
 inline void transfer_badge(State &state) noexcept { state.receiver.badge = state.cap.badge; }
 
 /// Establish reply linkage from sender to receiver.
+///
+/// @param state Fastpath state referencing sender and receiver.
+/// @return void
 inline void establish_reply(State &state) noexcept { state.sender.reply_to = state.receiver.tid; }
 
 /// Copy message registers from sender to receiver.
+///
+/// @param state Fastpath state containing message buffers.
+/// @return void
 inline void copy_mrs(State &state) noexcept {
+    const auto len = std::min(state.msg_len, state.sender.mrs.size());
     if (message_region_valid(state.msg_region, state.msg_len)) {
         auto *buffer = static_cast<uint64_t *>(state.msg_region.zero_copy_map());
-        for (size_t i = 0; i < state.msg_len && i < state.sender.mrs.size(); ++i) {
-            buffer[i] = state.sender.mrs[i];
-            state.receiver.mrs[i] = buffer[i];
-        }
+        std::ranges::copy_n(state.sender.mrs.begin(), len, buffer);
+        std::ranges::copy_n(buffer, len, state.receiver.mrs.begin());
     } else {
-        for (size_t i = 0; i < state.msg_len && i < state.sender.mrs.size(); ++i) {
-            state.receiver.mrs[i] = state.sender.mrs[i];
-        }
+        std::ranges::copy_n(state.sender.mrs.begin(), len, state.receiver.mrs.begin());
     }
 }
 
@@ -76,16 +91,18 @@ inline void copy_mrs(State &state) noexcept {
 // These functions are now part of the consolidated "namespace detail"
 /// Update scheduling state after IPC.
 /// The receiver becomes runnable while the sender blocks waiting for a reply.
+///
+/// @param state Fastpath state referencing threads.
+/// @return void
 inline void update_thread_state(State &state) noexcept {
     state.receiver.status = ThreadStatus::Running;
     state.sender.status = ThreadStatus::Blocked;
 }
 
-/**
- * @brief Context switch to the receiver thread using the global scheduler.
- *
- * @param state Fastpath state being updated.
- */
+/// Context switch to the receiver thread using the global scheduler.
+///
+/// @param state Fastpath state being updated.
+/// @return void
 inline void context_switch(State &state) noexcept {
     sched::scheduler.yield_to(state.receiver.tid);
     state.current_tid = sched::scheduler.current();
@@ -96,9 +113,19 @@ inline void context_switch(State &state) noexcept {
 // These static functions remain in the outer ::fastpath namespace
 // update statistics for a failed precondition
 // Helper to determine if a capability conveys send rights.
+/// Determine whether the given rights include send permission.
+///
+/// @param rights Capability rights to inspect.
+/// @return True if send is permitted.
 static bool has_send_right(const CapRights &rights) noexcept { return rights.write; }
 
 // Helper for updating statistics when a precondition check fails.
+/// Record a failed precondition when @p condition is false.
+///
+/// @param condition Expression result to evaluate.
+/// @param idx Index of the failing precondition.
+/// @param stats Optional statistics structure to update.
+/// @return True if @p condition is true.
 static bool check(bool condition, Precondition idx, FastpathStats *stats) noexcept {
     if (condition) {
         return true;
@@ -112,6 +139,11 @@ static bool check(bool condition, Precondition idx, FastpathStats *stats) noexce
 }
 
 // Evaluate all preconditions for a fastpath execution attempt.
+/// Verify that the current state satisfies all fastpath requirements.
+///
+/// @param s State to validate.
+/// @param stats Optional statistics structure for failure accounting.
+/// @return True if every precondition holds.
 static bool preconditions(const State &s, FastpathStats *stats) noexcept {
     return check(s.extra_caps == 0, Precondition::P1, stats) &&
            check(s.msg_len <= s.sender.mrs.size(), Precondition::P2, stats) &&
@@ -130,18 +162,20 @@ static bool preconditions(const State &s, FastpathStats *stats) noexcept {
 using Transformer = void (*)(State &);
 
 /// Apply all transformation steps when fastpath preconditions hold.
+///
+/// @param state Fastpath state describing sender and receiver.
+/// @param stats Optional statistics structure to update.
+/// @return True if the fastpath completed successfully.
 bool execute_fastpath(State &state, FastpathStats *stats) noexcept {
     if (!preconditions(state, stats)) {
         return false;
     }
 
-    constexpr Transformer steps[] = {detail::dequeue_receiver,    detail::transfer_badge,
-                                     detail::establish_reply,     detail::copy_mrs,
-                                     detail::update_thread_state, detail::context_switch};
+    constexpr std::array<Transformer, 6> steps{detail::dequeue_receiver,    detail::transfer_badge,
+                                               detail::establish_reply,     detail::copy_mrs,
+                                               detail::update_thread_state, detail::context_switch};
 
-    for (Transformer step : steps) {
-        step(state);
-    }
+    std::ranges::for_each(steps, [&state](Transformer step) { step(state); });
 
     if (stats != nullptr) {
         stats->success_count.fetch_add(1, std::memory_order_relaxed);

--- a/kernel/wormhole.hpp
+++ b/kernel/wormhole.hpp
@@ -114,14 +114,14 @@ struct FastpathStats {
 /**
  * @brief Execute the fastpath transformations if preconditions are met.
  *
- * Applies each transformation step to @p s and updates @p stats when
+ * Applies each transformation step to @p state and updates @p stats when
  * provided.
  *
- * @param s     Mutable fastpath state.
+ * @param state Mutable fastpath state.
  * @param stats Optional statistics collector.
  * @return @c true when all preconditions pass and the fastpath completed.
  */
-bool execute_fastpath(State &s, FastpathStats *stats = nullptr) noexcept;
+bool execute_fastpath(State &state, FastpathStats *stats = nullptr) noexcept;
 
 /**
  * @brief Configure a zero-copy message region for the fastpath.
@@ -129,10 +129,10 @@ bool execute_fastpath(State &s, FastpathStats *stats = nullptr) noexcept;
  * The region must satisfy the alignment requirements defined by
  * MessageRegion.
  *
- * @param s      Fastpath state to modify.
+ * @param state  Fastpath state to modify.
  * @param region Zero-copy message region.
  */
-void set_message_region(State &s, const MessageRegion &region) noexcept;
+void set_message_region(State &state, const MessageRegion &region) noexcept;
 
 /**
  * @brief Validate that a message region can hold @p msg_len registers.
@@ -145,17 +145,17 @@ bool message_region_valid(const MessageRegion &region, size_t msg_len) noexcept;
 
 namespace detail {
 /// Remove the receiver from the endpoint queue.
-void dequeue_receiver(State &s) noexcept;
+void dequeue_receiver(State &state) noexcept;
 /// Transfer the sender's badge to the receiver.
-void transfer_badge(State &s) noexcept;
+void transfer_badge(State &state) noexcept;
 /// Link the sender to the receiver for replies.
-void establish_reply(State &s) noexcept;
+void establish_reply(State &state) noexcept;
 /// Copy message registers using the configured message region.
-void copy_mrs(State &s) noexcept;
+void copy_mrs(State &state) noexcept;
 /// Update thread states after IPC.
-void update_thread_state(State &s) noexcept;
+void update_thread_state(State &state) noexcept;
 /// Switch execution to the receiver.
-void context_switch(State &s) noexcept;
+void context_switch(State &state) noexcept;
 } // namespace detail
 
 } // namespace fastpath


### PR DESCRIPTION
## Summary
- modernize scheduler operations with `std::erase` and structured search
- use ranges algorithms in wormhole fastpath helpers
- clean up parameter names in wormhole header
- clang-format updated sources

## Testing
- `make docs`

------
https://chatgpt.com/codex/tasks/task_e_684e6a4b603c83319a90ba1a8ed5e905

## Summary by Sourcery

Modernize scheduler and fastpath helpers by adopting C++20 algorithms, refining API naming, and enhancing documentation

Enhancements:
- Adopt std::erase and std::ranges algorithms for queue manipulation and message copying
- Consolidate nested detail namespace and unify fastpath transformation steps invocation
- Rename parameters for clarity in fastpath API (e.g., s to state)
- Simplify scheduler methods by replacing manual loops with std::erase-based logic

Documentation:
- Add Doxygen-style comments to fastpath helpers, scheduler methods, and PQCrypto routines

Chores:
- Apply clang-format updates across sources