### PR TITLE
Fix docs and rebuild Sphinx

### DIFF
--- a/docs/sphinx/index.rst
+++ b/docs/sphinx/index.rst
@@ -16,7 +16,6 @@ The documentation is divided into several sections:
    :caption: Contents
 
    lattice_ipc
-   lattice_ipc#remote-channel-setup
    pq_crypto
    scheduler
    wait_graph

--- a/docs/sphinx/networking.rst
+++ b/docs/sphinx/networking.rst
@@ -4,7 +4,7 @@ Networking Driver
 The networking driver transports Lattice IPC packets between nodes over UDP or, optionally, TCP.  Each node:
 
 - **Binds** to a local UDP port (and a TCP listen socket if TCP‐enabled).  
-- **Registers** peers via :cpp:func:`net::add_remote(node, host, port, tcp?)`.  
+- **Registers** peers via :cpp:func:`net::add_remote`.
 - **Spawns** background threads to receive UDP datagrams and accept TCP connections.  
 - **Queues** incoming packets internally and invokes an optional callback.  
 - **Delivers** packets via :cpp:func:`net::recv`, or via the registered callback.  

--- a/docs/sphinx/service.rst
+++ b/docs/sphinx/service.rst
@@ -1,25 +1,21 @@
-Service Manager == == == == == == ==
-    =
+Service Manager
+===============
 
-        The service manager maintains critical user - space services and
-        their dependencies
-                .Services are registered with a dependency list forming a directed acyclic
-                    graph.If a service crashes the manager restarts it along with all dependents
-                .
+The service manager maintains critical user-space services and their
+dependencies. Services are registered with a dependency list forming a
+directed acyclic graph. If a service crashes the manager restarts it
+along with all dependents.
 
-            Restart Policies-- -- -- -- -- -- -- --
+Restart Policies
+----------------
+Each service registration optionally specifies an automatic restart
+limit. The limit is stored in a *liveness contract* which also tracks
+restart counts. When the limit is reached the manager refuses to
+restart the service again.
 
-            Each service registration optionally specifies an automatic restart limit.The limit is
-                stored in a *
-            liveness contract *
-            which also tracks how many times the service has
-                restarted.When the limit is reached the manager refuses to restart the service again
-                    .
+Additional dependencies may be declared at runtime using
+:cpp:func:`svc::ServiceManager::add_dependency`. The restart limit can
+be changed dynamically through
+:cpp:func:`svc::ServiceManager::set_restart_limit`.
 
-            Additional dependencies may be declared at runtime using : cpp : func
-    :`svc::ServiceManager::add_dependency`
-                    .The restart limit can be changed dynamically through : cpp : func
-    :`svc::ServiceManager::set_restart_limit`
-                    .
-
-                    ..doxygenclass::svc::ServiceManager : project : XINIM : members:
+For API-level details see :doc:`service_manager`.


### PR DESCRIPTION
## Summary
- cleanup service manager documentation
- fix cross-reference for `net::add_remote`
- remove invalid toctree target
- verify docs build without warnings

## Testing
- `sphinx-build -b html docs/sphinx docs/sphinx/_build/html`

------
https://chatgpt.com/codex/tasks/task_e_6850b298fc088331bc93e18e3aee5211