### PR TITLE
Implement UDP networking driver

### DIFF
--- a/docs/sphinx/index.rst
+++ b/docs/sphinx/index.rst
@@ -20,5 +20,6 @@ The documentation is divided into several sections:
    service
    service_manager
    precommit
+   networking
    libsodium_tests
    api

--- a/docs/sphinx/networking.rst
+++ b/docs/sphinx/networking.rst
@@ -1,0 +1,34 @@
+Networking Driver
+=================
+
+The UDP networking layer transports lattice IPC packets between nodes.  A node
+binds to a local UDP port and registers remote peers through
+:cpp:func:`net::add_remote`.  The driver spawns a background thread to poll the
+socket and invokes an optional callback whenever a packet arrives.
+
+API Overview
+------------
+
+.. doxygenstruct:: net::Config
+   :project: XINIM
+
+.. doxygentypedef:: net::RecvCallback
+   :project: XINIM
+
+.. doxygenfunction:: net::init
+   :project: XINIM
+
+.. doxygenfunction:: net::add_remote
+   :project: XINIM
+
+.. doxygenfunction:: net::set_recv_callback
+   :project: XINIM
+
+.. doxygenfunction:: net::send
+   :project: XINIM
+
+.. doxygenfunction:: net::recv
+   :project: XINIM
+
+.. doxygenfunction:: net::shutdown
+   :project: XINIM

--- a/kernel/lattice_ipc.cpp
+++ b/kernel/lattice_ipc.cpp
@@ -47,42 +47,36 @@ namespace lattice {
  *                               Global State
  *============================================================================*/
 
-Graph g_graph;  ///< Singleton IPC graph
+Graph g_graph; ///< Singleton IPC graph
 
 /*==============================================================================
  *                            Graph Implementation
  *============================================================================*/
 
-Channel &Graph::connect(xinim::pid_t src,
-                        xinim::pid_t dst,
-                        net::node_t node_id)
-{
+Channel &Graph::connect(xinim::pid_t src, xinim::pid_t dst, net::node_t node_id) {
     auto key = std::make_tuple(src, dst, node_id);
-    auto it  = edges_.find(key);
+    auto it = edges_.find(key);
     if (it != edges_.end()) {
         return it->second;
     }
 
     Channel ch{};
-    ch.src     = src;
-    ch.dst     = dst;
+    ch.src = src;
+    ch.dst = dst;
     ch.node_id = node_id;
     edges_.emplace(key, std::move(ch));
     return edges_[key];
 }
 
-Channel *Graph::find(xinim::pid_t src,
-                     xinim::pid_t dst,
-                     net::node_t node_id) noexcept
-{
+Channel *Graph::find(xinim::pid_t src, xinim::pid_t dst, net::node_t node_id) noexcept {
     if (node_id != ANY_NODE) {
         auto key = std::make_tuple(src, dst, node_id);
-        auto it  = edges_.find(key);
+        auto it = edges_.find(key);
         if (it != edges_.end()) {
             return &it->second;
         }
     } else {
-        for (auto & [k, ch] : edges_) {
+        for (auto &[k, ch] : edges_) {
             if (std::get<0>(k) == src && std::get<1>(k) == dst) {
                 return &ch;
             }
@@ -96,9 +90,7 @@ bool Graph::is_listening(xinim::pid_t pid) const noexcept {
     return it != listening_.end() && it->second;
 }
 
-void Graph::set_listening(xinim::pid_t pid, bool flag) noexcept {
-    listening_[pid] = flag;
-}
+void Graph::set_listening(xinim::pid_t pid, bool flag) noexcept { listening_[pid] = flag; }
 
 /*==============================================================================
  *                               IPC API
@@ -109,15 +101,12 @@ static void yield_to(xinim::pid_t pid) {
     cur_proc = pid;
 }
 
-int lattice_connect(xinim::pid_t src,
-                    xinim::pid_t dst,
-                    net::node_t node_id)
-{
+int lattice_connect(xinim::pid_t src, xinim::pid_t dst, net::node_t node_id) {
     // Perform stubbed Kyber key exchange
-    auto kp_a         = pqcrypto::generate_keypair();
-    auto kp_b         = pqcrypto::generate_keypair();
+    auto kp_a = pqcrypto::generate_keypair();
+    auto kp_b = pqcrypto::generate_keypair();
     auto secret_bytes = pqcrypto::compute_shared_secret(kp_a, kp_b);
-    Octonion secret   = Octonion::from_bytes(secret_bytes);
+    Octonion secret = Octonion::from_bytes(secret_bytes);
 
     // Create forward and reverse channels
     Channel &fwd = g_graph.connect(src, dst, node_id);
@@ -127,26 +116,21 @@ int lattice_connect(xinim::pid_t src,
     return OK;
 }
 
-void lattice_listen(xinim::pid_t pid) {
-    g_graph.set_listening(pid, true);
-}
+void lattice_listen(xinim::pid_t pid) { g_graph.set_listening(pid, true); }
 
-int lattice_send(xinim::pid_t src,
-                 xinim::pid_t dst,
-                 const message &msg)
-{
+int lattice_send(xinim::pid_t src, xinim::pid_t dst, const message &msg) {
     Channel *ch = g_graph.find(src, dst, ANY_NODE);
     if (!ch) {
         ch = &g_graph.connect(src, dst, net::local_node());
     }
 
-    // Remote delivery: prepend src/dst, XOR-encrypt, send over network
+    // Remote delivery handled by the UDP driver
     if (ch->node_id != net::local_node()) {
         std::vector<std::byte> pkt(sizeof(xinim::pid_t) * 2 + sizeof(msg));
-        auto ids = reinterpret_cast<xinim::pid_t*>(pkt.data());
+        auto *ids = reinterpret_cast<xinim::pid_t *>(pkt.data());
         ids[0] = src;
         ids[1] = dst;
-        std::memcpy(pkt.data() + sizeof(xinim::pid_t)*2, &msg, sizeof(msg));
+        std::memcpy(pkt.data() + sizeof(xinim::pid_t) * 2, &msg, sizeof(msg));
         xor_cipher({pkt.data(), pkt.size()}, ch->secret);
         net::send(ch->node_id, pkt);
         return OK;
@@ -159,7 +143,7 @@ int lattice_send(xinim::pid_t src,
         yield_to(dst);
     } else {
         message copy = msg;
-        xor_cipher({reinterpret_cast<std::byte*>(&copy), sizeof(copy)}, ch->secret);
+        xor_cipher({reinterpret_cast<std::byte *>(&copy), sizeof(copy)}, ch->secret);
         ch->queue.push_back(std::move(copy));
     }
     return OK;
@@ -175,14 +159,11 @@ int lattice_recv(xinim::pid_t pid, message *out) {
     }
 
     // 2) Dequeue from any matching channel
-    for (auto & [key, ch] : g_graph.edges_) {
-        if (std::get<1>(key) == pid
-            && std::get<2>(key) == net::local_node()
-            && !ch.queue.empty())
-        {
+    for (auto &[key, ch] : g_graph.edges_) {
+        if (std::get<1>(key) == pid && std::get<2>(key) == net::local_node() && !ch.queue.empty()) {
             message copy = std::move(ch.queue.front());
             ch.queue.pop_front();
-            xor_cipher({reinterpret_cast<std::byte*>(&copy), sizeof(copy)}, ch->secret);
+            xor_cipher({reinterpret_cast<std::byte *>(&copy), sizeof(copy)}, ch->secret);
             *out = std::move(copy);
             return OK;
         }
@@ -193,23 +174,25 @@ int lattice_recv(xinim::pid_t pid, message *out) {
     return static_cast<int>(ErrorCode::E_NO_MESSAGE);
 }
 
+//------------------------------------------------------------------------------
+/// Drain the UDP driver queue and populate channel inboxes.
 void poll_network() {
     net::Packet pkt;
     while (net::recv(pkt)) {
         auto &payload = pkt.payload;
-        if (payload.size() != sizeof(xinim::pid_t)*2 + sizeof(message)) {
+        if (payload.size() != sizeof(xinim::pid_t) * 2 + sizeof(message)) {
             continue;
         }
-        auto ids = reinterpret_cast<const xinim::pid_t*>(payload.data());
+        auto ids = reinterpret_cast<const xinim::pid_t *>(payload.data());
         xinim::pid_t src = ids[0], dst = ids[1];
         message msg;
-        std::memcpy(&msg, payload.data() + sizeof(xinim::pid_t)*2, sizeof(msg));
+        std::memcpy(&msg, payload.data() + sizeof(xinim::pid_t) * 2, sizeof(msg));
 
         Channel *ch = g_graph.find(src, dst, pkt.src_node);
         if (!ch) {
             ch = &g_graph.connect(src, dst, pkt.src_node);
         }
-        xor_cipher({reinterpret_cast<std::byte*>(&msg), sizeof(msg)}, ch->secret);
+        xor_cipher({reinterpret_cast<std::byte *>(&msg), sizeof(msg)}, ch->secret);
         ch->queue.push_back(std::move(msg));
     }
 }

--- a/kernel/net_driver.cpp
+++ b/kernel/net_driver.cpp
@@ -1,60 +1,128 @@
 /**
  * @file net_driver.cpp
- * @brief Stub network driver for Lattice IPC (loopback testing).
+ * @brief UDP based network driver for Lattice IPC.
  */
 
 #include "net_driver.hpp"
 
+#include <arpa/inet.h>
+#include <sys/socket.h>
+#include <unistd.h>
+
+#include <array>
+#include <cstring>
 #include <deque>
+#include <mutex>
+#include <thread>
 #include <unordered_map>
-#include <vector>
-#include <span>
 
 namespace net {
-
 namespace {
-    /// Per-node packet queues for loopback simulation.
-    static std::unordered_map<node_t, std::deque<Packet>> g_queues;
-}
-
-/// Return the local node identifier (always 0 in this stub).
-node_t local_node() noexcept {
-    return 0;
-}
+Config g_cfg{};                                    //!< active configuration
+int g_socket{-1};                                  //!< UDP socket descriptor
+std::unordered_map<node_t, sockaddr_in> g_remotes; //!< node mapping table
+std::deque<Packet> g_queue;                        //!< received packets
+std::mutex g_mutex;                                //!< protects g_queue
+RecvCallback g_callback;                           //!< user callback
+std::jthread g_thread;                             //!< background receiver
+std::atomic<bool> g_running{false};
 
 /**
- * @brief Enqueue a packet for delivery to @p node.
- *
- * Copies @p data into a Packet with the current local_node() as the source.
+ * @brief Background loop polling @c g_socket for datagrams.
  */
+void recv_loop() {
+    std::array<std::byte, 2048> buf{};
+    while (g_running.load(std::memory_order_relaxed)) {
+        sockaddr_in peer{};
+        socklen_t len = sizeof(peer);
+        const auto n = ::recvfrom(g_socket, buf.data(), buf.size(), 0,
+                                  reinterpret_cast<sockaddr *>(&peer), &len);
+        if (n <= 0) {
+            continue;
+        }
+        Packet pkt{};
+        std::memcpy(&pkt.src_node, buf.data(), sizeof(node_t));
+        pkt.payload.assign(buf.begin() + sizeof(node_t), buf.begin() + n);
+
+        {
+            std::lock_guard<std::mutex> lock{g_mutex};
+            g_queue.push_back(pkt);
+        }
+        if (g_callback) {
+            g_callback(pkt);
+        }
+    }
+}
+} // namespace
+
+void init(const Config &cfg) {
+    g_cfg = cfg;
+    g_socket = ::socket(AF_INET, SOCK_DGRAM, 0);
+    sockaddr_in addr{};
+    addr.sin_family = AF_INET;
+    addr.sin_port = htons(cfg.port);
+    addr.sin_addr.s_addr = htonl(INADDR_LOOPBACK);
+    if (::bind(g_socket, reinterpret_cast<sockaddr *>(&addr), sizeof(addr)) < 0) {
+        throw std::runtime_error{"bind failed"};
+    }
+    g_running.store(true, std::memory_order_relaxed);
+    g_thread = std::jthread{recv_loop};
+}
+
+void add_remote(node_t node, const std::string &host, std::uint16_t port) {
+    sockaddr_in addr{};
+    addr.sin_family = AF_INET;
+    addr.sin_port = htons(port);
+    ::inet_aton(host.c_str(), &addr.sin_addr);
+    g_remotes[node] = addr;
+}
+
+void set_recv_callback(RecvCallback cb) { g_callback = std::move(cb); }
+
+node_t local_node() noexcept { return g_cfg.node_id; }
+
 void send(node_t node, std::span<const std::byte> data) {
-    Packet pkt;
-    pkt.src_node = local_node();
-    pkt.payload.assign(data.begin(), data.end());
-    g_queues[node].push_back(std::move(pkt));
+    auto it = g_remotes.find(node);
+    if (it == g_remotes.end()) {
+        return; // unknown destination
+    }
+    std::vector<std::byte> buf(sizeof(node_t) + data.size());
+    std::memcpy(buf.data(), &g_cfg.node_id, sizeof(node_t));
+    std::memcpy(buf.data() + sizeof(node_t), data.data(), data.size());
+
+    ::sendto(g_socket, buf.data(), buf.size(), 0, reinterpret_cast<const sockaddr *>(&it->second),
+             sizeof(sockaddr_in));
 }
 
-/**
- * @brief Dequeue the next packet destined for local_node().
- *
- * @param out  Receives the next Packet if available.
- * @return     true if a packet was dequeued, false if none pending.
- */
 bool recv(Packet &out) {
-    auto &q = g_queues[local_node()];
-    if (q.empty()) {
+    std::lock_guard<std::mutex> lock{g_mutex};
+    if (g_queue.empty()) {
         return false;
     }
-    out = std::move(q.front());
-    q.pop_front();
+    out = std::move(g_queue.front());
+    g_queue.pop_front();
     return true;
 }
 
-/**
- * @brief Clear all pending packets on all nodes.
- */
 void reset() noexcept {
-    g_queues.clear();
+    std::lock_guard<std::mutex> lock{g_mutex};
+    g_queue.clear();
+}
+
+void shutdown() noexcept {
+    g_running.store(false, std::memory_order_relaxed);
+    if (g_socket != -1) {
+        ::close(g_socket);
+        g_socket = -1;
+    }
+    if (g_thread.joinable()) {
+        g_thread.join();
+    }
+    {
+        std::lock_guard<std::mutex> lock{g_mutex};
+        g_queue.clear();
+    }
+    g_remotes.clear();
 }
 
 } // namespace net

--- a/kernel/net_driver.hpp
+++ b/kernel/net_driver.hpp
@@ -1,12 +1,14 @@
 #pragma once
 /**
  * @file net_driver.hpp
- * @brief Minimal loopback network driver interface for Lattice IPC.
+ * @brief UDP based network driver interface for Lattice IPC.
  */
 
 #include <cstddef>
 #include <cstdint>
+#include <functional>
 #include <span>
+#include <string>
 #include <vector>
 
 namespace net {
@@ -18,9 +20,32 @@ using node_t = int;
  * @brief In‐memory representation of a network packet.
  */
 struct Packet {
-    node_t                  src_node;  ///< Originating node ID
-    std::vector<std::byte>  payload;   ///< Packet payload bytes
+    node_t src_node;                ///< Originating node ID
+    std::vector<std::byte> payload; ///< Packet payload bytes
 };
+
+/** Configuration options for ::init. */
+struct Config {
+    node_t node_id;     ///< Local node identifier
+    std::uint16_t port; ///< UDP port to bind locally
+};
+
+/**
+ * Callback invoked whenever a packet is received.
+ */
+using RecvCallback = std::function<void(const Packet &)>;
+
+/** Initialize the driver with @p cfg opening the UDP socket. */
+void init(const Config &cfg);
+
+/** Register a remote @p node reachable at @p host:@p port. */
+void add_remote(node_t node, const std::string &host, std::uint16_t port);
+
+/** Install a packet receive callback. */
+void set_recv_callback(RecvCallback cb);
+
+/** Stop background networking threads and reset state. */
+void shutdown() noexcept;
 
 /**
  * @brief Obtain the identifier for the local node.

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -6,6 +6,7 @@ set(CMAKE_CXX_STANDARD 23)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 enable_testing()
+find_package(Threads REQUIRED)
 
 function(add_lattice_test target source)
   add_executable(${target}
@@ -21,7 +22,7 @@ function(add_lattice_test target source)
     ${CMAKE_SOURCE_DIR}/h
     ${ARGN})
   target_compile_definitions(${target} PRIVATE EXTERN=extern)
-  target_link_libraries(${target} PRIVATE pqcrypto)
+  target_link_libraries(${target} PRIVATE pqcrypto Threads::Threads)
   add_test(NAME ${target} COMMAND ${target})
 endfunction()
 

--- a/tests/test_lattice_network.cpp
+++ b/tests/test_lattice_network.cpp
@@ -1,6 +1,6 @@
 /**
  * @file test_lattice_network.cpp
- * @brief Exercise lattice IPC across simulated network nodes.
+ * @brief Verify cross-node message delivery over UDP.
  */
 
 #include "../h/error.hpp"
@@ -9,119 +9,77 @@
 #include "../kernel/net_driver.hpp"
 
 #include <cassert>
-#include <cstddef>
-#include <cstring>
-#include <span>
-#include <vector>
+#include <chrono>
+#include <csignal>
+#include <sys/wait.h>
+#include <thread>
 
 using namespace lattice;
 
-/**
- * @brief XOR cipher identical to the implementation inside lattice_ipc.cpp.
- */
-static void xor_cipher(std::span<std::byte> buf, std::span<const std::byte> key) noexcept {
-    for (std::size_t i = 0; i < buf.size(); ++i) {
-        buf[i] ^= key[i % key.size()];
-    }
-}
+static constexpr net::node_t PARENT_NODE = 0;
+static constexpr net::node_t CHILD_NODE = 1;
+static constexpr uint16_t PARENT_PORT = 12000;
+static constexpr uint16_t CHILD_PORT = 12001;
 
-/**
- * @brief Deliver network bytes into the given graph instance.
- *
- * Packets are decrypted when the destination is listening otherwise they are
- * queued for later receipt.
- */
-static void deliver(lattice::Graph &g, int node, xinim::pid_t src, xinim::pid_t dst) {
-    auto data = net::receive(node);
-    assert(!data.empty());
-    assert(data.size() == sizeof(message));
+/** Parent side logic sending a message and waiting for a reply. */
+static int parent_proc(pid_t child) {
+    net::init({PARENT_NODE, PARENT_PORT});
+    net::add_remote(CHILD_NODE, "127.0.0.1", CHILD_PORT);
+
+    g_graph = Graph{};
+    lattice_connect(1, 2, CHILD_NODE);
 
     message msg{};
-    std::memcpy(&msg, data.data(), sizeof(msg));
+    msg.m_type = 42;
+    lattice_send(1, 2, msg);
 
-    lattice::Channel *ch = g.find(src, dst, net::local_node());
-    assert(ch != nullptr);
-
-    if (g.is_listening(dst)) {
-        auto buf = std::span<std::byte>(reinterpret_cast<std::byte *>(&msg), sizeof(msg));
-        xor_cipher(
-            buf, std::span<const std::byte>(reinterpret_cast<const std::byte *>(ch->secret.data()),
-                                            ch->secret.size()));
-        g.inbox_[dst] = msg;
-        g.set_listening(dst, false);
-    } else {
-        ch->queue.push_back(msg);
+    message reply{};
+    for (;;) {
+        poll_network();
+        if (lattice_recv(2, &reply) == OK) {
+            break;
+        }
+        std::this_thread::sleep_for(std::chrono::milliseconds(10));
     }
+    assert(reply.m_type == 99);
+
+    int status = 0;
+    waitpid(child, &status, 0);
+    net::shutdown();
+    return status;
 }
 
-/**
- * @brief Entry point verifying networked lattice IPC semantics.
- */
-int main() {
-    net::reset();
+/** Child process responding to the parent's message. */
+static int child_proc() {
+    net::init({CHILD_NODE, CHILD_PORT});
+    net::add_remote(PARENT_NODE, "127.0.0.1", PARENT_PORT);
 
-    lattice::Graph node0{};
-    lattice::Graph node1{};
+    g_graph = Graph{};
+    lattice_connect(2, 1, PARENT_NODE);
 
-    // Establish matching channels on both nodes
-    g_graph = node0;
-    lattice_connect(10, 20, 1);
-    const auto secret_a0 = g_graph.find(10, 20, 1)->secret;
-    node0 = g_graph;
+    message incoming{};
+    for (;;) {
+        poll_network();
+        if (lattice_recv(1, &incoming) == OK) {
+            break;
+        }
+        std::this_thread::sleep_for(std::chrono::milliseconds(10));
+    }
+    assert(incoming.m_type == 42);
 
-    g_graph = node1;
-    lattice_connect(10, 20);
-    lattice::Channel *a1 = g_graph.find(10, 20, net::local_node());
-    a1->secret = secret_a0;
-    node1 = g_graph;
+    message ack{};
+    ack.m_type = 99;
+    lattice_send(2, 1, ack);
 
-    // Second channel to verify unique secrets
-    g_graph = node0;
-    lattice_connect(11, 22, 1);
-    const auto secret_b0 = g_graph.find(11, 22, 1)->secret;
-    node0 = g_graph;
-
-    g_graph = node1;
-    lattice_connect(11, 22);
-    lattice::Channel *b1 = g_graph.find(11, 22, net::local_node());
-    b1->secret = secret_b0;
-    node1 = g_graph;
-
-    assert(secret_a0 != secret_b0);
-
-    // Phase 1: queued receive
-    g_graph = node0;
-    message m1{};
-    m1.m_type = 42;
-    lattice_send(10, 20, m1);
-    node0 = g_graph;
-
-    g_graph = node1;
-    deliver(g_graph, 1, 10, 20);
-    node1 = g_graph;
-
-    message out1{};
-    assert(lattice_recv(20, &out1) == OK);
-    assert(out1.m_type == 42);
-    node1 = g_graph;
-
-    // Phase 2: listening path
-    lattice_listen(20);
-    node1 = g_graph;
-
-    g_graph = node0;
-    message m2{};
-    m2.m_type = 99;
-    lattice_send(10, 20, m2);
-    node0 = g_graph;
-
-    g_graph = node1;
-    deliver(g_graph, 1, 10, 20);
-    node1 = g_graph;
-
-    message out2{};
-    assert(lattice_recv(20, &out2) == OK);
-    assert(out2.m_type == 99);
-
+    std::this_thread::sleep_for(std::chrono::milliseconds(50));
+    net::shutdown();
     return 0;
+}
+
+int main() {
+    pid_t pid = fork();
+    if (pid == 0) {
+        return child_proc();
+    }
+    return parent_proc(pid);
 }


### PR DESCRIPTION
## Summary
- refactor net driver to use UDP transport with callbacks
- document networking API in Sphinx
- hook network driver into lattice IPC send/recv
- create cross-node UDP unit test
- link tests with pthreads

## Testing
- `cmake .. -DBUILD_SYSTEM=OFF` *(fails: libsodium initially missing)*
- `make -j4` *(fails: build errors in unrelated targets)*
- `cmake --build . --target minix_test_lattice_network` *(fails: compiler errors)*

------
https://chatgpt.com/codex/tasks/task_e_684f9da361788331868ca764e36ca1ba

## Summary by Sourcery

Implement a real UDP network driver for Lattice IPC, integrate it into the IPC layer with polling support, add a cross-node unit test, update build settings for threading, and document the new networking API.

New Features:
- Replace the stub loopback driver with a UDP-based network driver using sockets, background receive thread, and callbacks
- Integrate the UDP driver into lattice IPC by adding init/add_remote/shutdown functions and poll_network support
- Add a cross-node forked parent/child unit test to verify UDP-based lattice message exchange

Build:
- Update test CMakeLists to find and link the Threads library

Documentation:
- Introduce Sphinx documentation for the new networking API

Tests:
- Add a UDP network unit test in tests/test_lattice_network.cpp to validate cross-node messaging