### PR TITLE
Add dev tool setup guide

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -98,3 +98,29 @@ A helper script `tools/modernize_cpp17.sh` automates renaming sources to
 `.cpppp` and `.hpp`, updates include paths and drops a temporary modernization
 header into each file. Invoke it from the repository root when ready to move
 the codebase fully to C++23.
+
+## Development Tools
+
+Several optional utilities generate code metrics and perform static analysis.
+Install them using the package manager and Python's package installer:
+
+```sh
+sudo apt-get install -y cloc cppcheck cscope
+python3 -m pip install --user lizard
+```
+
+### Running the Tools
+
+Create a directory called `logs/` at the project root and store all reports
+there:
+
+```sh
+mkdir -p logs
+cloc . > logs/cloc.log
+lizard -o logs/lizard.log .
+cppcheck --enable=all --std=c++23 --output-file=logs/cppcheck.log .
+cscope -Rb -q
+```
+
+`cscope` writes its database to `cscope.out`. The other commands generate log
+files in the `logs/` directory for later review.

--- a/setup.sh
+++ b/setup.sh
@@ -51,7 +51,8 @@ sudo apt-get install -y --no-install-recommends \
     qemu-utils \
     qemu-user \
     tmux \
-    cloc
+    cloc \
+    cscope
 
 # Ensure ack is installed for convenient searching
 if ! command -v ack >/dev/null 2>&1; then
@@ -63,6 +64,9 @@ fi
 
 # Install optional ack helpers for Python and Node
 # ack helpers are optional; skip if pip or npm are restricted
+
+# Install lizard via pip for complexity metrics
+python3 -m pip install --user lizard
 
 # Attempt to install libfuzzer development package if available.
 sudo apt-get install -y --no-install-recommends libfuzzer-dev || true


### PR DESCRIPTION
## Summary
- document optional development tools and logging in `BUILDING.md`
- install `cscope` and Python's `lizard` in `setup.sh`

## Testing
- `cmake -B build -DBUILD_SYSTEM=OFF`
- `cmake --build build -- -j$(nproc)` *(fails: 'printf' has not been declared)*

------
https://chatgpt.com/codex/tasks/task_e_6851a099219c83318ec658799acd411f