### PR TITLE
Document UDP networking driver

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,4 @@ docs/doxygen/
 /\.cache/
 *.DS_Store
 
+docs/sphinx/html/


### PR DESCRIPTION
## Summary
- document UDP network driver initialization, registration, and polling
- ignore generated HTML docs

## Testing
- `doxygen Doxyfile`
- `sphinx-build -b html docs/sphinx docs/sphinx/html`
- `make check` *(fails: No rule to make target 'obj/fsck.o')*

------
https://chatgpt.com/codex/tasks/task_e_6850b2bec4108331bcca98bee94e7a4b

## Summary by Sourcery

Document the UDP network driver setup and update ignore rules for generated documentation

Documentation:
- Add Doxygen and Sphinx documentation for UDP network driver initialization, registration, and polling

Chores:
- Update .gitignore to ignore generated HTML documentation