### PR TITLE
Fix lattice IPC build errors

### DIFF
--- a/kernel/lattice_ipc.hpp
+++ b/kernel/lattice_ipc.hpp
@@ -10,6 +10,7 @@
 #include "octonion_math.hpp"
 #include "pqcrypto.hpp"
 #include "proc.hpp"
+#include <deque>
 #include <map>
 #include <unordered_map>
 #include <vector>
@@ -42,8 +43,11 @@ struct Channel {
      * @brief Identifier of the remote node or 0 for local delivery.
      */
     net::node_t node_id{0};
-    std::vector<message> queue; //!< Pending messages encrypted with @c secret
-    OctonionToken secret;       //!< Capability derived from PQ secret
+    /**
+     * @brief FIFO of pending messages encrypted with @c secret.
+     */
+    std::deque<message> queue;
+    OctonionToken secret; //!< Capability derived from PQ secret
 };
 
 /**


### PR DESCRIPTION
## Summary
- include `error.hpp` after standard headers
- correctly reference `OctonionToken` in `xor_cipher`
- store queued messages in a `std::deque`

## Testing
- `cmake --build build --target minix_test_lattice_send_recv`

------
https://chatgpt.com/codex/tasks/task_e_6850fcb9e96c8331bd24396a876ead7d

## Summary by Sourcery

Fix build errors in lattice IPC and improve message queue handling

Bug Fixes:
- Qualify OctonionToken with lattice namespace and correct mask size in xor_cipher
- Fix channel secret access from ch->secret to ch.secret in lattice_recv

Enhancements:
- Replace std::vector with std::deque for FIFO message queue in Channel

Build:
- Move error.hpp include after standard headers and add <cerrno> to resolve missing symbols