### PR TITLE
Integrate libsodium test stubs

### DIFF
--- a/kernel/lattice_ipc.cpp
+++ b/kernel/lattice_ipc.cpp
@@ -98,11 +98,12 @@ Graph g_graph{};
  * pairs. The shared secret is negotiated using pqcrypto::compute_shared_secret
  * before the channel is inserted into the adjacency list.
  */
-Channel &Graph::connect(int s, int d, int node) {
+Channel &Graph::connect(int s, int d, int node_id) {
     auto &vec = edges[s];
     // Look for an existing channel matching both dst and node
-    auto it = std::find_if(vec.begin(), vec.end(),
-                           [d, node](const Channel &c) { return c.dst == d && c.node == node; });
+    auto it = std::find_if(vec.begin(), vec.end(), [d, node_id](const Channel &c) {
+        return c.dst == d && c.node_id == node_id;
+    });
     if (it != vec.end()) {
         return *it;
     }
@@ -112,7 +113,7 @@ Channel &Graph::connect(int s, int d, int node) {
     pqcrypto::KeyPair dst_kp = pqcrypto::generate_keypair();
 
     // Initialize the new channel
-    Channel ch{.src = s, .dst = d, .node = node};
+    Channel ch{.src = s, .dst = d, .node_id = node_id};
     ch.secret = pqcrypto::compute_shared_secret(src_kp, dst_kp);
 
     vec.push_back(ch);
@@ -122,7 +123,22 @@ Channel &Graph::connect(int s, int d, int node) {
 /**
  * @brief Locate an existing channel.
  */
-Channel *Graph::find(int s, int d) noexcept {
+Channel *Graph::find(int s, int d, int node_id) noexcept {
+    auto it = edges.find(s);
+    if (it == edges.end()) {
+        return nullptr;
+    }
+    auto &vec = it->second;
+    auto vit = std::find_if(vec.begin(), vec.end(), [d, node_id](const Channel &c) {
+        return c.dst == d && c.node_id == node_id;
+    });
+    return (vit != vec.end()) ? &*vit : nullptr;
+}
+
+/**
+ * @brief Locate a channel ignoring node identifier.
+ */
+Channel *Graph::find_any(int s, int d) noexcept {
     auto it = edges.find(s);
     if (it == edges.end()) {
         return nullptr;
@@ -143,8 +159,8 @@ bool Graph::is_listening(int pid) const noexcept {
 /**
  * @brief Wrapper around Graph::connect for external consumers.
  */
-int lattice_connect(int src, int dst, int node) {
-    g_graph.connect(src, dst, node);
+int lattice_connect(int src, int dst, int node_id) {
+    g_graph.connect(src, dst, node_id);
     return OK;
 }
 
@@ -165,16 +181,16 @@ static void yield_to(int pid) {
  * @brief Send a message across a channel.
  */
 int lattice_send(int src, int dst, const message &msg) {
-    Channel *ch = g_graph.find(src, dst);
+    Channel *ch = g_graph.find_any(src, dst);
     if (ch == nullptr) {
         ch = &g_graph.connect(src, dst, net::local_node());
     }
 
     // If the remote end is on another node, send over the network
-    if (ch->node != net::local_node()) {
+    if (ch->node_id != net::local_node()) {
         std::span<const std::byte> bytes{reinterpret_cast<const std::byte *>(&msg),
                                          sizeof(message)};
-        net::send(ch->node, bytes);
+        net::send(ch->node_id, bytes);
         return OK;
     }
 
@@ -207,7 +223,7 @@ int lattice_recv(int pid, message *msg) {
     // Then scan all edges for a queued message
     for (auto &[src, vec] : g_graph.edges) {
         auto vit = std::find_if(vec.begin(), vec.end(), [pid](const Channel &c) {
-            return c.dst == pid && !c.queue.empty();
+            return c.dst == pid && c.node_id == net::local_node() && !c.queue.empty();
         });
         if (vit != vec.end()) {
             *msg = vit->queue.front();

--- a/kernel/lattice_ipc.hpp
+++ b/kernel/lattice_ipc.hpp
@@ -20,7 +20,8 @@ using ::message;
 struct Channel {
     int src; //!< Source process id
     int dst; //!< Destination process id
-    int node{0};
+    /** Identifier of the remote node or 0 for local. */
+    int node_id{0};
     std::vector<message> queue;          //!< Pending messages encrypted with @c secret
     std::array<std::uint8_t, 32> secret; //!< Shared secret derived by PQ crypto
 };
@@ -31,12 +32,14 @@ struct Channel {
 class Graph {
   public:
     /**
-     * @brief Add an edge between @p s and @p d on @p node creating a channel if
-     *        absent.
+     * @brief Add an edge between @p s and @p d on @p node_id creating a channel
+     *        if absent.
      */
-    Channel &connect(int s, int d, int node = 0);
-    /** Find an existing channel or return nullptr. */
-    Channel *find(int s, int d) noexcept;
+    Channel &connect(int s, int d, int node_id = 0);
+    /** Find an existing channel on @p node_id or return nullptr. */
+    Channel *find(int s, int d, int node_id = 0) noexcept;
+    /** Find a channel ignoring node identifier. */
+    Channel *find_any(int s, int d) noexcept;
     /** Mark @p pid as waiting for a message. */
     void set_listening(int pid, bool flag) noexcept { listening[pid] = flag; }
     /** Check if @p pid is currently waiting for a message. */
@@ -57,9 +60,10 @@ extern Graph g_graph; //!< Global DAG instance
  *
  * @param src Source process identifier.
  * @param dst Destination process identifier.
+ * @param node_id Identifier of the remote node, 0 meaning local.
  * @return Always returns ::OK for now.
  */
-int lattice_connect(int src, int dst, int node = 0);
+int lattice_connect(int src, int dst, int node_id = 0);
 
 /**
  * @brief Mark a process as waiting for an incoming message.
@@ -76,8 +80,9 @@ void lattice_listen(int pid);
  *
  * If the destination is listening the message is delivered and the
  * scheduler yields directly to the receiver via ::sched::Scheduler::yield_to.
- * Otherwise the message is XOR encrypted with the channel secret and
- * queued on the channel.
+ * When @p dst resides on another node the payload is forwarded to the
+ * network layer. Otherwise the message is XOR encrypted with the channel
+ * secret and queued on the channel.
  *
  * @see sched::Scheduler::yield_to
  *
@@ -93,7 +98,8 @@ int lattice_send(int src, int dst, const message &msg);
  *
  * Queued messages are decrypted using the channel secret before being
  * delivered. If no message is pending the process is marked as
- * listening and ::E_NO_MESSAGE is returned.
+ * listening and ::E_NO_MESSAGE is returned. Remote messages are retrieved
+ * from the inbox populated by the network layer.
  *
  * @param pid Process identifier.
  * @param msg Buffer to store the received message.

--- a/kernel/proc.hpp
+++ b/kernel/proc.hpp
@@ -7,20 +7,23 @@
  * It contains the process' registers, memory map, accounting, and message
  * send/receive information.
  */
-#include "../include/defs.hpp" // Changed to .hpp
-#include "../h/type.hpp"      // For message, mem_map, real_time, xinim::pid_t, xinim::time_t
-#include "./type.hpp"         // For pc_psw, xinim::virt_addr_t, xinim::phys_addr_t (via core_types.hpp)
-// Assuming the above includes make xinim::core_types.hpp available.
-      // For pc_psw
+#include "../h/const.hpp"      // Process table sizing constants
+#include "../h/type.hpp"       // Message, mem_map, real_time, xinim types
+#include "../include/defs.hpp" // Project-wide integer definitions
+#include "./type.hpp"          // pc_psw definition
+#include "const.hpp"           // Scheduling constants and printf macro
+#ifdef printf
+#undef printf
+#endif
 
 EXTERN struct proc {
-    std::uint64_t p_reg[NR_REGS];   /* process' registers */
-    xinim::virt_addr_t p_sp;        /* stack pointer - Formerly u64_t */
-    struct pc_psw p_pcpsw;          /* pc and psw as pushed by interrupt */
-    int p_flags;                    /* P_SLOT_FREE, SENDING, RECEIVING, etc. */
-    struct mem_map p_map[NR_SEGS];  /* memory map */
-    xinim::virt_addr_t p_splimit;   /* lowest legal stack value - Formerly u64_t */
-    xinim::pid_t p_pid;             /* process id passed in from MM - Formerly int */
+    std::uint64_t p_reg[NR_REGS];  /* process' registers */
+    xinim::virt_addr_t p_sp;       /* stack pointer - Formerly u64_t */
+    struct pc_psw p_pcpsw;         /* pc and psw as pushed by interrupt */
+    int p_flags;                   /* P_SLOT_FREE, SENDING, RECEIVING, etc. */
+    struct mem_map p_map[NR_SEGS]; /* memory map */
+    xinim::virt_addr_t p_splimit;  /* lowest legal stack value - Formerly u64_t */
+    xinim::pid_t p_pid;            /* process id passed in from MM - Formerly int */
 
     real_time user_time;   /* user time in ticks (real_time -> xinim::time_t) */
     real_time sys_time;    /* sys time in ticks (real_time -> xinim::time_t) */
@@ -47,7 +50,7 @@ inline constexpr unsigned int SENDING = 004;     /* set when process blocked try
 inline constexpr unsigned int RECEIVING = 010;   /* set when process blocked trying to recv */
 
 #define proc_addr(n) &proc[NR_TASKS + n] // Macro for pointer arithmetic, can be kept
-inline constexpr struct proc* NIL_PROC = nullptr;
+inline constexpr struct proc *NIL_PROC = nullptr;
 
 EXTERN struct proc *proc_ptr;                        /* &proc[cur_proc] */
 EXTERN struct proc *bill_ptr;                        /* ptr to process to bill for clock ticks */

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -183,14 +183,17 @@ add_test(NAME minix_test_semantic_region COMMAND minix_test_semantic_region)
 add_executable(minix_test_lattice
   test_lattice.cpp
   ${CMAKE_SOURCE_DIR}/kernel/lattice_ipc.cpp
+  ${CMAKE_SOURCE_DIR}/kernel/net_driver.cpp
   ${CMAKE_SOURCE_DIR}/kernel/pqcrypto.cpp
   ${CMAKE_SOURCE_DIR}/kernel/table.cpp
+  task_stubs.cpp
 )
 target_include_directories(minix_test_lattice PUBLIC
   ${CMAKE_SOURCE_DIR}/kernel
   ${CMAKE_SOURCE_DIR}/include
   ${CMAKE_SOURCE_DIR}/h
 )
+target_link_libraries(minix_test_lattice PRIVATE pqcrypto)
 add_test(NAME minix_test_lattice COMMAND minix_test_lattice)
 
 # -----------------------------------------------------------------------------
@@ -199,8 +202,10 @@ add_test(NAME minix_test_lattice COMMAND minix_test_lattice)
 add_executable(minix_test_lattice_ipc
   test_lattice_ipc.cpp
   ${CMAKE_SOURCE_DIR}/kernel/lattice_ipc.cpp
+  ${CMAKE_SOURCE_DIR}/kernel/net_driver.cpp
   ${CMAKE_SOURCE_DIR}/kernel/pqcrypto.cpp
   ${CMAKE_SOURCE_DIR}/kernel/table.cpp
+  task_stubs.cpp
 )
 target_include_directories(minix_test_lattice_ipc PUBLIC
   ${CMAKE_SOURCE_DIR}/kernel
@@ -208,6 +213,7 @@ target_include_directories(minix_test_lattice_ipc PUBLIC
   ${CMAKE_SOURCE_DIR}/h
 )
 target_compile_definitions(minix_test_lattice_ipc PRIVATE EXTERN=extern)
+target_link_libraries(minix_test_lattice_ipc PRIVATE pqcrypto)
 add_test(NAME minix_test_lattice_ipc COMMAND minix_test_lattice_ipc)
 
 # -----------------------------------------------------------------------------

--- a/tests/task_stubs.cpp
+++ b/tests/task_stubs.cpp
@@ -1,0 +1,8 @@
+#include "../kernel/proc.hpp"
+// Simple task stubs used only for unit testing
+void printer_task() noexcept {}
+void tty_task() noexcept {}
+void winchester_task() noexcept {}
+void floppy_task() noexcept {}
+void clock_task() noexcept {}
+void sys_task() noexcept {}

--- a/tests/test_lattice.cpp
+++ b/tests/test_lattice.cpp
@@ -6,6 +6,7 @@
 #include "../h/error.hpp"
 #include "../h/type.hpp"
 #include "../kernel/lattice_ipc.hpp"
+#include "../kernel/net_driver.hpp"
 #include "../kernel/pqcrypto.hpp"
 #include <cassert>
 
@@ -21,11 +22,11 @@ int main() {
     msg.m_type = 42;
 
     assert(lattice_connect(1, 2) == OK);
-    assert(g_graph.find(1, 2) != nullptr);
+    assert(g_graph.find(1, 2, net::local_node()) != nullptr);
 
     // Destination not listening -> message enqueued
     assert(lattice_send(1, 2, msg) == OK);
-    auto *ch = g_graph.find(1, 2);
+    auto *ch = g_graph.find(1, 2, net::local_node());
     assert(ch && ch->queue.size() == 1);
 
     message out{};

--- a/tests/test_lattice_ipc.cpp
+++ b/tests/test_lattice_ipc.cpp
@@ -8,6 +8,7 @@
 #include "../h/type.hpp"
 #include "../kernel/const.hpp"
 #include "../kernel/lattice_ipc.hpp"
+#include "../kernel/net_driver.hpp"
 #include <cassert>
 
 /**
@@ -30,7 +31,7 @@ int main() {
 
     // Establish the channel between the processes.
     assert(lattice_connect(SRC_PID, DST_PID) == OK);
-    Channel *ch = g_graph.find(SRC_PID, DST_PID);
+    Channel *ch = g_graph.find(SRC_PID, DST_PID, net::local_node());
     assert(ch != nullptr);
 
     message msg{};


### PR DESCRIPTION
## Summary
- include libsodium-powered pqcrypto library in lattice IPC tests
- add bridging compute_shared_secret implementation
- stub kernel task functions for unit testing
- enable building lattice IPC test with network driver

## Testing
- `cmake --build build --target minix_test_lattice_ipc`
- `ctest -R minix_test_lattice_ipc --output-on-failure`

------
https://chatgpt.com/codex/tasks/task_e_684f3de4c38883318441611be17b87ba

## Summary by Sourcery

Introduce a span-based compute_shared_secret bridge in the kernel, refactor lattice IPC to use a node_id field with network forwarding support, and enable unit testing by adding kernel task stubs and updating test build configuration.

Enhancements:
- Add span-based compute_shared_secret wrapper in pqcrypto for interoperable key exchange
- Refactor Channel and Graph APIs to use node_id instead of node and add find_any for node-agnostic lookups
- Adapt lattice_connect, lattice_send, and lattice_recv to route messages over the network driver for remote node_ids
- Adjust proc.hpp includes and undefine printf to align header dependencies for testing

Build:
- Include net_driver.cpp and task_stubs.cpp in lattice IPC test targets and link them against the pqcrypto library

Tests:
- Add task_stubs.cpp to provide dummy kernel tasks for unit tests
- Update lattice and lattice_ipc tests to reference node_id and include net_driver.hpp