### PR TITLE
Add WaitForGraph docs

### DIFF
--- a/docs/sphinx/index.rst
+++ b/docs/sphinx/index.rst
@@ -19,6 +19,7 @@ The documentation is divided into several sections:
    lattice_ipc#remote-channel-setup
    pq_crypto
    scheduler
+   wait_graph
    service
    service_manager
    precommit

--- a/docs/sphinx/wait_graph.rst
+++ b/docs/sphinx/wait_graph.rst
@@ -1,0 +1,18 @@
+Wait-for Graph
+==============
+
+The kernel tracks which processes block on others through a directed wait-for graph. Each edge ``A -> B`` means that process ``A`` is waiting on ``B`` to release a resource. When a new edge is inserted the graph performs a reachability check from the destination back to the source. If a path already exists the edge would create a cycle and thus a potential deadlock. In that case the insertion is reverted and the caller is notified, allowing the scheduler to react before the system stalls.
+
+.. doxygenclass:: lattice::WaitForGraph
+   :project: XINIM
+   :members:
+
+.. doxygenfunction:: lattice::WaitForGraph::add_edge
+   :project: XINIM
+
+.. doxygenfunction:: lattice::WaitForGraph::remove_edge
+   :project: XINIM
+
+.. doxygenfunction:: lattice::WaitForGraph::clear
+   :project: XINIM
+


### PR DESCRIPTION
## Summary
- document wait-for graph in new page
- reference wait graph documentation from the main index

## Testing
- `cmake -B build -DBUILD_SYSTEM=OFF`
- `cmake --build build -- -j$(nproc)` *(fails: undefined reference and missing symbols)*

------
https://chatgpt.com/codex/tasks/task_e_684fa18e8b988331a52d7c20c3aadb58