### PR TITLE
Implement distributed IPC handling

### DIFF
--- a/docs/sphinx/lattice_ipc.rst
+++ b/docs/sphinx/lattice_ipc.rst
@@ -23,6 +23,20 @@ transfer and update scheduling state.
 .. doxygenfunction:: fastpath::execute_fastpath
    :project: XINIM
 
+Distributed Operation
+---------------------
+
+When nodes are connected over a network the lattice layer serializes messages
+into a small packet structure.  The packet begins with the sending and
+receiving process identifiers followed by the raw message bytes.  Packets are
+transmitted through :cpp:func:`net::send` and recovered with
+:cpp:func:`net::recv`.
+
+The helper :cpp:func:`lattice::poll_network` converts incoming packets back into
+messages.  Each message is encrypted with the channel's shared secret before
+being queued.  Applications call this function periodically to integrate remote
+messages into the standard queueing mechanism.
+
 Graph API
 ---------
 

--- a/kernel/lattice_ipc.cpp
+++ b/kernel/lattice_ipc.cpp
@@ -15,6 +15,7 @@
 
 #include <algorithm>
 #include <cstddef>
+#include <cstring>
 #include <deque>
 #include <memory>
 #include <span>
@@ -201,8 +202,12 @@ int lattice_send(xinim::pid_t src, xinim::pid_t dst, const message &msg) {
 
     // Remote‐node delivery over network
     if (ch->node_id != net::local_node()) {
-        std::span<const std::byte> bytes{reinterpret_cast<const std::byte *>(&msg),
-                                         sizeof(message)};
+        std::vector<std::byte> packet(sizeof(xinim::pid_t) * 2 + sizeof(message));
+        auto *ids = reinterpret_cast<xinim::pid_t *>(packet.data());
+        ids[0] = src;
+        ids[1] = dst;
+        std::memcpy(packet.data() + sizeof(xinim::pid_t) * 2, &msg, sizeof(message));
+        std::span<const std::byte> bytes(packet.data(), packet.size());
         net::send(ch->node_id, bytes);
         return OK;
     }
@@ -258,6 +263,32 @@ int lattice_recv(xinim::pid_t pid, message *out) {
     // 3) No message: register as listener
     lattice_listen(pid);
     return static_cast<int>(ErrorCode::E_NO_MESSAGE);
+}
+
+void poll_network() {
+    net::Packet pkt{};
+    while (net::recv(pkt)) {
+        if (pkt.payload.size() != sizeof(xinim::pid_t) * 2 + sizeof(message)) {
+            continue;
+        }
+        auto *ids = reinterpret_cast<const xinim::pid_t *>(pkt.payload.data());
+        xinim::pid_t src = ids[0];
+        xinim::pid_t dst = ids[1];
+        message msg{};
+        std::memcpy(reinterpret_cast<void *>(&msg), pkt.payload.data() + sizeof(xinim::pid_t) * 2,
+                    sizeof(message));
+
+        Channel *ch = g_graph.find(src, dst, pkt.src_node);
+        if (!ch) {
+            ch = &g_graph.connect(src, dst, pkt.src_node);
+        }
+
+        auto buf = std::span<std::byte>(reinterpret_cast<std::byte *>(&msg), sizeof(message));
+        xor_cipher(
+            buf, std::span<const std::byte>(reinterpret_cast<const std::byte *>(ch->secret.data()),
+                                            ch->secret.size()));
+        ch->queue.push_back(std::move(msg));
+    }
 }
 
 } // namespace lattice

--- a/kernel/lattice_ipc.hpp
+++ b/kernel/lattice_ipc.hpp
@@ -120,4 +120,12 @@ int lattice_send(xinim::pid_t src, xinim::pid_t dst, const message &msg);
  */
 int lattice_recv(xinim::pid_t pid, message *msg);
 
+/**
+ * @brief Poll the network driver for incoming packets.
+ *
+ * Received packets are transformed back into messages and encrypted with the
+ * corresponding channel secret before being queued on that channel.
+ */
+void poll_network();
+
 } // namespace lattice

--- a/kernel/net_driver.cpp
+++ b/kernel/net_driver.cpp
@@ -1,5 +1,9 @@
 #include "net_driver.hpp"
 
+#include <deque>
+#include <unordered_map>
+#include <vector>
+
 /**
  * @file net_driver.cpp
  * @brief Stub network driver for lattice IPC.
@@ -7,10 +11,26 @@
 
 namespace net {
 
+namespace {
+std::unordered_map<node_t, std::deque<Packet>> g_queues; ///< Per-node packet queues
+}
+
 int local_node() noexcept { return 0; }
 
-void send(int /*node*/, std::span<const std::byte> /*data*/) {
-    // Placeholder: real driver would transmit bytes
+void send(int node, std::span<const std::byte> data) {
+    std::vector<std::byte> copy(data.begin(), data.end());
+    Packet pkt{local_node(), std::move(copy)};
+    g_queues[node].push_back(std::move(pkt));
+}
+
+bool recv(Packet &out) {
+    auto &q = g_queues[local_node()];
+    if (q.empty()) {
+        return false;
+    }
+    out = std::move(q.front());
+    q.pop_front();
+    return true;
 }
 
 } // namespace net

--- a/kernel/net_driver.hpp
+++ b/kernel/net_driver.hpp
@@ -7,6 +7,7 @@
 #include <cstddef>
 #include <cstdint>
 #include <span>
+#include <vector>
 
 namespace net {
 
@@ -29,5 +30,21 @@ using node_t = int;
  * @param data Bytes to transmit.
  */
 void send(int node, std::span<const std::byte> data);
+
+/**
+ * @brief In-memory representation of a network packet.
+ */
+struct Packet {
+    node_t src_node;                ///< Identifier of the originating node
+    std::vector<std::byte> payload; ///< Raw bytes transmitted over the network
+};
+
+/**
+ * @brief Retrieve a pending packet for the local node.
+ *
+ * @param out Packet object to populate with received data.
+ * @return True when a packet was dequeued, false otherwise.
+ */
+[[nodiscard]] bool recv(Packet &out);
 
 } // namespace net


### PR DESCRIPTION
## Summary
- implement a simple in-memory network queue with send/recv
- queue network packets in lattice IPC
- add poll_network helper for distributed operation
- document distributed IPC protocol

## Testing
- `cmake -S . -B build`
- `cmake --build build --target minix_test_lattice minix_test_lattice_ipc`
- `ctest --test-dir build -R minix_test_lattice -VV` *(fails: minix_test_lattice)*
- `ctest --test-dir build -R minix_test_lattice_ipc -VV`

------
https://chatgpt.com/codex/tasks/task_e_684f99254524833187cd41b929f483a5