### PR TITLE
Fix Tanenbaum spelling in docs

### DIFF
--- a/docs/sphinx/conf.py
+++ b/docs/sphinx/conf.py
@@ -15,11 +15,9 @@ from pathlib import Path
 # Project metadata displayed in the documentation.
 project = "XINIM"  # Name of the project
 # Developers credited in the documentation. This edition is curated by
-# The 2025 XINIM team with deep gratitude and thanks to Andrew Tannenbaum
+# The 2025 XINIM team with deep gratitude and thanks to Andrew Tanenbaum
 # for the foundational concepts that shape XINIM's architecture.
-author = (
-    "The 2025 XINIM team with deep gratitude and thanks to Andrew Tannenbaum"
-)
+author = "The 2025 XINIM team with deep gratitude and thanks to Andrew Tanenbaum"
 version = "0.1"  # Short version string
 release = "0.1.0"  # Full version string including patch level
 


### PR DESCRIPTION
## Summary
- fix 'Tanenbaum' spelling in Sphinx configuration
- rebuild documentation to ensure updated author information

## Testing
- `doxygen Doxyfile`
- `sphinx-build -b html docs/sphinx docs/sphinx/html`

------
https://chatgpt.com/codex/tasks/task_e_684e6f4d2e188331980228215855d28a

## Summary by Sourcery

Fix the spelling of 'Tanenbaum' in the Sphinx documentation configuration and rebuild the HTML output to apply the correction.

Bug Fixes:
- Correct the spelling of 'Tanenbaum' in the Sphinx conf.py.

Documentation:
- Update the author attribution comment and string to use the correct spelling of 'Tanenbaum'.

Chores:
- Regenerate the Sphinx HTML documentation to reflect the updated spelling.