### PR TITLE
Encrypt queued lattice messages

### DIFF
--- a/kernel/lattice_ipc.hpp
+++ b/kernel/lattice_ipc.hpp
@@ -18,10 +18,10 @@ using ::message;
  * @brief Channel connecting two processes.
  */
 struct Channel {
-    int src;                             //!< Source process id
-    int dst;                             //!< Destination process id
-    int node{0};                         //!< Destination node identifier
-    std::vector<message> queue;          //!< Pending messages
+    int src; //!< Source process id
+    int dst; //!< Destination process id
+    int node{0};
+    std::vector<message> queue;          //!< Pending messages encrypted with @c secret
     std::array<std::uint8_t, 32> secret; //!< Shared secret derived by PQ crypto
 };
 
@@ -76,7 +76,8 @@ void lattice_listen(int pid);
  *
  * If the destination is listening the message is delivered and the
  * scheduler yields directly to the receiver via ::sched::Scheduler::yield_to.
- * Otherwise the message is queued on the channel.
+ * Otherwise the message is XOR encrypted with the channel secret and
+ * queued on the channel.
  *
  * @see sched::Scheduler::yield_to
  *
@@ -90,8 +91,9 @@ int lattice_send(int src, int dst, const message &msg);
 /**
  * @brief Receive a message for a process.
  *
- * If no message is pending the process is marked as listening and
- * ::E_NO_MESSAGE is returned.
+ * Queued messages are decrypted using the channel secret before being
+ * delivered. If no message is pending the process is marked as
+ * listening and ::E_NO_MESSAGE is returned.
  *
  * @param pid Process identifier.
  * @param msg Buffer to store the received message.


### PR DESCRIPTION
## Summary
- use a simple XOR cipher with each channel's secret
- encrypt queued messages during `lattice_send`
- decrypt queued messages in `lattice_recv`
- document the new behaviour in `lattice_ipc.hpp`

## Testing
- `make check` *(fails: No rule to make target 'obj/fsck.o', needed by 'bin/fsck')*

------
https://chatgpt.com/codex/tasks/task_e_684f3b7ff934833181e3c21b14c0f127

## Summary by Sourcery

Encrypt queued messages in the lattice IPC channel using a per-channel XOR cipher and update related documentation

New Features:
- Encrypt queued lattice messages using each channel’s secret

Enhancements:
- Add an XOR cipher helper for symmetric encryption and decryption
- Integrate encryption into lattice_send and decryption into lattice_recv

Documentation:
- Update lattice_ipc.hpp comments to document encrypted message queues and decryption behavior