### PR TITLE
Implement blocking IPC receive

### DIFF
--- a/docs/sphinx/lattice_ipc.rst
+++ b/docs/sphinx/lattice_ipc.rst
@@ -102,10 +102,11 @@ Channels live in a DAG managed by `lattice::Graph`:
 - `lattice_connect(src, dst, node_id)` → OK / error  
 - `lattice_listen(pid)`  
 - `lattice_send(src, dst, msg, flags)`  
-- `lattice_recv(pid, &msg, flags)`  
-- `lattice_channel_add_dep(parent, child)`  
-- `lattice_channel_submit(chan)`  
-- `lattice::poll_network()` integrates remote packets  
+- `lattice_recv(pid, &msg, flags)`
+- `lattice_channel_add_dep(parent, child)`
+- `lattice_channel_submit(chan)`
+- `lattice::poll_network()` integrates remote packets
+- Blocking `lattice_recv` waits up to 100ms for a message when `IpcFlags::NONE` is used
 
 Remote Channel Setup
 --------------------

--- a/docs/sphinx/scheduler.rst
+++ b/docs/sphinx/scheduler.rst
@@ -24,7 +24,9 @@ receiver is already waiting. On such a fast path the scheduler invokes
 :cpp:func:`sched::Scheduler::yield_to` so the receiver handles the message
 without an extra context switch. Both send and
 :cpp:func:`lattice::lattice_recv` accept :cpp:type:`lattice::IpcFlags` with the
-``NONBLOCK`` option to return immediately when no delivery is possible.
+``NONBLOCK`` option to return immediately when no delivery is possible. Without
+that flag the scheduler blocks the caller until a message arrives or a 100 ms
+timeout elapses.
 
 .. doxygenfunction:: sched::Scheduler::yield_to
    :project: XINIM

--- a/kernel/lattice_ipc.cpp
+++ b/kernel/lattice_ipc.cpp
@@ -15,9 +15,12 @@
 #include "schedule.hpp"
 
 #include <array>
+#include <chrono>
+#include <condition_variable>
 #include <cstddef>
 #include <cstring>
 #include <deque>
+#include <mutex>
 #include <span>
 #include <tuple>
 #include <unordered_map>
@@ -47,6 +50,11 @@ namespace lattice {
  *============================================================================*/
 
 Graph g_graph; ///< Singleton IPC graph
+
+/** Mutex guarding IPC wait state. */
+static std::mutex g_ipc_mutex;
+/** Condition variable to wake waiting receivers. */
+static std::condition_variable g_ipc_cv;
 
 /*==============================================================================
  *                            Graph Implementation
@@ -146,9 +154,12 @@ int lattice_send(xinim::pid_t src, xinim::pid_t dst, const message &msg, IpcFlag
 
     // Local direct handoff
     if (g_graph.is_listening(dst)) {
+        std::lock_guard lk(g_ipc_mutex);
         g_graph.inbox_[dst] = msg;
         g_graph.set_listening(dst, false);
-        schedule::scheduler.yield_to(dst);
+        sched::scheduler.unblock(dst);
+        g_ipc_cv.notify_all();
+        sched::scheduler.yield_to(dst);
         return OK;
     }
 
@@ -161,6 +172,11 @@ int lattice_send(xinim::pid_t src, xinim::pid_t dst, const message &msg, IpcFlag
     message copy = msg;
     xor_cipher({reinterpret_cast<std::byte *>(&copy), sizeof(copy)}, ch->secret);
     ch->queue.push_back(std::move(copy));
+    if (g_graph.is_listening(dst)) {
+        g_graph.set_listening(dst, false);
+        sched::scheduler.unblock(dst);
+        g_ipc_cv.notify_all();
+    }
     return OK;
 }
 
@@ -197,9 +213,39 @@ int lattice_recv(xinim::pid_t pid, message *out, IpcFlags flags) {
         return static_cast<int>(ErrorCode::E_NO_MESSAGE);
     }
 
-    // 4) Blocking: register listener and block
+    // 4) Blocking: register listener and wait with timeout
+    using namespace std::chrono_literals;
+    std::unique_lock lk(g_ipc_mutex);
     lattice_listen(pid);
-    return static_cast<int>(ErrorCode::E_NO_MESSAGE);
+    sched::scheduler.block_on(pid, -1);
+    auto deadline = std::chrono::steady_clock::now() + 100ms;
+    for (;;) {
+        auto ib2 = g_graph.inbox_.find(pid);
+        if (ib2 != g_graph.inbox_.end()) {
+            *out = ib2->second;
+            g_graph.inbox_.erase(ib2);
+            sched::scheduler.unblock(pid);
+            g_graph.set_listening(pid, false);
+            return OK;
+        }
+        for (auto &[key, ch] : g_graph.edges_) {
+            if (std::get<1>(key) == pid && std::get<2>(key) == net::local_node() &&
+                !ch.queue.empty()) {
+                message copy = std::move(ch.queue.front());
+                ch.queue.pop_front();
+                xor_cipher({reinterpret_cast<std::byte *>(&copy), sizeof(copy)}, ch.secret);
+                *out = std::move(copy);
+                sched::scheduler.unblock(pid);
+                g_graph.set_listening(pid, false);
+                return OK;
+            }
+        }
+        if (g_ipc_cv.wait_until(lk, deadline) == std::cv_status::timeout) {
+            sched::scheduler.unblock(pid);
+            g_graph.set_listening(pid, false);
+            return static_cast<int>(ErrorCode::E_NO_MESSAGE);
+        }
+    }
 }
 
 /**
@@ -225,6 +271,11 @@ void poll_network() {
         }
         xor_cipher({reinterpret_cast<std::byte *>(&msg), sizeof(msg)}, ch->secret);
         ch->queue.push_back(std::move(msg));
+        if (g_graph.is_listening(dst)) {
+            g_graph.set_listening(dst, false);
+            sched::scheduler.unblock(dst);
+            g_ipc_cv.notify_all();
+        }
     }
 }
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -137,6 +137,7 @@ add_test(NAME minix_test_service_contract COMMAND minix_test_service_contract)
 # Lattice IPC tests
 # -----------------------------------------------------------------------------
 add_lattice_test(minix_test_lattice_send_recv test_lattice_send_recv.cpp)
+add_lattice_test(minix_test_lattice_blocking test_lattice_blocking.cpp)
 
 # -----------------------------------------------------------------------------
 # minix_test_lattice_ipc
@@ -217,17 +218,6 @@ target_include_directories(minix_test_net_driver_loopback PUBLIC
 )
 target_link_libraries(minix_test_net_driver_loopback PRIVATE Threads::Threads)
 add_test(NAME minix_test_net_driver_loopback COMMAND minix_test_net_driver_loopback)
-add_lattice_test(minix_test_lattice                  test_lattice.cpp)
-add_lattice_test(minix_test_lattice_send_recv       test_lattice_send_recv.cpp)
-add_lattice_test(minix_test_lattice_send_error      test_lattice_send_error.cpp)
-add_lattice_test(minix_test_lattice_ipc             test_lattice_ipc.cpp)
-add_lattice_test(minix_test_lattice_network         test_lattice_network.cpp)
-add_lattice_test(minix_test_lattice_network_encrypted
-                                         test_lattice_network_encrypted.cpp)
-add_lattice_test(minix_test_net_two_node            test_net_two_node.cpp)
-add_lattice_test(minix_test_net_driver              test_net_driver.cpp)
-add_lattice_test(minix_test_net_driver_overflow     test_net_driver_overflow.cpp)
-add_lattice_test(minix_test_net_driver_tcp          test_net_driver_tcp.cpp)
 
 # -----------------------------------------------------------------------------
 # Crypto library

--- a/tests/test_lattice_blocking.cpp
+++ b/tests/test_lattice_blocking.cpp
@@ -1,0 +1,52 @@
+/**
+ * @file test_lattice_blocking.cpp
+ * @brief Regression tests for blocking IPC semantics.
+ */
+
+#include "../h/error.hpp"
+#include "../kernel/lattice_ipc.hpp"
+#include "../kernel/schedule.hpp"
+
+#include <cassert>
+#include <chrono>
+#include <thread>
+
+using namespace lattice;
+using namespace std::chrono_literals;
+
+/**
+ * @brief Thread entry waiting for a message.
+ *
+ * The function simply calls lattice_recv and stores the result code.
+ */
+static void receiver_task(int *rc, message *out) { *rc = lattice_recv(2, out); }
+
+int main() {
+    using sched::scheduler;
+
+    g_graph = Graph{};
+    scheduler = sched::Scheduler{};
+
+    scheduler.enqueue(1);
+    scheduler.enqueue(2);
+    scheduler.preempt(); // current = 1
+
+    lattice_connect(1, 2);
+
+    message out{};
+    int result = 0;
+    std::thread receiver(receiver_task, &result, &out);
+    std::this_thread::sleep_for(10ms);
+    assert(scheduler.is_blocked(2));
+
+    message msg{};
+    msg.m_type = 77;
+    assert(lattice_send(1, 2, msg) == OK);
+
+    receiver.join();
+    assert(result == OK);
+    assert(out.m_type == 77);
+    assert(!scheduler.is_blocked(2));
+
+    return 0;
+}


### PR DESCRIPTION
## Summary
- extend lattice_recv with scheduler-based blocking
- wake waiting receivers in lattice_send and poll_network
- document new blocking behavior
- add regression test for blocking send/receive

## Testing
- `cmake -B build -DCMAKE_BUILD_TYPE=Debug`
- `cmake --build build` *(fails: conflicting stdio declarations)*

------
https://chatgpt.com/codex/tasks/task_e_6850f8773cb8833186b274f5b02cda9b