### PR TITLE
Add per-CPU fastpath queue with fallback

### DIFF
--- a/docs/sphinx/lattice_ipc.rst
+++ b/docs/sphinx/lattice_ipc.rst
@@ -20,6 +20,10 @@ transfer and update scheduling state.
 .. doxygenstruct:: fastpath::FastpathStats
    :project: XINIM
 
+The statistics track how often the per-CPU fastpath queue succeeds as
+well as the number of spill events when the queue is exhausted.  The
+``hit_count`` and ``fallback_count`` fields provide this insight.
+
 .. doxygenfunction:: fastpath::execute_fastpath
    :project: XINIM
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -115,6 +115,20 @@ target_include_directories(minix_test_fastpath PUBLIC
 add_test(NAME minix_test_fastpath COMMAND minix_test_fastpath)
 
 # -----------------------------------------------------------------------------
+# minix_test_fastpath_fallback
+# -----------------------------------------------------------------------------
+add_executable(minix_test_fastpath_fallback
+  test_fastpath_fallback.cpp
+  ${CMAKE_SOURCE_DIR}/kernel/wormhole.cpp
+  ${CMAKE_SOURCE_DIR}/kernel/schedule.cpp
+  ${CMAKE_SOURCE_DIR}/kernel/wait_graph.cpp
+)
+target_include_directories(minix_test_fastpath_fallback PUBLIC
+  ${CMAKE_SOURCE_DIR}/kernel
+)
+add_test(NAME minix_test_fastpath_fallback COMMAND minix_test_fastpath_fallback)
+
+# -----------------------------------------------------------------------------
 # minix_test_scheduler
 # -----------------------------------------------------------------------------
 add_executable(minix_test_scheduler

--- a/tests/test_fastpath.cpp
+++ b/tests/test_fastpath.cpp
@@ -8,6 +8,7 @@ using namespace fastpath;
 int main() {
     using sched::scheduler;
     State s{};
+    reset_fastpath_queues();
     scheduler.enqueue(1);
     scheduler.enqueue(2);
     scheduler.preempt();
@@ -48,8 +49,9 @@ int main() {
     bool ok = execute_fastpath(s, &stats);
     assert(ok);
     assert(stats.success_count == 1);
+    assert(stats.hit_count == 1);
+    assert(stats.fallback_count == 0);
     assert(s.receiver.mrs[0] == 42);
-    assert(buffer[0] == 42);
     assert(s.receiver.status == ThreadStatus::Running);
     assert(s.sender.status == ThreadStatus::Blocked);
     assert(s.receiver.badge == s.cap.badge);

--- a/tests/test_fastpath_fallback.cpp
+++ b/tests/test_fastpath_fallback.cpp
@@ -1,0 +1,63 @@
+#include "../kernel/schedule.hpp"
+#include "../kernel/wormhole.hpp"
+#include <cassert>
+
+using namespace fastpath;
+
+/**
+ * @brief Verify fallback to shared memory when the per-CPU queue is full.
+ */
+int main() {
+    using sched::scheduler;
+    State s{};
+    reset_fastpath_queues();
+    scheduler.enqueue(1);
+    scheduler.enqueue(2);
+    scheduler.preempt();
+    alignas(64) uint64_t buffer[8]{};
+    set_message_region(s, MessageRegion(reinterpret_cast<std::uintptr_t>(buffer), sizeof(buffer)));
+
+    s.sender.tid = 1;
+    s.sender.priority = 5;
+    s.sender.domain = 0;
+    s.sender.core = 0;
+    s.sender.mrs[0] = 99;
+    s.msg_len = 1;
+    s.extra_caps = 0;
+
+    s.receiver.tid = 2;
+    s.receiver.priority = 5;
+    s.receiver.domain = 0;
+    s.receiver.core = 0;
+
+    s.endpoint.eid = 1;
+    s.cap.cptr = 1;
+    s.cap.type = CapType::Endpoint;
+    s.cap.rights.write = true;
+    s.cap.object = 1;
+
+    s.current_tid = scheduler.current();
+    FastpathStats stats;
+
+    for (std::size_t i = 0; i < FASTPATH_QUEUE_SIZE; ++i) {
+        s.sender.status = ThreadStatus::Running;
+        s.receiver.status = ThreadStatus::RecvBlocked;
+        s.endpoint.state = EndpointState::Recv;
+        s.endpoint.queue = {2};
+        bool ok = execute_fastpath(s, &stats);
+        assert(ok);
+        scheduler.enqueue(1);
+        scheduler.enqueue(2);
+        scheduler.preempt();
+    }
+
+    s.sender.status = ThreadStatus::Running;
+    s.receiver.status = ThreadStatus::RecvBlocked;
+    s.endpoint.state = EndpointState::Recv;
+    s.endpoint.queue = {2};
+    bool ok = execute_fastpath(s, &stats);
+    assert(ok);
+    assert(stats.fallback_count == 1);
+    assert(stats.hit_count == FASTPATH_QUEUE_SIZE);
+    return 0; //!< success
+}


### PR DESCRIPTION
## Summary
- keep zero-copy wormhole buffers hot by adding per-CPU queues
- fallback to shared memory when queue is exhausted
- track fastpath hits and fallbacks in `FastpathStats`
- exercise both paths in new unit tests

## Testing
- `cmake -S . -B build`
- `cmake --build build` *(fails: conflicting declarations in stdio headers)*

------
https://chatgpt.com/codex/tasks/task_e_684f99571fd48331ab253490d5a2afe5