### PR TITLE
Integrate remote node IDs in IPC graph

### DIFF
--- a/kernel/proc.hpp
+++ b/kernel/proc.hpp
@@ -7,20 +7,23 @@
  * It contains the process' registers, memory map, accounting, and message
  * send/receive information.
  */
-#include "../include/defs.hpp" // Changed to .hpp
-#include "../h/type.hpp"      // For message, mem_map, real_time, xinim::pid_t, xinim::time_t
-#include "./type.hpp"         // For pc_psw, xinim::virt_addr_t, xinim::phys_addr_t (via core_types.hpp)
-// Assuming the above includes make xinim::core_types.hpp available.
-      // For pc_psw
+#include "../h/const.hpp"      // Process table sizing constants
+#include "../h/type.hpp"       // Message, mem_map, real_time, xinim types
+#include "../include/defs.hpp" // Project-wide integer definitions
+#include "./type.hpp"          // pc_psw definition
+#include "const.hpp"           // Scheduling constants and printf macro
+#ifdef printf
+#undef printf
+#endif
 
 EXTERN struct proc {
-    std::uint64_t p_reg[NR_REGS];   /* process' registers */
-    xinim::virt_addr_t p_sp;        /* stack pointer - Formerly u64_t */
-    struct pc_psw p_pcpsw;          /* pc and psw as pushed by interrupt */
-    int p_flags;                    /* P_SLOT_FREE, SENDING, RECEIVING, etc. */
-    struct mem_map p_map[NR_SEGS];  /* memory map */
-    xinim::virt_addr_t p_splimit;   /* lowest legal stack value - Formerly u64_t */
-    xinim::pid_t p_pid;             /* process id passed in from MM - Formerly int */
+    std::uint64_t p_reg[NR_REGS];  /* process' registers */
+    xinim::virt_addr_t p_sp;       /* stack pointer - Formerly u64_t */
+    struct pc_psw p_pcpsw;         /* pc and psw as pushed by interrupt */
+    int p_flags;                   /* P_SLOT_FREE, SENDING, RECEIVING, etc. */
+    struct mem_map p_map[NR_SEGS]; /* memory map */
+    xinim::virt_addr_t p_splimit;  /* lowest legal stack value - Formerly u64_t */
+    xinim::pid_t p_pid;            /* process id passed in from MM - Formerly int */
 
     real_time user_time;   /* user time in ticks (real_time -> xinim::time_t) */
     real_time sys_time;    /* sys time in ticks (real_time -> xinim::time_t) */
@@ -47,7 +50,7 @@ inline constexpr unsigned int SENDING = 004;     /* set when process blocked try
 inline constexpr unsigned int RECEIVING = 010;   /* set when process blocked trying to recv */
 
 #define proc_addr(n) &proc[NR_TASKS + n] // Macro for pointer arithmetic, can be kept
-inline constexpr struct proc* NIL_PROC = nullptr;
+inline constexpr struct proc *NIL_PROC = nullptr;
 
 EXTERN struct proc *proc_ptr;                        /* &proc[cur_proc] */
 EXTERN struct proc *bill_ptr;                        /* ptr to process to bill for clock ticks */

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -183,14 +183,17 @@ add_test(NAME minix_test_semantic_region COMMAND minix_test_semantic_region)
 add_executable(minix_test_lattice
   test_lattice.cpp
   ${CMAKE_SOURCE_DIR}/kernel/lattice_ipc.cpp
+  ${CMAKE_SOURCE_DIR}/kernel/net_driver.cpp
   ${CMAKE_SOURCE_DIR}/kernel/pqcrypto.cpp
   ${CMAKE_SOURCE_DIR}/kernel/table.cpp
+  task_stubs.cpp
 )
 target_include_directories(minix_test_lattice PUBLIC
   ${CMAKE_SOURCE_DIR}/kernel
   ${CMAKE_SOURCE_DIR}/include
   ${CMAKE_SOURCE_DIR}/h
 )
+target_link_libraries(minix_test_lattice PRIVATE pqcrypto)
 add_test(NAME minix_test_lattice COMMAND minix_test_lattice)
 
 # -----------------------------------------------------------------------------
@@ -199,8 +202,10 @@ add_test(NAME minix_test_lattice COMMAND minix_test_lattice)
 add_executable(minix_test_lattice_ipc
   test_lattice_ipc.cpp
   ${CMAKE_SOURCE_DIR}/kernel/lattice_ipc.cpp
+  ${CMAKE_SOURCE_DIR}/kernel/net_driver.cpp
   ${CMAKE_SOURCE_DIR}/kernel/pqcrypto.cpp
   ${CMAKE_SOURCE_DIR}/kernel/table.cpp
+  task_stubs.cpp
 )
 target_include_directories(minix_test_lattice_ipc PUBLIC
   ${CMAKE_SOURCE_DIR}/kernel
@@ -208,6 +213,7 @@ target_include_directories(minix_test_lattice_ipc PUBLIC
   ${CMAKE_SOURCE_DIR}/h
 )
 target_compile_definitions(minix_test_lattice_ipc PRIVATE EXTERN=extern)
+target_link_libraries(minix_test_lattice_ipc PRIVATE pqcrypto)
 add_test(NAME minix_test_lattice_ipc COMMAND minix_test_lattice_ipc)
 
 # -----------------------------------------------------------------------------

--- a/tests/task_stubs.cpp
+++ b/tests/task_stubs.cpp
@@ -1,0 +1,8 @@
+#include "../kernel/proc.hpp"
+// Simple task stubs used only for unit testing
+void printer_task() noexcept {}
+void tty_task() noexcept {}
+void winchester_task() noexcept {}
+void floppy_task() noexcept {}
+void clock_task() noexcept {}
+void sys_task() noexcept {}

--- a/tests/test_lattice.cpp
+++ b/tests/test_lattice.cpp
@@ -6,6 +6,7 @@
 #include "../h/error.hpp"
 #include "../h/type.hpp"
 #include "../kernel/lattice_ipc.hpp"
+#include "../kernel/net_driver.hpp"
 #include "../kernel/pqcrypto.hpp"
 #include <cassert>
 
@@ -21,11 +22,11 @@ int main() {
     msg.m_type = 42;
 
     assert(lattice_connect(1, 2) == OK);
-    assert(g_graph.find(1, 2) != nullptr);
+    assert(g_graph.find(1, 2, net::local_node()) != nullptr);
 
     // Destination not listening -> message enqueued
     assert(lattice_send(1, 2, msg) == OK);
-    auto *ch = g_graph.find(1, 2);
+    auto *ch = g_graph.find(1, 2, net::local_node());
     assert(ch && ch->queue.size() == 1);
 
     message out{};

--- a/tests/test_lattice_ipc.cpp
+++ b/tests/test_lattice_ipc.cpp
@@ -8,6 +8,7 @@
 #include "../h/type.hpp"
 #include "../kernel/const.hpp"
 #include "../kernel/lattice_ipc.hpp"
+#include "../kernel/net_driver.hpp"
 #include <cassert>
 
 /**
@@ -30,7 +31,7 @@ int main() {
 
     // Establish the channel between the processes.
     assert(lattice_connect(SRC_PID, DST_PID) == OK);
-    Channel *ch = g_graph.find(SRC_PID, DST_PID);
+    Channel *ch = g_graph.find(SRC_PID, DST_PID, net::local_node());
     assert(ch != nullptr);
 
     message msg{};


### PR DESCRIPTION
## Summary
- refactor `Graph` to store channels keyed by `(src,dst,node_id)`
- adjust lookup helpers and message queue scanning to use new key
- keep remote send stub for future network driver integration
- document fields and methods via Doxygen

## Testing
- `cmake --build build --target minix_test_lattice_ipc`
- `cd build && ctest -R minix_test_lattice_ipc --output-on-failure`


------
https://chatgpt.com/codex/tasks/task_e_684f3de4c38883318441611be17b87ba

## Summary by Sourcery

Integrate remote node identifiers into the IPC graph by refactoring channel storage and lookup to use a (src, dst, node_id) key, updating IPC APIs to handle cross-node message forwarding via the network driver, and adjusting the crypto API and tests accordingly.

Enhancements:
- Refactor Graph to store channels in a map keyed by (src, dst, node_id) instead of per-source vectors
- Add node_id parameter to Graph.connect, Graph.find, lattice_connect, lattice_send/recv and introduce find_any for node-agnostic lookups
- Rename Channel.node to node_id and route messages on remote node_id through the net_driver in lattice_send/lattice_recv
- Introduce a span-based compute_shared_secret wrapper in pqcrypto and forward-declare the span-based API

Build:
- Update test CMakeLists to include net_driver.cpp and task_stubs.cpp and link the pqcrypto library

Documentation:
- Add Doxygen comments for the new node_id field and updated IPC methods

Tests:
- Adjust unit tests to use the new find signatures with node_id and include net_driver.hpp