### PR TITLE
Add non-blocking IPC flags

### DIFF
--- a/docs/sphinx/scheduler.rst
+++ b/docs/sphinx/scheduler.rst
@@ -20,9 +20,11 @@ Message Hand-off
 ----------------
 
 Calling :cpp:func:`lattice::lattice_send` delivers a message immediately when the
-receiver is already waiting. In that case execution yields directly to the
-receiver via :cpp:func:`sched::Scheduler::yield_to` so the message handler runs
-without delay.
+receiver is already waiting. On such a fast path the scheduler invokes
+:cpp:func:`sched::Scheduler::yield_to` so the receiver handles the message
+without an extra context switch. Both send and
+:cpp:func:`lattice::lattice_recv` accept :cpp:type:`lattice::IpcFlags` with the
+``NONBLOCK`` option to return immediately when no delivery is possible.
 
 .. doxygenfunction:: sched::Scheduler::yield_to
    :project: XINIM

--- a/kernel/lattice_ipc.hpp
+++ b/kernel/lattice_ipc.hpp
@@ -23,6 +23,14 @@ inline constexpr net::node_t ANY_NODE = -1;
 using ::message;
 
 /**
+ * @brief Flags controlling send and receive behavior.
+ */
+enum class IpcFlags : unsigned {
+    NONE = 0,     //!< Blocking semantics
+    NONBLOCK = 1, //!< Return immediately if no message can be sent or received
+};
+
+/**
  * @brief Channel connecting two processes.
  */
 struct Channel {
@@ -101,10 +109,12 @@ void lattice_listen(xinim::pid_t pid);
  *
  * @param src Sending process identifier.
  * @param dst Receiving process identifier.
- * @param msg Message to send.
- * @return ::OK on success.
+ * @param msg   Message to send.
+ * @param flags Behaviour control flags such as ::IpcFlags::NONBLOCK.
+ * @return ::OK on success or ::E_TRY_AGAIN when non-blocking fails.
  */
-int lattice_send(xinim::pid_t src, xinim::pid_t dst, const message &msg);
+int lattice_send(xinim::pid_t src, xinim::pid_t dst, const message &msg,
+                 IpcFlags flags = IpcFlags::NONE);
 
 /**
  * @brief Receive a message for a process.
@@ -115,9 +125,10 @@ int lattice_send(xinim::pid_t src, xinim::pid_t dst, const message &msg);
  * from the inbox populated by the network layer.
  *
  * @param pid Process identifier.
- * @param msg Buffer to store the received message.
+ * @param msg   Buffer to store the received message.
+ * @param flags Behaviour control flags, e.g. ::IpcFlags::NONBLOCK.
  * @return ::OK on success or ::E_NO_MESSAGE when no message is available.
  */
-int lattice_recv(xinim::pid_t pid, message *msg);
+int lattice_recv(xinim::pid_t pid, message *msg, IpcFlags flags = IpcFlags::NONE);
 
 } // namespace lattice

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -13,6 +13,9 @@ function(add_lattice_test target source)
     ${CMAKE_SOURCE_DIR}/kernel/lattice_ipc.cpp
     ${CMAKE_SOURCE_DIR}/kernel/net_driver.cpp
     ${CMAKE_SOURCE_DIR}/kernel/pqcrypto.cpp
+    ${CMAKE_SOURCE_DIR}/kernel/schedule.cpp
+    ${CMAKE_SOURCE_DIR}/kernel/service.cpp
+    ${CMAKE_SOURCE_DIR}/kernel/wait_graph.cpp
     ${CMAKE_SOURCE_DIR}/kernel/table.cpp
     task_stubs.cpp)
   target_include_directories(${target} PUBLIC


### PR DESCRIPTION
## Summary
- allow `lattice_send` and `lattice_recv` to receive a new `IpcFlags` enum
- yield directly to the receiver upon fast-path send via `sched::scheduler.yield_to`
- document non-blocking semantics in the scheduler docs
- update test CMakeLists for scheduler dependencies
- fix PQ crypto test to validate non-zero secret

## Testing
- `cmake --build build --target minix_test_lattice`
- `./build/tests/minix_test_lattice`
- `cmake --build build --target minix_test_lattice_ipc`
- `./build/tests/minix_test_lattice_ipc`


------
https://chatgpt.com/codex/tasks/task_e_684f992c0bb88331aaf0c196ed7bf713