### PR TITLE
Implement restart contracts for services

### DIFF
--- a/docs/sphinx/index.rst
+++ b/docs/sphinx/index.rst
@@ -18,6 +18,7 @@ The documentation is divided into several sections:
    pq_crypto
    scheduler
    service
+   service_manager
    precommit
    libsodium_tests
    api

--- a/docs/sphinx/service_manager.rst
+++ b/docs/sphinx/service_manager.rst
@@ -1,0 +1,31 @@
+Service Manager Contracts
+=========================
+
+This document expands on how services are registered with the kernel's service
+manager, how dependencies are resolved and how crashed services are
+automatically restarted.
+
+Service Registration
+--------------------
+
+Services register with :cpp:func:`svc::ServiceManager::register_service` and may
+specify a list of dependencies. A dependency implies the service will be
+restarted after its parents to ensure correct ordering.
+
+Dependencies
+------------
+
+Dependencies form a directed acyclic graph. The manager verifies new edges do not
+introduce cycles using an internal search routine.
+
+Automatic Restarts
+------------------
+
+Whenever a service terminates unexpectedly the scheduler notifies the service
+manager. Contracts track how many times each service has been restarted via the
+``RestartContract`` structure. Dependents of the crashed service are restarted in
+order to preserve required ordering.
+
+.. doxygenclass:: svc::ServiceManager
+   :project: XINIM
+   :members:

--- a/kernel/CMakeLists.txt
+++ b/kernel/CMakeLists.txt
@@ -8,7 +8,7 @@ endif()
 set(KERNEL_SRC
     clock.cpp dmp.cpp floppy.cpp main.cpp memory.cpp printer.cpp proc.cpp system.cpp
     table.cpp tty.cpp idt64.cpp mpx64.cpp klib64.cpp klib88.cpp mpx88.cpp paging.cpp
-    wormhole.cpp lattice_ipc.cpp net_driver.cpp wait_graph.cpp pqcrypto.cpp syscall.cpp ${WINI_SRC})
+    wormhole.cpp lattice_ipc.cpp net_driver.cpp wait_graph.cpp pqcrypto.cpp syscall.cpp service.cpp ${WINI_SRC})
 
 
 #Note : klib88.cpp and mpx88.cpp were added as they appear to be kernel related sources.

--- a/kernel/service.cpp
+++ b/kernel/service.cpp
@@ -1,8 +1,17 @@
 #include "service.hpp"
 #include "schedule.hpp"
 
+#include <algorithm>
+#include <ranges>
+
 namespace svc {
 
+/**
+ * @brief Determine whether a dependency path exists between two services.
+ *
+ * The search performs a depth-first traversal while avoiding cycles using the
+ * @p visited set.
+ */
 bool ServiceManager::has_path(xinim::pid_t start, xinim::pid_t target,
                               std::unordered_set<xinim::pid_t> &visited) const {
     if (start == target) {
@@ -23,35 +32,55 @@ bool ServiceManager::has_path(xinim::pid_t start, xinim::pid_t target,
     return false;
 }
 
+/**
+ * @brief Register a new service with dependency information.
+ *
+ * Contracts are created lazily for each service and track restart counts.
+ */
 void ServiceManager::register_service(xinim::pid_t pid, const std::vector<xinim::pid_t> &deps) {
     auto &info = services_[pid];
-    for (xinim::pid_t dep : deps) {
+    if (info.contract.id == 0) {
+        info.contract.id = next_contract_id_++;
+    }
+
+    for (auto dep : deps) {
         std::unordered_set<xinim::pid_t> visited;
         if (!has_path(dep, pid, visited)) {
             info.deps.push_back(dep);
         }
     }
+
     info.running = true;
     sched::scheduler.enqueue(pid);
 }
 
+/**
+ * @brief Restart @p pid and recursively restart dependents.
+ */
 void ServiceManager::restart_tree(xinim::pid_t pid, std::unordered_set<xinim::pid_t> &visited) {
     if (!visited.insert(pid).second) {
         return;
     }
+
     auto it = services_.find(pid);
     if (it == services_.end()) {
         return;
     }
+
     it->second.running = true;
+    ++it->second.contract.count;
     sched::scheduler.enqueue(pid);
+
     for (auto &[other_pid, info] : services_) {
-        if (std::find(info.deps.begin(), info.deps.end(), pid) != info.deps.end()) {
+        if (std::ranges::contains(info.deps, pid)) {
             restart_tree(other_pid, visited);
         }
     }
 }
 
+/**
+ * @brief React to a service crash by marking it inactive and restarting.
+ */
 void ServiceManager::handle_crash(xinim::pid_t pid) {
     auto it = services_.find(pid);
     if (it == services_.end()) {
@@ -63,5 +92,7 @@ void ServiceManager::handle_crash(xinim::pid_t pid) {
 }
 
 ServiceManager service_manager{};
+
+std::atomic_uint64_t ServiceManager::next_contract_id_{1};
 
 } // namespace svc

--- a/kernel/service.hpp
+++ b/kernel/service.hpp
@@ -5,6 +5,8 @@
  */
 
 #include "../include/xinim/core_types.hpp"
+#include <atomic>
+#include <ranges>
 #include <unordered_map>
 #include <unordered_set>
 #include <vector>
@@ -39,9 +41,21 @@ class ServiceManager {
     void handle_crash(xinim::pid_t pid);
 
   private:
+    /**
+     * @brief Tracks restart statistics for a service.
+     */
+    struct RestartContract {
+        std::uint64_t id{0};    ///< Unique contract identifier
+        std::uint32_t count{0}; ///< Number of recorded restarts
+    };
+
+    /**
+     * @brief Metadata associated with each registered service.
+     */
     struct ServiceInfo {
         bool running{false};            ///< Whether the service is active
         std::vector<xinim::pid_t> deps; ///< Services this one depends on
+        RestartContract contract{};     ///< Restart statistics for the service
     };
 
     bool has_path(xinim::pid_t start, xinim::pid_t target,
@@ -49,6 +63,7 @@ class ServiceManager {
     void restart_tree(xinim::pid_t pid, std::unordered_set<xinim::pid_t> &visited);
 
     std::unordered_map<xinim::pid_t, ServiceInfo> services_{}; ///< Registered services
+    static std::atomic_uint64_t next_contract_id_;             ///< Counter for contract IDs
 };
 
 /// Global instance used by the kernel.

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -107,6 +107,7 @@ add_executable(minix_test_fastpath
   test_fastpath.cpp
   ${CMAKE_SOURCE_DIR}/kernel/wormhole.cpp
   ${CMAKE_SOURCE_DIR}/kernel/schedule.cpp
+  ${CMAKE_SOURCE_DIR}/kernel/service.cpp
   ${CMAKE_SOURCE_DIR}/kernel/wait_graph.cpp
 )
 target_include_directories(minix_test_fastpath PUBLIC
@@ -120,6 +121,7 @@ add_test(NAME minix_test_fastpath COMMAND minix_test_fastpath)
 add_executable(minix_test_scheduler
   test_scheduler.cpp
   ${CMAKE_SOURCE_DIR}/kernel/schedule.cpp
+  ${CMAKE_SOURCE_DIR}/kernel/service.cpp
   ${CMAKE_SOURCE_DIR}/kernel/wait_graph.cpp
 )
 target_include_directories(minix_test_scheduler PUBLIC
@@ -134,6 +136,7 @@ add_test(NAME minix_test_scheduler COMMAND minix_test_scheduler)
 add_executable(minix_test_scheduler_deadlock
   test_scheduler_deadlock.cpp
   ${CMAKE_SOURCE_DIR}/kernel/schedule.cpp
+  ${CMAKE_SOURCE_DIR}/kernel/service.cpp
   ${CMAKE_SOURCE_DIR}/kernel/wait_graph.cpp
 )
 target_include_directories(minix_test_scheduler_deadlock PUBLIC
@@ -148,6 +151,7 @@ add_test(NAME minix_test_scheduler_deadlock COMMAND minix_test_scheduler_deadloc
 add_executable(minix_test_scheduler_edge
   test_scheduler_edge.cpp
   ${CMAKE_SOURCE_DIR}/kernel/schedule.cpp
+  ${CMAKE_SOURCE_DIR}/kernel/service.cpp
   ${CMAKE_SOURCE_DIR}/kernel/wait_graph.cpp
 )
 target_include_directories(minix_test_scheduler_edge PUBLIC
@@ -176,6 +180,7 @@ add_executable(minix_test_fastpath_preconditions
   test_fastpath_preconditions.cpp
   ${CMAKE_SOURCE_DIR}/kernel/wormhole.cpp
   ${CMAKE_SOURCE_DIR}/kernel/schedule.cpp
+  ${CMAKE_SOURCE_DIR}/kernel/service.cpp
   ${CMAKE_SOURCE_DIR}/kernel/wait_graph.cpp
 )
 target_include_directories(minix_test_fastpath_preconditions PUBLIC


### PR DESCRIPTION
## Summary
- track restart contracts for services
- document contract-based restarts in Sphinx
- integrate service manager into test builds

## Testing
- `cmake -B build -DBUILD_SYSTEM=OFF`
- `cmake --build build -- -j$(nproc)`
- `ctest --test-dir build --output-on-failure` *(fails: minix_test_scheduler_deadlock, minix_test_lattice)*

------
https://chatgpt.com/codex/tasks/task_e_684f99464e18833192a0f7324867a452