### PR TITLE
Add automatic node ID detection

### DIFF
--- a/docs/sphinx/lattice_ipc.rst
+++ b/docs/sphinx/lattice_ipc.rst
@@ -60,10 +60,12 @@ Configuration (`net::Config`):
 
 Local Node Identification
 -------------------------
-:cpp:func:`net::local_node` returns in order:
-1. configured ``node_id`` if nonzero  
-2. IP address bound to UDP socket via ``getsockname``  
-3. Fallback to hashed hostname  
+:cpp:func:`net::local_node` returns the identifier chosen during
+:cpp:func:`net::init`.  Detection proceeds in order:
+1. configured ``node_id`` if nonzero
+2. hash of the primary interface's MAC address
+3. hash of the interface's IPv4 address
+4. hashed hostname
 
 Graph API
 ---------

--- a/docs/sphinx/networking.rst
+++ b/docs/sphinx/networking.rst
@@ -41,9 +41,11 @@ API Overview
 
 Local Node Identification
 -------------------------
-:cpp:func:`net::local_node` opens its UDP socket (via :cpp:func:`net::init`),  
-calls ``getsockname()``, and returns the bound IPv4 address in host byte order  
-as a stable ``node_t`` identifier.
+When :cpp:func:`net::init` is invoked with ``Config::node_id`` set to ``0`` the
+driver hashes the MAC address of the primary network interface.  If that fails
+the IPv4 address is hashed instead.  This derived value becomes the identifier
+returned by :cpp:func:`net::local_node`.  Passing a non-zero ``node_id``
+overrides detection entirely.
 
 Registering Remote Peers
 ------------------------
@@ -62,7 +64,7 @@ Typical Configuration Steps
 
    .. code-block:: cpp
 
-      net::init({ local_node_id, udp_port });
+   net::init({ 0, udp_port });  // derive node_id automatically
 
 2. **Register** remote peers:
 

--- a/kernel/net_driver.cpp
+++ b/kernel/net_driver.cpp
@@ -11,12 +11,16 @@
 #include "net_driver.hpp"
 
 #include <arpa/inet.h>
+#include <ifaddrs.h>
+#include <net/if.h>
 #include <netdb.h>
+#include <netpacket/packet.h>
+#include <string_view>
 #include <sys/socket.h>
 #include <unistd.h>
 
-#include <atomic>
 #include <array>
+#include <atomic>
 #include <cstring>
 #include <deque>
 #include <mutex>
@@ -30,37 +34,86 @@ namespace net {
 namespace {
 
 /** Active configuration. */
-static Config                         g_cfg{};
+static Config g_cfg{};
 /** UDP socket descriptor. */
-static int                            g_udp_sock   = -1;
+static int g_udp_sock = -1;
 /** TCP listen socket descriptor. */
-static int                            g_tcp_listen = -1;
+static int g_tcp_listen = -1;
 /**
  * Represents a remote peer with UDP or persistent TCP transport.
  */
 struct Remote {
     sockaddr_in addr{};
-    Protocol     proto = Protocol::UDP;
-    int          tcp_fd = -1; ///< valid if proto==TCP
+    Protocol proto = Protocol::UDP;
+    int tcp_fd = -1; ///< valid if proto==TCP
 };
 /** Peer registry: node_id → Remote. */
 static std::unordered_map<node_t, Remote> g_remotes;
 /** Incoming packet queue. */
-static std::deque<Packet>                g_queue;
+static std::deque<Packet> g_queue;
 /** Protects g_queue. */
-static std::mutex                         g_mutex;
+static std::mutex g_mutex;
 /** Optional receive‐callback. */
-static RecvCallback                       g_callback;
+static RecvCallback g_callback;
 /** Controls I/O threads. */
-static std::atomic<bool>                  g_running{false};
+static std::atomic<bool> g_running{false};
 /** Background threads for UDP & TCP. */
-static std::jthread                       g_udp_thread, g_tcp_thread;
+static std::jthread g_udp_thread, g_tcp_thread;
+
+/**
+ * @brief Derive a unique node identifier.
+ *
+ * When the caller does not specify a Config::node_id, the driver hashes the
+ * primary network interface's MAC address. If no MAC address is available the
+ * IPv4 address is used instead. As a last resort the host name is hashed. The
+ * result is always non-zero.
+ *
+ * @return Derived node identifier.
+ */
+static node_t derive_node_id() {
+    node_t id = 0;
+    ifaddrs *ifa_list = nullptr;
+    if (::getifaddrs(&ifa_list) == 0) {
+        for (auto *ifa = ifa_list; ifa != nullptr; ifa = ifa->ifa_next) {
+            if (!ifa->ifa_addr || (ifa->ifa_flags & IFF_LOOPBACK)) {
+                continue;
+            }
+            if (ifa->ifa_addr->sa_family == AF_PACKET) {
+                auto *sll = reinterpret_cast<sockaddr_ll *>(ifa->ifa_addr);
+                const unsigned char *mac = sll->sll_addr;
+                std::size_t len = sll->sll_halen;
+                std::uint64_t h = 14695981039346656037ull;
+                for (std::size_t i = 0; i < len; ++i) {
+                    h ^= mac[i];
+                    h *= 1099511628211ull;
+                }
+                id = static_cast<node_t>(h & 0x7fffffff);
+                break;
+            }
+            if (ifa->ifa_addr->sa_family == AF_INET) {
+                auto *sa = reinterpret_cast<sockaddr_in *>(ifa->ifa_addr);
+                if (sa->sin_addr.s_addr != htonl(INADDR_LOOPBACK)) {
+                    id = static_cast<node_t>(ntohl(sa->sin_addr.s_addr) & 0x7fffffff);
+                    break;
+                }
+            }
+        }
+        ::freeifaddrs(ifa_list);
+    }
+    if (id == 0) {
+        char host[256]{};
+        if (::gethostname(host, sizeof(host)) == 0) {
+            auto h = std::hash<std::string_view>{}(host);
+            id = static_cast<node_t>(h & 0x7fffffff);
+        }
+    }
+    return id ? id : 1;
+}
 
 /**
  * Frame data as [ local_node | payload... ].
  */
-static std::vector<std::byte>
-frame_payload(std::span<const std::byte> data) {
+static std::vector<std::byte> frame_payload(std::span<const std::byte> data) {
     node_t nid = local_node();
     std::vector<std::byte> buf(sizeof(nid) + data.size());
     std::memcpy(buf.data(), &nid, sizeof(nid));
@@ -71,11 +124,10 @@ frame_payload(std::span<const std::byte> data) {
 /**
  * Enqueue a packet with overflow policy.
  */
-static void enqueue_packet(Packet&& pkt) {
+static void enqueue_packet(Packet &&pkt) {
     std::lock_guard lock{g_mutex};
     if (g_cfg.max_queue_length > 0 &&
-        g_queue.size() >= static_cast<size_t>(g_cfg.max_queue_length))
-    {
+        g_queue.size() >= static_cast<size_t>(g_cfg.max_queue_length)) {
         if (g_cfg.overflow == OverflowPolicy::DropOldest) {
             g_queue.pop_front();
         } else { // OverwriteOldest
@@ -95,17 +147,14 @@ void udp_recv_loop() {
     std::array<std::byte, 2048> buf;
     while (g_running.load(std::memory_order_relaxed)) {
         sockaddr_in peer{};
-        socklen_t   len = sizeof(peer);
-        ssize_t     n   = ::recvfrom(g_udp_sock,
-                                     buf.data(), buf.size(),
-                                     0,
-                                     reinterpret_cast<sockaddr*>(&peer),
-                                     &len);
-        if (n <= static_cast<ssize_t>(sizeof(node_t) * 2)) continue;
+        socklen_t len = sizeof(peer);
+        ssize_t n = ::recvfrom(g_udp_sock, buf.data(), buf.size(), 0,
+                               reinterpret_cast<sockaddr *>(&peer), &len);
+        if (n <= static_cast<ssize_t>(sizeof(node_t) * 2))
+            continue;
         Packet pkt;
         std::memcpy(&pkt.src_node, buf.data(), sizeof(pkt.src_node));
-        pkt.payload.assign(buf.begin() + sizeof(pkt.src_node),
-                           buf.begin() + n);
+        pkt.payload.assign(buf.begin() + sizeof(pkt.src_node), buf.begin() + n);
         enqueue_packet(std::move(pkt));
     }
 }
@@ -117,21 +166,18 @@ void tcp_accept_loop() {
     ::listen(g_tcp_listen, 8);
     while (g_running.load(std::memory_order_relaxed)) {
         sockaddr_in peer{};
-        socklen_t   len = sizeof(peer);
-        int client = ::accept(g_tcp_listen,
-                              reinterpret_cast<sockaddr*>(&peer),
-                              &len);
-        if (client < 0) continue;
+        socklen_t len = sizeof(peer);
+        int client = ::accept(g_tcp_listen, reinterpret_cast<sockaddr *>(&peer), &len);
+        if (client < 0)
+            continue;
         std::array<std::byte, 2048> buf;
         while (true) {
-            ssize_t n = ::recv(client,
-                               buf.data(), buf.size(),
-                               0);
-            if (n <= static_cast<ssize_t>(sizeof(node_t))) break;
+            ssize_t n = ::recv(client, buf.data(), buf.size(), 0);
+            if (n <= static_cast<ssize_t>(sizeof(node_t)))
+                break;
             Packet pkt;
             std::memcpy(&pkt.src_node, buf.data(), sizeof(pkt.src_node));
-            pkt.payload.assign(buf.begin() + sizeof(pkt.src_node),
-                               buf.begin() + n);
+            pkt.payload.assign(buf.begin() + sizeof(pkt.src_node), buf.begin() + n);
             enqueue_packet(std::move(pkt));
         }
         ::close(client);
@@ -140,24 +186,29 @@ void tcp_accept_loop() {
 
 } // namespace
 
-void init(const Config& cfg) {
+void init(const Config &cfg) {
     g_cfg = cfg;
+    if (g_cfg.node_id == 0) {
+        g_cfg.node_id = derive_node_id();
+    }
 
     // UDP socket setup
     g_udp_sock = ::socket(AF_INET, SOCK_DGRAM, 0);
-    if (g_udp_sock < 0) throw std::system_error(errno, std::generic_category(), "UDP socket");
-    sockaddr_in addr{ .sin_family = AF_INET,
-                      .sin_port   = htons(cfg.port),
-                      .sin_addr   = { .s_addr = htonl(INADDR_ANY) } };
-    if (::bind(g_udp_sock, reinterpret_cast<sockaddr*>(&addr), sizeof(addr)) < 0)
+    if (g_udp_sock < 0)
+        throw std::system_error(errno, std::generic_category(), "UDP socket");
+    sockaddr_in addr{.sin_family = AF_INET,
+                     .sin_port = htons(cfg.port),
+                     .sin_addr = {.s_addr = htonl(INADDR_ANY)}};
+    if (::bind(g_udp_sock, reinterpret_cast<sockaddr *>(&addr), sizeof(addr)) < 0)
         throw std::system_error(errno, std::generic_category(), "UDP bind");
 
     // TCP listen socket
     g_tcp_listen = ::socket(AF_INET, SOCK_STREAM, 0);
-    if (g_tcp_listen < 0) throw std::system_error(errno, std::generic_category(), "TCP socket");
+    if (g_tcp_listen < 0)
+        throw std::system_error(errno, std::generic_category(), "TCP socket");
     int opt = 1;
     ::setsockopt(g_tcp_listen, SOL_SOCKET, SO_REUSEADDR, &opt, sizeof(opt));
-    if (::bind(g_tcp_listen, reinterpret_cast<sockaddr*>(&addr), sizeof(addr)) < 0)
+    if (::bind(g_tcp_listen, reinterpret_cast<sockaddr *>(&addr), sizeof(addr)) < 0)
         throw std::system_error(errno, std::generic_category(), "TCP bind");
 
     // Start I/O threads
@@ -168,82 +219,71 @@ void init(const Config& cfg) {
 
 void shutdown() noexcept {
     g_running.store(false, std::memory_order_relaxed);
-    if (g_udp_sock != -1) { ::close(g_udp_sock);   g_udp_sock = -1; }
-    if (g_tcp_listen != -1) { ::shutdown(g_tcp_listen, SHUT_RDWR); ::close(g_tcp_listen); g_tcp_listen = -1; }
-    if (g_udp_thread.joinable()) g_udp_thread.join();
-    if (g_tcp_thread.joinable()) g_tcp_thread.join();
+    if (g_udp_sock != -1) {
+        ::close(g_udp_sock);
+        g_udp_sock = -1;
+    }
+    if (g_tcp_listen != -1) {
+        ::shutdown(g_tcp_listen, SHUT_RDWR);
+        ::close(g_tcp_listen);
+        g_tcp_listen = -1;
+    }
+    if (g_udp_thread.joinable())
+        g_udp_thread.join();
+    if (g_tcp_thread.joinable())
+        g_tcp_thread.join();
     {
         std::lock_guard lock{g_mutex};
         g_queue.clear();
     }
-    for (auto& [_, r] : g_remotes) {
-        if (r.proto == Protocol::TCP && r.tcp_fd >= 0) ::close(r.tcp_fd);
+    for (auto &[_, r] : g_remotes) {
+        if (r.proto == Protocol::TCP && r.tcp_fd >= 0)
+            ::close(r.tcp_fd);
     }
     g_remotes.clear();
     g_callback = nullptr;
 }
 
-void add_remote(node_t node,
-                const std::string& host,
-                uint16_t port,
-                Protocol proto)
-{
+void add_remote(node_t node, const std::string &host, uint16_t port, Protocol proto) {
     Remote rem{};
     rem.proto = proto;
     rem.addr.sin_family = AF_INET;
-    rem.addr.sin_port   = htons(port);
+    rem.addr.sin_port = htons(port);
     if (::inet_aton(host.c_str(), &rem.addr.sin_addr) == 0)
         throw std::invalid_argument("net_driver: bad host address");
     if (proto == Protocol::TCP) {
         rem.tcp_fd = ::socket(AF_INET, SOCK_STREAM, 0);
         if (rem.tcp_fd < 0 ||
-            ::connect(rem.tcp_fd, reinterpret_cast<sockaddr*>(&rem.addr), sizeof(rem.addr)) != 0)
-        {
-            if (rem.tcp_fd >= 0) ::close(rem.tcp_fd);
+            ::connect(rem.tcp_fd, reinterpret_cast<sockaddr *>(&rem.addr), sizeof(rem.addr)) != 0) {
+            if (rem.tcp_fd >= 0)
+                ::close(rem.tcp_fd);
             throw std::system_error(errno, std::generic_category(), "TCP connect");
         }
     }
     g_remotes[node] = rem;
 }
 
-void set_recv_callback(RecvCallback cb) {
-    g_callback = std::move(cb);
-}
+void set_recv_callback(RecvCallback cb) { g_callback = std::move(cb); }
 
-node_t local_node() noexcept {
-    if (g_cfg.node_id != 0) return g_cfg.node_id;
-    if (g_udp_sock >= 0) {
-        sockaddr_in sa{}; socklen_t len = sizeof(sa);
-        if (::getsockname(g_udp_sock, reinterpret_cast<sockaddr*>(&sa), &len)==0) {
-            node_t id = static_cast<node_t>(ntohl(sa.sin_addr.s_addr) & 0x7fffffff);
-            return id ? id : 1;
-        }
-    }
-    char host[256]{};
-    if (::gethostname(host, sizeof(host)) == 0) {
-        auto h = std::hash<std::string_view>{}(host);
-        node_t id = static_cast<node_t>(h & 0x7fffffff);
-        return id ? id : 1;
-    }
-    return 1;
-}
+node_t local_node() noexcept { return g_cfg.node_id; }
 
 bool send(node_t node, std::span<const std::byte> data) {
     auto it = g_remotes.find(node);
-    if (it == g_remotes.end()) return false;
+    if (it == g_remotes.end())
+        return false;
     auto buf = frame_payload(data);
-    auto& rem = it->second;
+    auto &rem = it->second;
     if (rem.proto == Protocol::TCP && rem.tcp_fd >= 0) {
         return ::send(rem.tcp_fd, buf.data(), buf.size(), 0) == static_cast<ssize_t>(buf.size());
     }
-    return ::sendto(g_udp_sock, buf.data(), buf.size(), 0,
-                    reinterpret_cast<sockaddr*>(&rem.addr), sizeof(rem.addr))
-         == static_cast<ssize_t>(buf.size());
+    return ::sendto(g_udp_sock, buf.data(), buf.size(), 0, reinterpret_cast<sockaddr *>(&rem.addr),
+                    sizeof(rem.addr)) == static_cast<ssize_t>(buf.size());
 }
 
-bool recv(Packet& out) {
+bool recv(Packet &out) {
     std::lock_guard lock{g_mutex};
-    if (g_queue.empty()) return false;
+    if (g_queue.empty())
+        return false;
     out = std::move(g_queue.front());
     g_queue.pop_front();
     return true;

--- a/kernel/net_driver.hpp
+++ b/kernel/net_driver.hpp
@@ -34,8 +34,8 @@ using node_t = int;
  * @brief In‐memory representation of a network packet.
  */
 struct Packet {
-    node_t                 src_node;  ///< Originating node ID
-    std::vector<std::byte> payload;   ///< Raw payload bytes (post‐prefix)
+    node_t src_node;                ///< Originating node ID
+    std::vector<std::byte> payload; ///< Raw payload bytes (post‐prefix)
 };
 
 /**
@@ -73,13 +73,13 @@ enum class Protocol { UDP, TCP };
  * When proto==UDP, send() uses sendto() on the bound UDP socket.
  */
 struct Remote {
-    sockaddr_in addr;     ///< IPv4 socket address of the peer
-    Protocol     proto;   ///< Protocol to use (UDP or TCP)
-    int          tcp_fd{-1}; ///< TCP socket FD (if persistent; optional)
+    sockaddr_in addr; ///< IPv4 socket address of the peer
+    Protocol proto;   ///< Protocol to use (UDP or TCP)
+    int tcp_fd{-1};   ///< TCP socket FD (if persistent; optional)
 };
 
 /** Callback type invoked on packet arrival. */
-using RecvCallback = std::function<void(const Packet&)>;
+using RecvCallback = std::function<void(const Packet &)>;
 
 /**
  * @brief Initialize the network driver.
@@ -91,7 +91,7 @@ using RecvCallback = std::function<void(const Packet&)>;
  * @param cfg Local node configuration.
  * @throws std::system_error on socket/bind errors.
  */
-void init(const Config& cfg);
+void init(const Config &cfg);
 
 /**
  * @brief Register a remote peer for send().
@@ -101,9 +101,7 @@ void init(const Config& cfg);
  * @param port  UDP/TCP port on which peer listens.
  * @param proto Transport protocol to use.
  */
-void add_remote(node_t node,
-                const std::string& host,
-                uint16_t port,
+void add_remote(node_t node, const std::string &host, uint16_t port,
                 Protocol proto = Protocol::UDP);
 
 /**
@@ -126,9 +124,10 @@ void shutdown() noexcept;
 /**
  * @brief Retrieve the local node identifier.
  *
- * Returns cfg.node_id if nonzero; otherwise calls getsockname()
- * on the bound UDP socket, converting the IPv4 address to host‐order.
- * Returns 0 if detection fails.
+ * The node identifier is established during ::init. If ``Config::node_id`` is
+ * zero, the driver hashes the MAC address of the primary network interface, or
+ * its IPv4 address when the MAC cannot be read. A hashed host name is used as a
+ * final fallback. Providing a non-zero ``node_id`` bypasses the detection.
  */
 [[nodiscard]] node_t local_node() noexcept;
 
@@ -154,7 +153,7 @@ void shutdown() noexcept;
  * @param out Packet object to populate.
  * @return true if a packet was dequeued into out, false otherwise.
  */
-[[nodiscard]] bool recv(Packet& out);
+[[nodiscard]] bool recv(Packet &out);
 
 /**
  * @brief Clear all pending packets across every node.

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -321,6 +321,19 @@ target_link_libraries(minix_test_net_driver_tcp PRIVATE Threads::Threads)
 add_test(NAME minix_test_net_driver_tcp COMMAND minix_test_net_driver_tcp)
 
 # -----------------------------------------------------------------------------
+# minix_test_net_driver_autodetect
+# -----------------------------------------------------------------------------
+add_executable(minix_test_net_driver_autodetect
+  test_net_driver_autodetect.cpp
+  ${CMAKE_SOURCE_DIR}/kernel/net_driver.cpp
+)
+target_include_directories(minix_test_net_driver_autodetect PUBLIC
+  ${CMAKE_SOURCE_DIR}/kernel
+)
+target_link_libraries(minix_test_net_driver_autodetect PRIVATE Threads::Threads)
+add_test(NAME minix_test_net_driver_autodetect COMMAND minix_test_net_driver_autodetect)
+
+# -----------------------------------------------------------------------------
 # Crypto subdirectory
 # -----------------------------------------------------------------------------
 add_subdirectory(crypto)

--- a/tests/test_net_driver_autodetect.cpp
+++ b/tests/test_net_driver_autodetect.cpp
@@ -1,0 +1,16 @@
+/**
+ * @file test_net_driver_autodetect.cpp
+ * @brief Verify automatic node ID detection when none is provided.
+ */
+
+#include "../kernel/net_driver.hpp"
+
+#include <cassert>
+
+int main() {
+    constexpr std::uint16_t PORT = 14999;
+    net::init({0, PORT});
+    assert(net::local_node() != 0);
+    net::shutdown();
+    return 0;
+}


### PR DESCRIPTION
## Summary
- derive node IDs from the primary interface MAC or IP
- cache node ID in `net::init`
- document auto-detection in networking docs
- update lattice IPC docs with detection order
- add unit test for node ID auto-detection

## Testing
- `cmake --build build` *(fails: no template named 'expected' in namespace 'std')*

------
https://chatgpt.com/codex/tasks/task_e_6850b26f9eb883319b267835148c5aef