### PR TITLE
Persist node id

### DIFF
--- a/docs/sphinx/networking.rst
+++ b/docs/sphinx/networking.rst
@@ -62,7 +62,8 @@ Otherwise the driver calls ``getifaddrs()`` to list network interfaces and
 hashes the first active device that is not a loopback interface. Should this
 process fail, the driver falls back to hashing the local host name. The
 computed identifier is non-zero and remains constant for the lifetime of the
-process.
+process. When the identifier is computed it is written to ``/etc/xinim/node_id``
+so that subsequent invocations of :cpp:func:`net::init` reuse the same value.
 Registering Remote Peers
 ------------------------
 A node communicates only with peers explicitly added using

--- a/kernel/net_driver.cpp
+++ b/kernel/net_driver.cpp
@@ -26,6 +26,8 @@
 #include <atomic>
 #include <cstring>
 #include <deque>
+#include <filesystem>
+#include <fstream>
 #include <mutex>
 #include <span>
 #include <system_error>
@@ -38,6 +40,8 @@ namespace {
 
 /** Active driver configuration. */
 static Config g_cfg{};
+/** Path storing persistent node identifier. */
+static constexpr char NODE_ID_FILE[] = "/etc/xinim/node_id";
 /** UDP socket descriptor. */
 static int g_udp_sock = -1;
 /** TCP listening socket descriptor. */
@@ -148,6 +152,12 @@ static void tcp_accept_loop() {
 
 void init(const Config &cfg) {
     g_cfg = cfg;
+    if (g_cfg.node_id == 0) {
+        std::ifstream idin{NODE_ID_FILE};
+        if (idin) {
+            idin >> g_cfg.node_id;
+        }
+    }
 
     // Create UDP socket
     g_udp_sock = ::socket(AF_INET, SOCK_DGRAM, 0);
@@ -238,9 +248,18 @@ void add_remote(node_t node, const std::string &host, uint16_t port, Protocol pr
 void set_recv_callback(RecvCallback cb) { g_callback = std::move(cb); }
 
 node_t local_node() noexcept {
-    // 1) user-supplied identifier
+    // 1) user-supplied or loaded identifier
     if (g_cfg.node_id != 0) {
         return g_cfg.node_id;
+    }
+    {
+        std::ifstream idin{NODE_ID_FILE};
+        if (idin) {
+            idin >> g_cfg.node_id;
+            if (g_cfg.node_id != 0) {
+                return g_cfg.node_id;
+            }
+        }
     }
     // 2) derive from active network interface
     ifaddrs *ifa = nullptr;
@@ -272,6 +291,12 @@ node_t local_node() noexcept {
         }
         ::freeifaddrs(ifa);
         if (result != 0) {
+            g_cfg.node_id = result;
+            std::filesystem::create_directories("/etc/xinim");
+            std::ofstream out{NODE_ID_FILE, std::ios::trunc};
+            if (out) {
+                out << result;
+            }
             return result;
         }
     }
@@ -279,7 +304,13 @@ node_t local_node() noexcept {
     char host[256]{};
     if (::gethostname(host, sizeof(host)) == 0) {
         auto h = std::hash<std::string_view>{}(host) & 0x7fffffff;
-        return static_cast<node_t>(h);
+        g_cfg.node_id = static_cast<node_t>(h);
+        std::filesystem::create_directories("/etc/xinim");
+        std::ofstream out{NODE_ID_FILE, std::ios::trunc};
+        if (out) {
+            out << g_cfg.node_id;
+        }
+        return g_cfg.node_id;
     }
     return 0;
 }

--- a/kernel/net_driver.cpp
+++ b/kernel/net_driver.cpp
@@ -155,7 +155,10 @@ void init(const Config &cfg) {
     if (g_cfg.node_id == 0) {
         std::ifstream idin{NODE_ID_FILE};
         if (idin) {
-            idin >> g_cfg.node_id;
+            node_t file_node_id = 0;
+            if (idin >> file_node_id) {
+                g_cfg.node_id = file_node_id;
+            }
         }
     }
 

--- a/kernel/net_driver.hpp
+++ b/kernel/net_driver.hpp
@@ -57,10 +57,10 @@ enum class OverflowPolicy {
 /**
  * @brief Network driver configuration for ::init.
  *
- * Setting ``node_id`` to ``0`` instructs the driver to derive a unique
- * identifier by hashing the primary network interface.  A non-zero value
- * overrides the automatic detection and is returned by
- * ::local_node().
+ * Setting ``node_id`` to ``0`` instructs the driver to reuse the identifier
+ * stored in ``/etc/xinim/node_id`` when available or derive a unique value by
+ * hashing the primary network interface.  A non-zero value overrides the
+ * automatic detection and is returned by ::local_node().
  */
 struct Config {
     node_t node_id;               ///< Local node identifier
@@ -131,10 +131,12 @@ void shutdown() noexcept;
  * or an automatically derived identifier when ``Config::node_id`` equals
  * zero. ``0`` is returned if initialization has not yet occurred.
  *
- * When no identifier is configured the driver enumerates active network
- * interfaces via ``getifaddrs(3)`` and hashes the first non-loopback MAC or
- * IPv4 address found. If detection fails the hostname is hashed as a
- * deterministic fallback.
+ * When no identifier is configured the driver loads ``/etc/xinim/node_id`` if
+ * present.  Otherwise it enumerates active network interfaces via
+ * ``getifaddrs(3)`` and hashes the first non-loopback MAC or IPv4 address
+ * found. If detection succeeds the identifier is saved back to the file so
+ * future runs reuse it. Should detection fail, the hostname is hashed and also
+ * written to the file.
 
  */
 [[nodiscard]] node_t local_node() noexcept;

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -233,6 +233,19 @@ target_link_libraries(minix_test_net_driver_concurrency PRIVATE Threads::Threads
 add_test(NAME minix_test_net_driver_concurrency COMMAND minix_test_net_driver_concurrency)
 
 # -----------------------------------------------------------------------------
+# minix_test_net_driver_persistent_id
+# -----------------------------------------------------------------------------
+add_executable(minix_test_net_driver_persistent_id
+  test_net_driver_persistent_id.cpp
+  ${CMAKE_SOURCE_DIR}/kernel/net_driver.cpp
+)
+target_include_directories(minix_test_net_driver_persistent_id PUBLIC
+  ${CMAKE_SOURCE_DIR}/kernel
+)
+target_link_libraries(minix_test_net_driver_persistent_id PRIVATE Threads::Threads)
+add_test(NAME minix_test_net_driver_persistent_id COMMAND minix_test_net_driver_persistent_id)
+
+# -----------------------------------------------------------------------------
 # Crypto library
 # -----------------------------------------------------------------------------
 add_subdirectory(crypto)

--- a/tests/test_net_driver_persistent_id.cpp
+++ b/tests/test_net_driver_persistent_id.cpp
@@ -1,0 +1,26 @@
+/**
+ * @file test_net_driver_persistent_id.cpp
+ * @brief Ensure local node identifier persists across driver runs.
+ */
+
+#include "../kernel/net_driver.hpp"
+
+#include <cassert>
+#include <unistd.h>
+
+int main() {
+    ::unlink("/etc/xinim/node_id");
+
+    net::init(net::Config{0, 16000});
+    const auto first = net::local_node();
+    assert(first != 0);
+    net::shutdown();
+
+    net::init(net::Config{0, 16000});
+    const auto second = net::local_node();
+    assert(first == second);
+    net::shutdown();
+
+    ::unlink("/etc/xinim/node_id");
+    return 0;
+}


### PR DESCRIPTION
## Summary
- persist automatically derived node id under `/etc/xinim/node_id`
- reuse saved identifier on startup
- regression test to ensure id remains constant
- document persistent id in the Networking Driver docs

## Testing
- `cmake -B build -DBUILD_SYSTEM=OFF`
- `cmake --build build -- -j$(nproc)`
- `ctest --test-dir build --output-on-failure` *(fails: Unable to find executable)*

------
https://chatgpt.com/codex/tasks/task_e_685120ef307c8331932aba372d551177

## Summary by Sourcery

Persist and reuse the network driver’s node identifier across runs by loading from and saving to /etc/xinim/node_id, add a regression test for id stability, and update driver documentation accordingly

New Features:
- Persist node identifier across driver runs via /etc/xinim/node_id

Enhancements:
- Load saved node identifier on initialization and fallback to deriving from network interfaces or hostname
- Save newly derived identifier to disk for future reuse

Documentation:
- Document persistent node identifier behavior in networking driver documentation

Tests:
- Add regression test to verify node identifier remains constant across driver restarts