### PR TITLE
Fix mem_init iteration

### DIFF
--- a/mm/alloc.cpp
+++ b/mm/alloc.cpp
@@ -1,48 +1,44 @@
-/* This file is concerned with allocating and freeing arbitrary-size blocks of
- * physical memory on behalf of the FORK and EXEC system calls.  The key data
- * structure used is the hole table, which maintains a list of holes in memory.
- * It is kept sorted in order of increasing memory address. The addresses
- * it contains refer to physical memory, starting at absolute address 0
- * (i.e., they are not relative to the start of MM).  During system
- * initialization, that part of memory containing the interrupt vectors,
- * kernel, and MM are "allocated" to mark them as not available and to
- * remove them from the hole list.
+/**
+ * @file alloc.cpp
+ * @brief Physical memory allocator for the memory manager.
  *
- * The entry points into this file are:
- *   alloc_mem:	allocate a given sized chunk of memory
- *   free_mem:	release a previously allocated chunk of memory
- *   mem_init:	initialize the tables when MM start up
- *   max_hole:	returns the largest hole currently available
+ * This module keeps a linked list of free regions referred to as "holes".
+ * Memory is allocated in units of clicks using a first-fit strategy.  During
+ * system initialisation the regions occupied by the kernel and memory manager
+ * are removed from the list so they cannot be reused.
  */
 
 #include "../h/const.hpp"
 #include "../h/type.hpp" // This should define phys_clicks as uint64_t
 #include "const.hpp"     // For NO_MEM
-#include <cstdint>       // For explicit uint64_t usage
 #include <cstddef>       // For nullptr
+#include <cstdint>       // For explicit uint64_t usage
+#include <iterator>      // For std::begin/std::end
 
-constexpr int NR_HOLES = 128; /* max # entries in hole table */
+/** Maximum number of entries in the hole table. */
+constexpr int NR_HOLES = 128;
 // constexpr struct hole *NIL_HOLE = nullptr; // Definition removed
 
+/**
+ * @brief Descriptor for a free region of physical memory.
+ */
 PRIVATE struct hole {
-    uint64_t h_base;     /* where does the hole begin? (phys_clicks) */
-    uint64_t h_len;      /* how big is the hole? (phys_clicks) */
-    struct hole *h_next; /* pointer to next entry on the list */
+    uint64_t h_base;     ///< Start address of the hole in clicks.
+    uint64_t h_len;      ///< Length of the hole in clicks.
+    struct hole *h_next; ///< Next hole in the linked list.
 } hole[NR_HOLES];
 
-PRIVATE struct hole *hole_head;  /* pointer to first hole */
-PRIVATE struct hole *free_slots; /* ptr to list of unused table slots */
-
-/*===========================================================================*
- *				alloc_mem				     *
- *===========================================================================*/
+/** Pointer to the first hole in the list. */
+PRIVATE struct hole *hole_head;
+/** Pointer to the list of unused table slots. */
+PRIVATE struct hole *free_slots;
+/**
+ * @brief Allocate a block from the hole list using first fit.
+ *
+ * @param clicks Number of clicks to allocate.
+ * @return Base click address of the allocated block or ::NO_MEM.
+ */
 [[nodiscard]] PUBLIC uint64_t alloc_mem(uint64_t clicks) noexcept { // phys_clicks -> uint64_t
-    /* Allocate a block of memory from the free list using first fit. The block
-     * consists of a sequence of contiguous bytes, whose length in clicks is
-     * given by 'clicks'.  A pointer to the block is returned.  The block is
-     * always on a click boundary.  This procedure is called when memory is
-     * needed for FORK or EXEC.
-     */
 
     register struct hole *hp, *prev_ptr;
     uint64_t old_base; // phys_clicks -> uint64_t
@@ -58,7 +54,12 @@ PRIVATE struct hole *free_slots; /* ptr to list of unused table slots */
             /* If hole is only partly used, reduce size and return. */
             if (hp->h_len != 0)
                 return (old_base);
-
+            /**
+             * @brief Remove an entry from the hole list.
+             *
+             * @param prev_ptr Hole preceding the one to remove.
+             * @param hp       Hole to remove.
+             */
             /* The entire hole has been used up.  Manipulate free list. */
             del_slot(prev_ptr, hp);
             return (old_base);
@@ -69,17 +70,13 @@ PRIVATE struct hole *free_slots; /* ptr to list of unused table slots */
     }
     return (NO_MEM);
 }
-
-/*===========================================================================*
- *				free_mem				     *
- *===========================================================================*/
+/**
+ * @brief Return a block of memory to the allocator.
+ *
+ * @param base   Starting click of the block.
+ * @param clicks Size of the block in clicks.
+ */
 PUBLIC void free_mem(uint64_t base, uint64_t clicks) noexcept { // phys_clicks -> uint64_t
-    /* Return a block of free memory to the hole list.  The parameters tell where
-     * the block starts in physical memory and how big it is.  The block is added
-     * to the hole list.  If it is contiguous with an existing hole on either end,
-     * it is merged with the hole or holes.
-     */
-
     register struct hole *hp, *new_ptr, *prev_ptr;
 
     if ((new_ptr = free_slots) == nullptr) // NIL_HOLE -> nullptr
@@ -113,16 +110,13 @@ PUBLIC void free_mem(uint64_t base, uint64_t clicks) noexcept { // phys_clicks -
     merge(prev_ptr); /* sequence is 'prev_ptr', 'new_ptr', 'hp' */
 }
 
-/*===========================================================================*
- *				del_slot				     *
- *===========================================================================*/
+/**
+ * @brief Remove an entry from the hole list.
+ *
+ * @param prev_ptr Hole preceding the one to remove.
+ * @param hp       Hole to remove.
+ */
 PRIVATE void del_slot(struct hole *prev_ptr, struct hole *hp) noexcept {
-    /* Remove an entry from the hole list.  This procedure is called when a
-     * request to allocate memory removes a hole in its entirety, thus reducing
-     * the numbers of holes in memory, and requiring the elimination of one
-     * entry in the hole list.
-     */
-
     if (hp == hole_head)
         hole_head = hp->h_next;
     else
@@ -132,15 +126,12 @@ PRIVATE void del_slot(struct hole *prev_ptr, struct hole *hp) noexcept {
     free_slots = hp;
 }
 
-/*===========================================================================*
- *				merge					     *
- *===========================================================================*/
+/**
+ * @brief Merge a hole with adjacent holes if they are contiguous.
+ *
+ * @param hp Pointer to the first hole in a chain to check.
+ */
 PRIVATE void merge(struct hole *hp) noexcept {
-    /* Check for contiguous holes and merge any found.  Contiguous holes can occur
-     * when a block of memory is freed, and it happens to abut another hole on
-     * either or both ends.  The pointer 'hp' points to the first of a series of
-     * three holes that can potentially all be merged together.
-     */
 
     register struct hole *next_ptr;
 
@@ -167,10 +158,9 @@ PRIVATE void merge(struct hole *hp) noexcept {
     }
 }
 
-/*===========================================================================*
- *				max_hole				     *
- *===========================================================================*/
-// Return the size of the largest hole currently available.
+/**
+ * @brief Return the size of the largest available hole.
+ */
 [[nodiscard]] PUBLIC uint64_t max_hole() noexcept { // phys_clicks -> uint64_t
     /* Scan the hole list and return the largest hole. */
 
@@ -187,26 +177,26 @@ PRIVATE void merge(struct hole *hp) noexcept {
     return (max);
 }
 
-/*===========================================================================*
- *				mem_init				     *
- *===========================================================================*/
+/**
+ * @brief Initialise the hole allocator with a single region.
+ *
+ * The hole table is prepared so that one hole spans the entire region
+ * described by @p clicks. All remaining table slots are added to the
+ * free-slot list for later use.
+ *
+ * @param clicks Number of clicks available.
+ */
 PUBLIC void mem_init(uint64_t clicks) noexcept { // phys_clicks -> uint64_t
-    /* Initialize hole lists.  There are two lists: 'hole_head' points to a linked
-     * list of all the holes (unused memory) in the system; 'free_slots' points to
-     * a linked list of table entries that are not in use.  Initially, the former
-     * list has one entry, a single hole encompassing all of memory, and the second
-     * list links together all the remaining table slots.  As memory becomes more
-     * fragmented in the course of time (i.e., the initial big hole breaks up into
-     * many small holes), new table slots are needed to represent them.  These
-     * slots are taken from the list headed by 'free_slots'.
-     */
+    // Chain free slots using modern iteration. The first hole represents the
+    // available memory region; remaining slots are placed on the free list.
+    auto first = std::begin(hole);
+    auto last = std::end(hole);
+    for (auto it = std::next(first, 1); it != last; ++it) {
+        auto next = std::next(it);
+        it->h_next = (next != last) ? &(*next) : nullptr;
+    }
 
-    register struct hole *hp;
-
-    for (hp = &hole[0]; hp < &hole[NR_HOLES]; hp++)
-        hp->h_next = hp + 1;
-    hole[0].h_next = nullptr; /* only 1 big hole initially */ // NIL_HOLE -> nullptr
-    hole[NR_HOLES - 1].h_next = nullptr; // NIL_HOLE -> nullptr
+    hole[0].h_next = nullptr; /* only 1 big hole initially */
     hole_head = &hole[0];
     free_slots = &hole[1];
     hole[0].h_base = 0;

--- a/mm/alloc.hpp
+++ b/mm/alloc.hpp
@@ -1,0 +1,37 @@
+#pragma once
+/**
+ * @file alloc.hpp
+ * @brief Interfaces for memory allocation used by the memory manager.
+ */
+
+#include <cstdint>
+
+/**
+ * @brief Allocate a block of physical memory measured in clicks.
+ *
+ * The allocator uses a first-fit policy on a list of free holes.
+ *
+ * @param clicks Number of memory clicks to allocate.
+ * @return Base click address of the allocated block or ::NO_MEM on failure.
+ */
+[[nodiscard]] uint64_t alloc_mem(uint64_t clicks) noexcept;
+
+/**
+ * @brief Free a previously allocated block of physical memory.
+ *
+ * @param base   Starting click of the block to free.
+ * @param clicks Size of the block in clicks.
+ */
+void free_mem(uint64_t base, uint64_t clicks) noexcept;
+
+/**
+ * @brief Return the size of the largest available hole.
+ */
+[[nodiscard]] uint64_t max_hole() noexcept;
+
+/**
+ * @brief Initialise the hole allocator with a single region of memory.
+ *
+ * @param clicks Total number of clicks available.
+ */
+void mem_init(uint64_t clicks) noexcept;

--- a/mm/exec.cpp
+++ b/mm/exec.cpp
@@ -17,6 +17,7 @@
 #include "../h/error.hpp"
 #include "../h/stat.h"
 #include "../h/type.hpp" // Defines target types like phys_bytes, vir_bytes, vir_clicks
+#include "alloc.hpp"
 #include "const.hpp"
 #include "glo.hpp"
 #include "mproc.hpp"

--- a/mm/main.cpp
+++ b/mm/main.cpp
@@ -18,6 +18,7 @@
 #include "../h/const.hpp"
 #include "../h/error.hpp"
 #include "../include/vm.h"
+#include "alloc.hpp"
 #include "const.hpp"
 #include "glo.hpp"
 #include "mproc.hpp"
@@ -138,8 +139,6 @@ static void mm_init() noexcept { // PRIVATE -> static, void return, noexcept
 
     // Assuming modernized signatures for these extern functions from other modules
     extern uint64_t get_tot_mem() noexcept;
-    extern uint64_t alloc_mem(uint64_t clicks) noexcept;
-    extern void mem_init(uint64_t clicks) noexcept;
     extern void mm_paging_init() noexcept;
     extern void vm_init() noexcept;
 


### PR DESCRIPTION
## Summary
- modernize mem_init by linking free slots with std iterators
- include <iterator> in allocator implementation

## Testing
- `doxygen Doxyfile`
- `sphinx-build -b html docs/sphinx docs/sphinx/html` (warnings expected)


------
https://chatgpt.com/codex/tasks/task_e_684e6f5884e08331bd5ab45d8426f0f0

## Summary by Sourcery

Fix incorrect free_slots initialization in mem_init by replacing manual pointer arithmetic with standard iterator-based linking, introduce a public alloc.hpp header for allocator APIs, update mm modules to include the new header, standardize physical click types to uint64_t and modernize comments with Doxygen style.

Bug Fixes:
- Correct free_slots list initialization in mem_init to ensure all unused hole slots are properly linked.

Enhancements:
- Modernize mem_init iteration by using std::begin/std::end and std::next for free slot linking.
- Add alloc.hpp to expose alloc_mem, free_mem, max_hole and mem_init interfaces and include it across mm modules.
- Standardize use of uint64_t for physical click counts and unify include directives in forkexit.cpp, main.cpp and exec.cpp.
- Refactor allocator implementation comments to Doxygen format and remove obsolete code and comments.