### PR TITLE
Add lattice IPC encryption test

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -206,7 +206,9 @@ target_include_directories(minix_test_lattice_ipc PUBLIC
   ${CMAKE_SOURCE_DIR}/kernel
   ${CMAKE_SOURCE_DIR}/include
   ${CMAKE_SOURCE_DIR}/h
+  ${CMAKE_SOURCE_DIR}/crypto
 )
+target_link_libraries(minix_test_lattice_ipc PRIVATE pqcrypto)
 target_compile_definitions(minix_test_lattice_ipc PRIVATE EXTERN=extern)
 add_test(NAME minix_test_lattice_ipc COMMAND minix_test_lattice_ipc)
 


### PR DESCRIPTION
## Summary
- add encryption, queued and immediate IPC test
- update test suite build for pqcrypto library

## Testing
- `cmake -S . -B build -DBUILD_SYSTEM=OFF`
- `cmake --build build --target minix_test_lattice_ipc` *(fails: `NR_REGS` not declared)*
- `ctest --test-dir build --output-on-failure` *(fails: Unable to find executable)*

------
https://chatgpt.com/codex/tasks/task_e_684f3b832c448331a4d9f614d8dc87ac

## Summary by Sourcery

Add a new IPC test that exercises lattice message passing with Kyber-based encryption, including helper routines for byte handling, and update build scripts to link the PQ crypto library.

New Features:
- Integrate post-quantum Kyber encryption into the lattice IPC test to validate secure message delivery.

Enhancements:
- Add utility functions to convert text to byte vectors and compare byte spans.

Build:
- Update CMake configuration to include the crypto directory and link the pqcrypto library for the test.

Tests:
- Expand IPC test to perform queued and immediate delivery of encrypted payloads, decrypt and verify plaintext, and handle no-message errors.