### PR TITLE
Prune unused PQ crypto helper

### DIFF
--- a/include/pqcrypto.hpp
+++ b/include/pqcrypto.hpp
@@ -19,7 +19,7 @@ struct KeyPair {
  * @brief Generate a new lattice-based key pair.
  *
  * The generated keys use the Kyber512 parameter set and are compatible
- * with the establish and compute routines provided by this header.
+ * with the compute routines provided by this header.
  *
  * @return Newly created key pair containing Kyber public and private data.
  */

--- a/kernel/pqcrypto.cpp
+++ b/kernel/pqcrypto.cpp
@@ -28,32 +28,6 @@ KeyPair generate_keypair() noexcept {
 }
 
 /**
- * @brief Establish a shared secret via Kyber encapsulation.
- *
- * The routine encapsulates to @p peer using its public key and decapsulates
- * with the peer's private key to yield a symmetric secret. The @p local key
- * pair is reserved for future protocol extensions and is currently unused.
- *
- * @param local Local key pair (unused).
- * @param peer  Remote key pair providing the public component.
- * @return Derived shared secret.
- */
-std::array<std::uint8_t, pqcrystals_kyber512_BYTES> establish_secret(const KeyPair &local,
-                                                                     const KeyPair &peer) noexcept {
-    (void)local; // local keypair currently unused
-    std::array<std::uint8_t, pqcrystals_kyber512_BYTES> secret{};
-    std::array<std::uint8_t, pqcrystals_kyber512_CIPHERTEXTBYTES> ct{};
-
-    // Encapsulate to peer.public_key → ciphertext + shared secret
-    pqcrystals_kyber512_ref_enc(ct.data(), secret.data(), peer.public_key.data());
-
-    // Decapsulate using peer.private_key to confirm shared secret
-    pqcrystals_kyber512_ref_dec(secret.data(), ct.data(), peer.private_key.data());
-
-    return secret;
-}
-
-/**
  * @brief Derive a shared secret given two key pairs.
  *
  * The helper validates the provided key sizes before forwarding to the


### PR DESCRIPTION
## Summary
- drop unused `establish_secret` implementation
- adjust pqcrypto docs after removal
- run clang-format for consistency

## Testing
- `cmake -B build -DBUILD_SYSTEM=OFF` *(fails: add_executable cannot create target "minix_test_net_driver_overflow" because another target with the same name already exists)*

------
https://chatgpt.com/codex/tasks/task_e_6850f8787cd88331a18b66b9a64d8be2