### PR TITLE
Improve networking docs

### DIFF
--- a/docs/sphinx/networking.rst
+++ b/docs/sphinx/networking.rst
@@ -41,28 +41,34 @@ API Overview
 
 Local Node Identification
 -------------------------
-:cpp:func:`net::local_node` opens its UDP socket (via :cpp:func:`net::init`),  
-calls ``getsockname()``, and returns the bound IPv4 address in host byte order  
-as a stable ``node_t`` identifier.
-
+:cpp:func:`net::local_node` first checks whether ``net::init`` supplied a
+non-zero ``node_id``.  If so, the value is returned directly.  Otherwise the
+function calls ``getsockname()`` on the UDP socket and converts the bound IPv4
+address to host byte order.  If this lookup fails, the host name is hashed.  In
+all cases the identifier is guaranteed to be non-zero and remains stable for
+the life of the process.
 Registering Remote Peers
 ------------------------
-Use:
-
-.. code-block:: cpp
+A node communicates only with peers explicitly added using
+:cpp:func:`net::add_remote`::
 
    net::add_remote(node_id, "hostname-or-ip", port, /*tcp=*/false);
 
-to associate a numeric ``node_id`` with a host:port.  Only packets to registered  
-peers are transmitted.  For TCP, pass ``tcp=true``.
+The ``node_id`` uniquely identifies the peer.  The ``host`` and ``port``
+parameters supply its address.  Set ``tcp=true`` to create a persistent TCP
+connection; otherwise UDP datagrams are used.  Packets are sent only to
+registered peers and looked up by ``node_id`` at transmission time.
+
+
 
 Typical Configuration Steps
 ---------------------------
-1. **Initialize** the driver:
+1. **Initialize** the driver.  Pass ``0`` as ``node_id`` to let
+   :cpp:func:`net::local_node` derive the identifier from the bound address:
 
    .. code-block:: cpp
 
-      net::init({ local_node_id, udp_port });
+      net::init({ node_id, udp_port });
 
 2. **Register** remote peers:
 
@@ -94,61 +100,71 @@ Typical Configuration Steps
 
       net::shutdown();
 
-Example: Two‐Node Exchange
---------------------------
-This example shows a parent and child process exchanging small payloads over UDP.
+
+Example: Two-Node Handshake
+---------------------------
+The :file:`tests/test_net_two_node.cpp` unit test spawns a parent and child
+process that exchange a handshake. The child echoes its
+:cpp:func:`net::local_node` value so the parent can verify unique identifiers.
 
 .. code-block:: cpp
 
-   #include <array>
-   #include <thread>
-   #include <chrono>
+   #include <chrono>           // std::chrono literals
+   #include <thread>           // sleep while polling
    #include <cassert>
-   #include <unistd.h>
-   #include <sys/wait.h>
+   #include <unistd.h>         // fork and waitpid
+   #include "lattice_ipc.hpp"
    #include "net_driver.hpp"
 
+   using namespace lattice;
    using namespace std::chrono_literals;
-   constexpr net::node_t   PARENT_NODE = 0, CHILD_NODE = 1;
-   constexpr uint16_t      PARENT_PORT = 14000, CHILD_PORT = 14001;
 
-   int parent_proc(pid_t child) {
-       net::init({PARENT_NODE, PARENT_PORT});
-       net::add_remote(CHILD_NODE, "127.0.0.1", CHILD_PORT, /*tcp=*/false);
+   constexpr net::node_t PARENT_NODE = 0;   ///< ID for the parent
+   constexpr net::node_t CHILD_NODE  = 1;   ///< ID for the child
+   constexpr std::uint16_t PARENT_PORT = 13000; ///< Parent UDP port
+   constexpr std::uint16_t CHILD_PORT  = 13001; ///< Child UDP port
 
-       // wait for readiness signal
-       net::Packet pkt;
-       while (!net::recv(pkt)) std::this_thread::sleep_for(10ms);
-       assert(pkt.src_node == CHILD_NODE);
+   // Child waits for a handshake then replies with its node ID
+   int child_proc() {
+       net::init({CHILD_NODE, CHILD_PORT});
+       net::add_remote(PARENT_NODE, "127.0.0.1", PARENT_PORT);
+       g_graph = Graph{};
+       lattice_connect(2, 1, PARENT_NODE);
 
-       // send data
-       std::array<std::byte,3> data{1,2,3};
-       net::send(CHILD_NODE, data);
+       message incoming{};
+       while (true) {                // poll until handshake arrives
+           poll_network();
+           if (lattice_recv(1, &incoming) == OK) break;
+           std::this_thread::sleep_for(10ms);
+       }
 
-       // await reply
-       while (!net::recv(pkt)) std::this_thread::sleep_for(10ms);
-       assert(pkt.src_node == CHILD_NODE);
-       assert(pkt.payload == std::vector<std::byte>{9,8,7});
-
-       waitpid(child, nullptr, 0);
+       message reply{};
+       reply.m_type = net::local_node();
+       lattice_send(2, 1, reply);
        net::shutdown();
        return 0;
    }
 
-   int child_proc() {
-       net::init({CHILD_NODE, CHILD_PORT});
-       net::add_remote(PARENT_NODE, "127.0.0.1", PARENT_PORT, /*tcp=*/false);
+   // Parent sends the handshake and verifies the response
+   int parent_proc(pid_t child) {
+       net::init({PARENT_NODE, PARENT_PORT});
+       net::add_remote(CHILD_NODE, "127.0.0.1", CHILD_PORT);
+       g_graph = Graph{};
+       lattice_connect(1, 2, CHILD_NODE);
 
-       // signal readiness
-       net::send(PARENT_NODE, std::array<std::byte,1>{0});
+       message hi{};
+       hi.m_type = 0x1234;
+       lattice_send(1, 2, hi);
 
-       // receive payload
-       net::Packet pkt;
-       while (!net::recv(pkt)) std::this_thread::sleep_for(10ms);
-       assert(pkt.src_node == PARENT_NODE);
+       message reply{};
+       while (true) {                // poll until reply arrives
+           poll_network();
+           if (lattice_recv(2, &reply) == OK) break;
+           std::this_thread::sleep_for(10ms);
+       }
 
-       // reply
-       net::send(PARENT_NODE, std::array<std::byte,3>{9,8,7});
+       assert(reply.m_type != net::local_node());
+       waitpid(child, nullptr, 0);
        net::shutdown();
        return 0;
    }
@@ -157,7 +173,7 @@ This example shows a parent and child process exchanging small payloads over UDP
        pid_t pid = fork();
        if (pid == 0) {
            return child_proc();
-       } else {
-           return parent_proc(pid);
        }
+       return parent_proc(pid);
    }
+


### PR DESCRIPTION
## Summary
- document how `local_node()` decides the node ID
- explain registering remote peers and common setup steps
- show a two-process handshake example

## Testing
- `make docs` *(fails: doxygen missing)*
- `make check` *(fails: missing build rule)*

------
https://chatgpt.com/codex/tasks/task_e_6850b29dcbc48331b8922f5c33f054f6

## Summary by Sourcery

Improve the networking documentation with detailed explanations and examples

Documentation:
- Describe how local_node() determines its node ID
- Explain how to register remote peers and outline common setup steps
- Add a two-process handshake example to illustrate peer interaction