### PR TITLE
Improve network send error handling

### DIFF
--- a/kernel/net_driver.cpp
+++ b/kernel/net_driver.cpp
@@ -15,8 +15,8 @@
 #include <sys/socket.h>
 #include <unistd.h>
 
-#include <atomic>
 #include <array>
+#include <atomic>
 #include <cstring>
 #include <deque>
 #include <mutex>
@@ -30,37 +30,36 @@ namespace net {
 namespace {
 
 /** Active configuration. */
-static Config                         g_cfg{};
+static Config g_cfg{};
 /** UDP socket descriptor. */
-static int                            g_udp_sock   = -1;
+static int g_udp_sock = -1;
 /** TCP listen socket descriptor. */
-static int                            g_tcp_listen = -1;
+static int g_tcp_listen = -1;
 /**
  * Represents a remote peer with UDP or persistent TCP transport.
  */
 struct Remote {
     sockaddr_in addr{};
-    Protocol     proto = Protocol::UDP;
-    int          tcp_fd = -1; ///< valid if proto==TCP
+    Protocol proto = Protocol::UDP;
+    int tcp_fd = -1; ///< valid if proto==TCP
 };
 /** Peer registry: node_id → Remote. */
 static std::unordered_map<node_t, Remote> g_remotes;
 /** Incoming packet queue. */
-static std::deque<Packet>                g_queue;
+static std::deque<Packet> g_queue;
 /** Protects g_queue. */
-static std::mutex                         g_mutex;
+static std::mutex g_mutex;
 /** Optional receive‐callback. */
-static RecvCallback                       g_callback;
+static RecvCallback g_callback;
 /** Controls I/O threads. */
-static std::atomic<bool>                  g_running{false};
+static std::atomic<bool> g_running{false};
 /** Background threads for UDP & TCP. */
-static std::jthread                       g_udp_thread, g_tcp_thread;
+static std::jthread g_udp_thread, g_tcp_thread;
 
 /**
  * Frame data as [ local_node | payload... ].
  */
-static std::vector<std::byte>
-frame_payload(std::span<const std::byte> data) {
+static std::vector<std::byte> frame_payload(std::span<const std::byte> data) {
     node_t nid = local_node();
     std::vector<std::byte> buf(sizeof(nid) + data.size());
     std::memcpy(buf.data(), &nid, sizeof(nid));
@@ -71,11 +70,10 @@ frame_payload(std::span<const std::byte> data) {
 /**
  * Enqueue a packet with overflow policy.
  */
-static void enqueue_packet(Packet&& pkt) {
+static void enqueue_packet(Packet &&pkt) {
     std::lock_guard lock{g_mutex};
     if (g_cfg.max_queue_length > 0 &&
-        g_queue.size() >= static_cast<size_t>(g_cfg.max_queue_length))
-    {
+        g_queue.size() >= static_cast<size_t>(g_cfg.max_queue_length)) {
         if (g_cfg.overflow == OverflowPolicy::DropOldest) {
             g_queue.pop_front();
         } else { // OverwriteOldest
@@ -95,17 +93,14 @@ void udp_recv_loop() {
     std::array<std::byte, 2048> buf;
     while (g_running.load(std::memory_order_relaxed)) {
         sockaddr_in peer{};
-        socklen_t   len = sizeof(peer);
-        ssize_t     n   = ::recvfrom(g_udp_sock,
-                                     buf.data(), buf.size(),
-                                     0,
-                                     reinterpret_cast<sockaddr*>(&peer),
-                                     &len);
-        if (n <= static_cast<ssize_t>(sizeof(node_t) * 2)) continue;
+        socklen_t len = sizeof(peer);
+        ssize_t n = ::recvfrom(g_udp_sock, buf.data(), buf.size(), 0,
+                               reinterpret_cast<sockaddr *>(&peer), &len);
+        if (n <= static_cast<ssize_t>(sizeof(node_t) * 2))
+            continue;
         Packet pkt;
         std::memcpy(&pkt.src_node, buf.data(), sizeof(pkt.src_node));
-        pkt.payload.assign(buf.begin() + sizeof(pkt.src_node),
-                           buf.begin() + n);
+        pkt.payload.assign(buf.begin() + sizeof(pkt.src_node), buf.begin() + n);
         enqueue_packet(std::move(pkt));
     }
 }
@@ -117,21 +112,18 @@ void tcp_accept_loop() {
     ::listen(g_tcp_listen, 8);
     while (g_running.load(std::memory_order_relaxed)) {
         sockaddr_in peer{};
-        socklen_t   len = sizeof(peer);
-        int client = ::accept(g_tcp_listen,
-                              reinterpret_cast<sockaddr*>(&peer),
-                              &len);
-        if (client < 0) continue;
+        socklen_t len = sizeof(peer);
+        int client = ::accept(g_tcp_listen, reinterpret_cast<sockaddr *>(&peer), &len);
+        if (client < 0)
+            continue;
         std::array<std::byte, 2048> buf;
         while (true) {
-            ssize_t n = ::recv(client,
-                               buf.data(), buf.size(),
-                               0);
-            if (n <= static_cast<ssize_t>(sizeof(node_t))) break;
+            ssize_t n = ::recv(client, buf.data(), buf.size(), 0);
+            if (n <= static_cast<ssize_t>(sizeof(node_t)))
+                break;
             Packet pkt;
             std::memcpy(&pkt.src_node, buf.data(), sizeof(pkt.src_node));
-            pkt.payload.assign(buf.begin() + sizeof(pkt.src_node),
-                               buf.begin() + n);
+            pkt.payload.assign(buf.begin() + sizeof(pkt.src_node), buf.begin() + n);
             enqueue_packet(std::move(pkt));
         }
         ::close(client);
@@ -140,24 +132,26 @@ void tcp_accept_loop() {
 
 } // namespace
 
-void init(const Config& cfg) {
+void init(const Config &cfg) {
     g_cfg = cfg;
 
     // UDP socket setup
     g_udp_sock = ::socket(AF_INET, SOCK_DGRAM, 0);
-    if (g_udp_sock < 0) throw std::system_error(errno, std::generic_category(), "UDP socket");
-    sockaddr_in addr{ .sin_family = AF_INET,
-                      .sin_port   = htons(cfg.port),
-                      .sin_addr   = { .s_addr = htonl(INADDR_ANY) } };
-    if (::bind(g_udp_sock, reinterpret_cast<sockaddr*>(&addr), sizeof(addr)) < 0)
+    if (g_udp_sock < 0)
+        throw std::system_error(errno, std::generic_category(), "UDP socket");
+    sockaddr_in addr{.sin_family = AF_INET,
+                     .sin_port = htons(cfg.port),
+                     .sin_addr = {.s_addr = htonl(INADDR_ANY)}};
+    if (::bind(g_udp_sock, reinterpret_cast<sockaddr *>(&addr), sizeof(addr)) < 0)
         throw std::system_error(errno, std::generic_category(), "UDP bind");
 
     // TCP listen socket
     g_tcp_listen = ::socket(AF_INET, SOCK_STREAM, 0);
-    if (g_tcp_listen < 0) throw std::system_error(errno, std::generic_category(), "TCP socket");
+    if (g_tcp_listen < 0)
+        throw std::system_error(errno, std::generic_category(), "TCP socket");
     int opt = 1;
     ::setsockopt(g_tcp_listen, SOL_SOCKET, SO_REUSEADDR, &opt, sizeof(opt));
-    if (::bind(g_tcp_listen, reinterpret_cast<sockaddr*>(&addr), sizeof(addr)) < 0)
+    if (::bind(g_tcp_listen, reinterpret_cast<sockaddr *>(&addr), sizeof(addr)) < 0)
         throw std::system_error(errno, std::generic_category(), "TCP bind");
 
     // Start I/O threads
@@ -168,53 +162,59 @@ void init(const Config& cfg) {
 
 void shutdown() noexcept {
     g_running.store(false, std::memory_order_relaxed);
-    if (g_udp_sock != -1) { ::close(g_udp_sock);   g_udp_sock = -1; }
-    if (g_tcp_listen != -1) { ::shutdown(g_tcp_listen, SHUT_RDWR); ::close(g_tcp_listen); g_tcp_listen = -1; }
-    if (g_udp_thread.joinable()) g_udp_thread.join();
-    if (g_tcp_thread.joinable()) g_tcp_thread.join();
+    if (g_udp_sock != -1) {
+        ::close(g_udp_sock);
+        g_udp_sock = -1;
+    }
+    if (g_tcp_listen != -1) {
+        ::shutdown(g_tcp_listen, SHUT_RDWR);
+        ::close(g_tcp_listen);
+        g_tcp_listen = -1;
+    }
+    if (g_udp_thread.joinable())
+        g_udp_thread.join();
+    if (g_tcp_thread.joinable())
+        g_tcp_thread.join();
     {
         std::lock_guard lock{g_mutex};
         g_queue.clear();
     }
-    for (auto& [_, r] : g_remotes) {
-        if (r.proto == Protocol::TCP && r.tcp_fd >= 0) ::close(r.tcp_fd);
+    for (auto &[_, r] : g_remotes) {
+        if (r.proto == Protocol::TCP && r.tcp_fd >= 0)
+            ::close(r.tcp_fd);
     }
     g_remotes.clear();
     g_callback = nullptr;
 }
 
-void add_remote(node_t node,
-                const std::string& host,
-                uint16_t port,
-                Protocol proto)
-{
+void add_remote(node_t node, const std::string &host, uint16_t port, Protocol proto) {
     Remote rem{};
     rem.proto = proto;
     rem.addr.sin_family = AF_INET;
-    rem.addr.sin_port   = htons(port);
+    rem.addr.sin_port = htons(port);
     if (::inet_aton(host.c_str(), &rem.addr.sin_addr) == 0)
         throw std::invalid_argument("net_driver: bad host address");
     if (proto == Protocol::TCP) {
         rem.tcp_fd = ::socket(AF_INET, SOCK_STREAM, 0);
         if (rem.tcp_fd < 0 ||
-            ::connect(rem.tcp_fd, reinterpret_cast<sockaddr*>(&rem.addr), sizeof(rem.addr)) != 0)
-        {
-            if (rem.tcp_fd >= 0) ::close(rem.tcp_fd);
+            ::connect(rem.tcp_fd, reinterpret_cast<sockaddr *>(&rem.addr), sizeof(rem.addr)) != 0) {
+            if (rem.tcp_fd >= 0)
+                ::close(rem.tcp_fd);
             throw std::system_error(errno, std::generic_category(), "TCP connect");
         }
     }
     g_remotes[node] = rem;
 }
 
-void set_recv_callback(RecvCallback cb) {
-    g_callback = std::move(cb);
-}
+void set_recv_callback(RecvCallback cb) { g_callback = std::move(cb); }
 
 node_t local_node() noexcept {
-    if (g_cfg.node_id != 0) return g_cfg.node_id;
+    if (g_cfg.node_id != 0)
+        return g_cfg.node_id;
     if (g_udp_sock >= 0) {
-        sockaddr_in sa{}; socklen_t len = sizeof(sa);
-        if (::getsockname(g_udp_sock, reinterpret_cast<sockaddr*>(&sa), &len)==0) {
+        sockaddr_in sa{};
+        socklen_t len = sizeof(sa);
+        if (::getsockname(g_udp_sock, reinterpret_cast<sockaddr *>(&sa), &len) == 0) {
             node_t id = static_cast<node_t>(ntohl(sa.sin_addr.s_addr) & 0x7fffffff);
             return id ? id : 1;
         }
@@ -228,22 +228,41 @@ node_t local_node() noexcept {
     return 1;
 }
 
+/**
+ * @brief Transmit a payload to a registered peer.
+ *
+ * Frames the data with the local node identifier and sends it via the
+ * appropriate transport. Any socket error results in ``false`` being
+ * returned.
+ */
 bool send(node_t node, std::span<const std::byte> data) {
     auto it = g_remotes.find(node);
-    if (it == g_remotes.end()) return false;
-    auto buf = frame_payload(data);
-    auto& rem = it->second;
-    if (rem.proto == Protocol::TCP && rem.tcp_fd >= 0) {
-        return ::send(rem.tcp_fd, buf.data(), buf.size(), 0) == static_cast<ssize_t>(buf.size());
+    if (it == g_remotes.end()) {
+        return false;
     }
-    return ::sendto(g_udp_sock, buf.data(), buf.size(), 0,
-                    reinterpret_cast<sockaddr*>(&rem.addr), sizeof(rem.addr))
-         == static_cast<ssize_t>(buf.size());
+
+    auto buf = frame_payload(data);
+    auto &rem = it->second;
+    if (rem.proto == Protocol::TCP && rem.tcp_fd >= 0) {
+        const auto rc = ::send(rem.tcp_fd, buf.data(), buf.size(), 0);
+        if (rc < 0) {
+            return false;
+        }
+        return static_cast<std::size_t>(rc) == buf.size();
+    }
+
+    const auto rc = ::sendto(g_udp_sock, buf.data(), buf.size(), 0,
+                             reinterpret_cast<sockaddr *>(&rem.addr), sizeof(rem.addr));
+    if (rc < 0) {
+        return false;
+    }
+    return static_cast<std::size_t>(rc) == buf.size();
 }
 
-bool recv(Packet& out) {
+bool recv(Packet &out) {
     std::lock_guard lock{g_mutex};
-    if (g_queue.empty()) return false;
+    if (g_queue.empty())
+        return false;
     out = std::move(g_queue.front());
     g_queue.pop_front();
     return true;

--- a/kernel/net_driver.hpp
+++ b/kernel/net_driver.hpp
@@ -34,8 +34,8 @@ using node_t = int;
  * @brief In‐memory representation of a network packet.
  */
 struct Packet {
-    node_t                 src_node;  ///< Originating node ID
-    std::vector<std::byte> payload;   ///< Raw payload bytes (post‐prefix)
+    node_t src_node;                ///< Originating node ID
+    std::vector<std::byte> payload; ///< Raw payload bytes (post‐prefix)
 };
 
 /**
@@ -73,13 +73,13 @@ enum class Protocol { UDP, TCP };
  * When proto==UDP, send() uses sendto() on the bound UDP socket.
  */
 struct Remote {
-    sockaddr_in addr;     ///< IPv4 socket address of the peer
-    Protocol     proto;   ///< Protocol to use (UDP or TCP)
-    int          tcp_fd{-1}; ///< TCP socket FD (if persistent; optional)
+    sockaddr_in addr; ///< IPv4 socket address of the peer
+    Protocol proto;   ///< Protocol to use (UDP or TCP)
+    int tcp_fd{-1};   ///< TCP socket FD (if persistent; optional)
 };
 
 /** Callback type invoked on packet arrival. */
-using RecvCallback = std::function<void(const Packet&)>;
+using RecvCallback = std::function<void(const Packet &)>;
 
 /**
  * @brief Initialize the network driver.
@@ -91,7 +91,7 @@ using RecvCallback = std::function<void(const Packet&)>;
  * @param cfg Local node configuration.
  * @throws std::system_error on socket/bind errors.
  */
-void init(const Config& cfg);
+void init(const Config &cfg);
 
 /**
  * @brief Register a remote peer for send().
@@ -101,9 +101,7 @@ void init(const Config& cfg);
  * @param port  UDP/TCP port on which peer listens.
  * @param proto Transport protocol to use.
  */
-void add_remote(node_t node,
-                const std::string& host,
-                uint16_t port,
+void add_remote(node_t node, const std::string &host, uint16_t port,
                 Protocol proto = Protocol::UDP);
 
 /**
@@ -144,7 +142,8 @@ void shutdown() noexcept;
  *
  * @param node Destination node ID.
  * @param data Span of bytes to transmit.
- * @return ``true`` on success, ``false`` on failure or unknown destination.
+ * @return ``true`` on success; ``false`` if the peer is unknown or a socket
+ *         error occurs.
  */
 [[nodiscard]] bool send(node_t node, std::span<const std::byte> data);
 
@@ -154,7 +153,7 @@ void shutdown() noexcept;
  * @param out Packet object to populate.
  * @return true if a packet was dequeued into out, false otherwise.
  */
-[[nodiscard]] bool recv(Packet& out);
+[[nodiscard]] bool recv(Packet &out);
 
 /**
  * @brief Clear all pending packets across every node.

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -258,6 +258,11 @@ add_lattice_test(minix_test_lattice test_lattice.cpp)
 # minix_test_lattice_send_recv
 # -----------------------------------------------------------------------------
 add_lattice_test(minix_test_lattice_send_recv test_lattice_send_recv.cpp)
+# -----------------------------------------------------------------------------
+# minix_test_lattice_send_error
+# -----------------------------------------------------------------------------
+add_lattice_test(minix_test_lattice_send_error test_lattice_send_error.cpp)
+
 
 # -----------------------------------------------------------------------------
 # minix_test_lattice_ipc

--- a/tests/test_lattice_send_error.cpp
+++ b/tests/test_lattice_send_error.cpp
@@ -1,0 +1,25 @@
+/**
+ * @file test_lattice_send_error.cpp
+ * @brief Validate error handling when sending to an unknown node.
+ */
+
+#include "../h/error.hpp"
+#include "../kernel/lattice_ipc.hpp"
+
+#include <cassert>
+
+using namespace lattice;
+
+/**
+ * @brief Ensure lattice_send reports EIO for unknown remote nodes.
+ */
+int main() {
+    g_graph = Graph{};
+    lattice_connect(1, 2, 99); // Connect to unregistered node
+
+    message msg{};
+    msg.m_type = 1;
+    int rc = lattice_send(1, 2, msg);
+    assert(rc == static_cast<int>(ErrorCode::EIO));
+    return 0;
+}

--- a/tests/test_net_two_node.cpp
+++ b/tests/test_net_two_node.cpp
@@ -62,7 +62,7 @@ static int child_proc() {
 
     message reply{};
     reply.m_type = net::local_node();
-    lattice_send(2, 1, reply);
+    assert(lattice_send(2, 1, reply) == OK);
 
     std::this_thread::sleep_for(std::chrono::milliseconds(50));
     net::shutdown();
@@ -84,7 +84,7 @@ static int parent_proc(pid_t child) {
 
     message msg{};
     msg.m_type = 0x1234;
-    lattice_send(1, 2, msg);
+    assert(lattice_send(1, 2, msg) == OK);
 
     message reply{};
     for (;;) {


### PR DESCRIPTION
## Summary
- validate `::sendto` results in the network driver
- propagate failures from `lattice_send`
- check send return status in two node test
- add regression test for unknown remote node
- register new test with CMake

## Testing
- `make check` *(fails: No rule to make target 'obj/fsck.o', needed by 'bin/fsck')*
- `cmake -S . -B build` *(passes)*
- `cmake --build build` *(fails: build errors in lib)*

------
https://chatgpt.com/codex/tasks/task_e_6850b27791308331b8db0fe9cc0ecfe3