### PR TITLE
Add ServiceManager docs

### DIFF
--- a/kernel/service.cpp
+++ b/kernel/service.cpp
@@ -56,6 +56,15 @@ void ServiceManager::register_service(xinim::pid_t pid, const std::vector<xinim:
     sched::scheduler.enqueue(pid);
 }
 
+/**
+ * @brief Add a new dependency to an existing service.
+ *
+ * The method ensures the dependency graph remains acyclic by validating that
+ * adding @p dep does not introduce a path back to @p pid.
+ *
+ * @param pid Service that will gain the dependency.
+ * @param dep Service that @p pid depends on.
+ */
 void ServiceManager::add_dependency(xinim::pid_t pid, xinim::pid_t dep) {
     auto it = services_.find(pid);
     if (it == services_.end()) {
@@ -68,6 +77,12 @@ void ServiceManager::add_dependency(xinim::pid_t pid, xinim::pid_t dep) {
     }
 }
 
+/**
+ * @brief Update the automatic restart limit for a service.
+ *
+ * @param pid   Service identifier to update.
+ * @param limit New restart limit applied to the service contract.
+ */
 void ServiceManager::set_restart_limit(xinim::pid_t pid, std::uint32_t limit) {
     auto it = services_.find(pid);
     if (it == services_.end()) {
@@ -121,6 +136,15 @@ bool ServiceManager::handle_crash(xinim::pid_t pid) {
     return true;
 }
 
+/**
+ * @brief Retrieve the liveness contract for @p pid.
+ *
+ * If the service has not been registered, a static empty contract is returned
+ * instead.
+ *
+ * @param pid Identifier of the service.
+ * @return Reference to the associated contract or an empty fallback.
+ */
 const ServiceManager::LivenessContract &ServiceManager::contract(xinim::pid_t pid) const {
     static const LivenessContract empty{};
     if (auto it = services_.find(pid); it != services_.end()) {
@@ -129,6 +153,12 @@ const ServiceManager::LivenessContract &ServiceManager::contract(xinim::pid_t pi
     return empty;
 }
 
+/**
+ * @brief Check whether a service is currently running.
+ *
+ * @param pid Identifier of the service.
+ * @return @c true if the service is active.
+ */
 bool ServiceManager::is_running(xinim::pid_t pid) const noexcept {
     if (auto it = services_.find(pid); it != services_.end()) {
         return it->second.running;
@@ -136,8 +166,10 @@ bool ServiceManager::is_running(xinim::pid_t pid) const noexcept {
     return false;
 }
 
+/// Global manager instance accessible throughout the kernel.
 ServiceManager service_manager{};
 
+/// Counter used to assign unique IDs to liveness contracts.
 std::atomic_uint64_t ServiceManager::next_contract_id_{1};
 
 } // namespace svc

--- a/kernel/service.hpp
+++ b/kernel/service.hpp
@@ -101,8 +101,31 @@ class ServiceManager {
         LivenessContract contract{};    ///< Liveness contract for restarts
     };
 
+    /**
+     * @brief Check if a dependency path exists from @p start to @p target.
+     *
+     * The search avoids cycles by keeping track of previously @p visited
+     * services. A true result indicates that @p start transitively depends on
+     * @p target.
+     *
+     * @param start   Service to begin the search from.
+     * @param target  Service to reach.
+     * @param visited Set of services already examined.
+     * @return @c true if a path exists.
+     */
     bool has_path(xinim::pid_t start, xinim::pid_t target,
                   std::unordered_set<xinim::pid_t> &visited) const;
+
+    /**
+     * @brief Restart @p pid and recursively restart all dependents.
+     *
+     * This helper traverses the dependency DAG and restarts every service that
+     * directly or indirectly depends on @p pid. The @p visited set prevents
+     * cycles during the traversal.
+     *
+     * @param pid     Service to restart.
+     * @param visited Set of services already restarted in this operation.
+     */
     void restart_tree(xinim::pid_t pid, std::unordered_set<xinim::pid_t> &visited);
 
     std::unordered_map<xinim::pid_t, ServiceInfo> services_{}; ///< Registered services


### PR DESCRIPTION
## Summary
- document all ServiceManager methods in `service.cpp`/`service.hpp`
- ensure docs build attempts via Doxygen and Sphinx

## Testing
- `clang-format -i kernel/service.cpp kernel/service.hpp`
- `doxygen Doxyfile`
- `/root/.pyenv/versions/3.12.10/bin/sphinx-build -b html docs/sphinx docs/sphinx/html` *(fails: duplicate declaration errors)*

------
https://chatgpt.com/codex/tasks/task_e_684f9fc5c1f883319771126eed177a9c