### PR TITLE
Add modern FS header implementations

### DIFF
--- a/include/minix/fs/buffer.hpp
+++ b/include/minix/fs/buffer.hpp
@@ -1,0 +1,278 @@
+#pragma once
+
+/**
+ * @file buffer.hpp
+ * @brief C++23 modernized buffer cache with enhanced memory safety
+ */
+
+#include "const.hpp"
+#include <array>
+#include <atomic>
+#include <concepts>
+#include <expected>
+#include <memory>
+#include <span>
+#include <string_view>
+#include <type_traits>
+#include <variant>
+
+namespace minix::fs {
+
+class BufferManager;
+class DeviceManager;
+
+template <typename T>
+concept BufferDataType = requires {
+    sizeof(T) <= DefaultFsConstants::kBlockSize;
+    std::is_trivially_copyable_v<T>;
+    std::is_standard_layout_v<T>;
+};
+
+enum class BufferError {
+    NoFreeBuffers,
+    InvalidDevice,
+    DiskError,
+    InvalidBlockNumber,
+    BufferInUse,
+    CorruptedData
+};
+
+/**
+ * @class BufferData
+ * @brief Type-safe buffer data union
+ */
+class BufferData {
+  private:
+    alignas(std::max_align_t) std::array<std::byte, DefaultFsConstants::kBlockSize> raw_data_{};
+
+  public:
+    template <BufferDataType T> [[nodiscard]] auto as() -> std::span<T> {
+        static_assert(DefaultFsConstants::kBlockSize % sizeof(T) == 0,
+                      "Buffer size must be divisible by data type size");
+        return std::span<T>{reinterpret_cast<T *>(raw_data_.data()),
+                            DefaultFsConstants::kBlockSize / sizeof(T)};
+    }
+    template <BufferDataType T> [[nodiscard]] auto as() const -> std::span<const T> {
+        static_assert(DefaultFsConstants::kBlockSize % sizeof(T) == 0,
+                      "Buffer size must be divisible by data type size");
+        return std::span<const T>{reinterpret_cast<const T *>(raw_data_.data()),
+                                  DefaultFsConstants::kBlockSize / sizeof(T)};
+    }
+
+    [[nodiscard]] auto bytes() -> std::span<std::byte> { return std::span{raw_data_}; }
+
+    [[nodiscard]] auto bytes() const -> std::span<const std::byte> { return std::span{raw_data_}; }
+
+    void zero() noexcept { std::fill(raw_data_.begin(), raw_data_.end(), std::byte{0}); }
+};
+
+/**
+ * @class BufferHandle
+ * @brief RAII buffer handle with automatic lifetime management
+ */
+class BufferHandle {
+  private:
+    class Buffer *buffer_;
+    bool owned_;
+
+  public:
+    explicit BufferHandle(Buffer *buf, bool owned = true) : buffer_{buf}, owned_{owned} {}
+    ~BufferHandle();
+
+    BufferHandle(const BufferHandle &) = delete;
+    BufferHandle &operator=(const BufferHandle &) = delete;
+
+    BufferHandle(BufferHandle &&other) noexcept
+        : buffer_{std::exchange(other.buffer_, nullptr)},
+          owned_{std::exchange(other.owned_, false)} {}
+
+    BufferHandle &operator=(BufferHandle &&other) noexcept {
+        if (this != &other) {
+            if (owned_ && buffer_) {
+                release();
+            }
+            buffer_ = std::exchange(other.buffer_, nullptr);
+            owned_ = std::exchange(other.owned_, false);
+        }
+        return *this;
+    }
+
+    [[nodiscard]] auto get() -> Buffer * { return buffer_; }
+    [[nodiscard]] auto get() const -> const Buffer * { return buffer_; }
+
+    [[nodiscard]] auto operator->() -> Buffer * { return buffer_; }
+    [[nodiscard]] auto operator->() const -> const Buffer * { return buffer_; }
+
+    [[nodiscard]] auto operator*() -> Buffer & { return *buffer_; }
+    [[nodiscard]] auto operator*() const -> const Buffer & { return *buffer_; }
+
+    [[nodiscard]] bool valid() const noexcept { return buffer_ != nullptr; }
+    explicit operator bool() const noexcept { return valid(); }
+
+    void release();
+};
+
+/**
+ * @class Buffer
+ * @brief Modern buffer with enhanced type safety and atomic operations
+ */
+class Buffer {
+  private:
+    friend class BufferManager;
+    friend class BufferHandle;
+
+    BufferData data_{};
+    std::atomic<std::uint32_t> reference_count_{0};
+    std::atomic<BlockType> block_type_{BlockType::FullDataBlock};
+    std::atomic<bool> dirty_{false};
+
+    Buffer *next_{nullptr};
+    Buffer *prev_{nullptr};
+    Buffer *hash_next_{nullptr};
+
+    block_nr block_number_{kNoBlock};
+    dev_nr device_{kNoDev};
+
+  public:
+    template <BufferDataType T> [[nodiscard]] auto data_as() -> std::span<T> {
+        return data_.template as<T>();
+    }
+
+    template <BufferDataType T> [[nodiscard]] auto data_as() const -> std::span<const T> {
+        return data_.template as<T>();
+    }
+
+    [[nodiscard]] auto raw_data() -> std::span<std::byte> { return data_.bytes(); }
+
+    [[nodiscard]] auto raw_data() const -> std::span<const std::byte> { return data_.bytes(); }
+
+    [[nodiscard]] auto block_number() const noexcept -> block_nr { return block_number_; }
+
+    [[nodiscard]] auto device() const noexcept -> dev_nr { return device_; }
+
+    [[nodiscard]] bool is_dirty() const noexcept { return dirty_.load(std::memory_order_acquire); }
+
+    void mark_dirty() noexcept { dirty_.store(true, std::memory_order_release); }
+
+    void mark_clean() noexcept { dirty_.store(false, std::memory_order_release); }
+
+    [[nodiscard]] auto get_block_type() const noexcept -> BlockType {
+        return block_type_.load(std::memory_order_acquire);
+    }
+
+    void set_block_type(BlockType type) noexcept {
+        block_type_.store(type, std::memory_order_release);
+    }
+
+    [[nodiscard]] auto reference_count() const noexcept -> std::uint32_t {
+        return reference_count_.load(std::memory_order_acquire);
+    }
+
+    void zero_data() noexcept {
+        data_.zero();
+        mark_dirty();
+    }
+
+  private:
+    void increment_references() noexcept {
+        reference_count_.fetch_add(1, std::memory_order_acq_rel);
+    }
+
+    void decrement_references() noexcept {
+        reference_count_.fetch_sub(1, std::memory_order_acq_rel);
+    }
+};
+
+/**
+ * @class BufferPool
+ * @brief Type-safe buffer pool with enhanced resource management
+ */
+class BufferPool {
+  private:
+    static constexpr std::size_t kPoolSize = DefaultFsConstants::kNrBufs;
+    static constexpr std::size_t kHashSize = DefaultFsConstants::kNrBufHash;
+
+    std::array<Buffer, kPoolSize> buffers_{};
+    std::array<Buffer *, kHashSize> hash_table_{};
+
+    Buffer *lru_front_{nullptr};
+    Buffer *lru_rear_{nullptr};
+
+    std::atomic<std::size_t> buffers_in_use_{0};
+
+    [[nodiscard]] static auto hash_block(block_nr block) noexcept -> std::size_t {
+        return std::to_underlying(block) & (kHashSize - 1);
+    }
+
+    void move_to_front(Buffer *buffer) noexcept;
+    void move_to_rear(Buffer *buffer) noexcept;
+    void remove_from_lru(Buffer *buffer) noexcept;
+
+    void add_to_hash(Buffer *buffer) noexcept;
+    void remove_from_hash(Buffer *buffer) noexcept;
+    [[nodiscard]] auto find_in_hash(dev_nr device, block_nr block) const noexcept -> Buffer *;
+
+  public:
+    BufferPool();
+    ~BufferPool() = default;
+
+    BufferPool(const BufferPool &) = delete;
+    BufferPool &operator=(const BufferPool &) = delete;
+    BufferPool(BufferPool &&) = default;
+    BufferPool &operator=(BufferPool &&) = default;
+
+    [[nodiscard]] auto get_buffer(dev_nr device, block_nr block, IoMode mode)
+        -> std::expected<BufferHandle, BufferError>;
+
+    void put_buffer(Buffer *buffer, BlockType type) noexcept;
+
+    void invalidate_device(dev_nr device) noexcept;
+
+    [[nodiscard]] auto flush_dirty_buffers() -> std::size_t;
+
+    [[nodiscard]] auto buffers_in_use() const noexcept -> std::size_t {
+        return buffers_in_use_.load(std::memory_order_acquire);
+    }
+
+    [[nodiscard]] auto available_buffers() const noexcept -> std::size_t {
+        return kPoolSize - buffers_in_use();
+    }
+
+    [[nodiscard]] auto begin() noexcept -> Buffer * { return buffers_.data(); }
+    [[nodiscard]] auto end() noexcept -> Buffer * { return buffers_.data() + kPoolSize; }
+    [[nodiscard]] auto begin() const noexcept -> const Buffer * { return buffers_.data(); }
+    [[nodiscard]] auto end() const noexcept -> const Buffer * {
+        return buffers_.data() + kPoolSize;
+    }
+};
+
+/**
+ * @class BufferGuard
+ * @brief RAII guard for automatic buffer release
+ */
+class BufferGuard {
+  private:
+    BufferHandle handle_;
+    BlockType block_type_;
+
+  public:
+    BufferGuard(BufferHandle handle, BlockType type)
+        : handle_{std::move(handle)}, block_type_{type} {}
+
+    ~BufferGuard() {
+        if (handle_.valid()) {
+            release_buffer(std::move(handle_), block_type_);
+        }
+    }
+
+    [[nodiscard]] auto get() -> Buffer * { return handle_.get(); }
+    [[nodiscard]] auto operator->() -> Buffer * { return handle_.get(); }
+    [[nodiscard]] auto operator*() -> Buffer & { return *handle_.get(); }
+
+    [[nodiscard]] auto release() -> BufferHandle { return std::move(handle_); }
+
+  private:
+    static void release_buffer(BufferHandle handle, BlockType type);
+};
+
+} // namespace minix::fs

--- a/include/minix/fs/const.hpp
+++ b/include/minix/fs/const.hpp
@@ -1,0 +1,214 @@
+#pragma once
+
+/**
+ * @file const.hpp
+ * @brief C++23 modernized file system constants with enhanced type safety
+ */
+
+#include <concepts>
+#include <cstddef>
+#include <cstdint>
+#include <limits>
+#include <type_traits>
+
+namespace minix::fs {
+
+/** @enum block_nr
+ *  @brief Strongly typed block number
+ */
+enum class block_nr : std::uint32_t {};
+
+/** @enum inode_nr
+ *  @brief Strongly typed inode number
+ */
+enum class inode_nr : std::uint32_t {};
+
+/** @enum zone_nr
+ *  @brief Strongly typed zone number
+ */
+enum class zone_nr : std::uint32_t {};
+
+/** @enum dev_nr
+ *  @brief Strongly typed device number
+ */
+enum class dev_nr : std::uint16_t {};
+
+/** @enum bit_nr
+ *  @brief Bit number type
+ */
+enum class bit_nr : std::uint32_t {};
+
+/** @enum uid
+ *  @brief User identifier type
+ */
+enum class uid : std::uint16_t {};
+
+/** @enum gid
+ *  @brief Group identifier type
+ */
+enum class gid : std::uint8_t {};
+
+/** @enum file_pos
+ *  @brief 32-bit file position type
+ */
+enum class file_pos : std::int32_t {};
+
+/** @enum file_pos64
+ *  @brief 64-bit file position type
+ */
+enum class file_pos64 : std::int64_t {};
+
+/** @enum mask_bits
+ *  @brief Permission mask bits
+ */
+enum class mask_bits : std::uint16_t {};
+
+/** @enum links
+ *  @brief Link count type
+ */
+enum class links : std::uint8_t {};
+
+/** @enum real_time
+ *  @brief Time type representation
+ */
+enum class real_time : std::int64_t {};
+
+inline constexpr block_nr kNoBlock{0};
+inline constexpr zone_nr kNoZone{0};
+inline constexpr dev_nr kNoDev{0};
+inline constexpr bit_nr kNoBit{0};
+inline constexpr inode_nr kNoInode{0};
+
+/**
+ * @concept PowerOfTwo
+ * @brief Concept for validating numeric constraints at compile time
+ */
+template <typename T>
+concept PowerOfTwo = requires(T value) {
+    std::is_integral_v<T>;
+    ((value & (value - 1)) == 0) && (value > 0);
+};
+
+/**
+ * @tparam BlockSize compile-time block size
+ * @struct FsConstants
+ * @brief File system constant set validated at compile time
+ */
+template <std::size_t BlockSize>
+    requires PowerOfTwo<BlockSize>
+struct FsConstants {
+    static constexpr std::size_t kBlockSize = BlockSize;
+    static constexpr std::size_t kZoneNumSize = sizeof(zone_nr);
+    static constexpr std::size_t kNrZoneNums = 9;
+    static constexpr std::size_t kNrBufs = 20;
+    static constexpr std::size_t kNrBufHash = 32;
+    static constexpr std::size_t kNrFds = 20;
+    static constexpr std::size_t kNrFilps = 64;
+    static constexpr std::size_t kNrInodes = 32;
+    static constexpr std::size_t kNrSupers = 5;
+    static constexpr std::size_t kNameSize = 14;
+    static constexpr std::size_t kFsStackBytes = 512;
+    static constexpr std::uint16_t kSuperMagic = 0x137F;
+    static constexpr uid kSuUid{0};
+    static constexpr uid kSysUid{0};
+    static constexpr gid kSysGid{0};
+
+    /** @enum IoMode
+     *  @brief I/O mode flags
+     */
+    enum class IoMode : std::uint8_t { Normal = 0, NoRead = 1 };
+
+    /** @enum DirOp
+     *  @brief Directory operations semantics
+     */
+    enum class DirOp : std::uint8_t { LookUp = 0, Enter = 1, Delete = 2 };
+
+    /** @enum BufferState
+     *  @brief Dirty state for buffers
+     */
+    enum class BufferState : std::uint8_t { Clean = 0, Dirty = 1 };
+
+    static constexpr std::size_t kNrDzoneNum = kNrZoneNums - 2;
+    static constexpr std::size_t kDirEntrySize = sizeof(struct dir_struct);
+    static constexpr std::size_t kInodeSize = sizeof(struct d_inode);
+    static constexpr std::size_t kInodesPerBlock = kBlockSize / kInodeSize;
+    static constexpr std::size_t kNrDirEntries = kBlockSize / kDirEntrySize;
+    static constexpr std::size_t kNrIndirects = kBlockSize / kZoneNumSize;
+    static constexpr std::size_t kIntsPerBlock = kBlockSize / sizeof(std::int32_t);
+    static constexpr std::size_t kPipeSize = kNrDzoneNum * kBlockSize;
+
+    static_assert(kBlockSize % kInodeSize == 0, "Block size must be divisible by inode size");
+    static_assert(kNrBufHash > 0 && PowerOfTwo<kNrBufHash>,
+                  "Buffer hash size must be power of two");
+    static_assert(kNrFds <= 127, "File descriptor limit constraint");
+    static_assert(kNrBufs >= 6, "Minimum buffer requirement");
+};
+
+using DefaultFsConstants = FsConstants<1024>;
+
+/** @namespace FileTypes
+ *  @brief File type constants with enhanced type safety
+ */
+namespace FileTypes {
+inline constexpr mask_bits kRegular{0o100000};
+inline constexpr mask_bits kDirectory{0o040000};
+inline constexpr mask_bits kBlockSpecial{0o060000};
+inline constexpr mask_bits kCharSpecial{0o020000};
+inline constexpr mask_bits kPipe{0o010000};
+inline constexpr mask_bits kTypeMask{0o170000};
+} // namespace FileTypes
+
+/** @namespace Permissions
+ *  @brief Permission bits with semantic clarity
+ */
+namespace Permissions {
+inline constexpr mask_bits kReadBit{0o4};
+inline constexpr mask_bits kWriteBit{0o2};
+inline constexpr mask_bits kExecBit{0o1};
+inline constexpr mask_bits kAllModes{0o777};
+inline constexpr mask_bits kRwxModes{0o700};
+} // namespace Permissions
+
+/** @enum BlockType
+ *  @brief Classification of buffer block types
+ */
+enum class BlockType : std::uint8_t {
+    InodeBlock = 0,
+    DirectoryBlock = 1,
+    IndirectBlock = 2,
+    ImapBlock = 3,
+    ZmapBlock = 4,
+    SuperBlock = 5,
+    FullDataBlock = 6,
+    PartialDataBlock = 7
+};
+
+/** @namespace BlockFlags
+ *  @brief Enhanced block type flags
+ */
+namespace BlockFlags {
+inline constexpr std::uint8_t kWriteImmed = 0100;
+inline constexpr std::uint8_t kOneShot = 0200;
+} // namespace BlockFlags
+
+/**
+ * @brief Compute block number from zone number.
+ * @tparam ZoneSize Size of a zone in blocks.
+ */
+template <std::size_t ZoneSize> constexpr auto zones_to_blocks(zone_nr zone) -> block_nr {
+    return block_nr{std::to_underlying(zone) * ZoneSize};
+}
+
+/**
+ * @brief Return maximum representable value for enum type.
+ * @tparam T Enum type.
+ */
+template <typename T> constexpr T max_value() {
+    return T{std::numeric_limits<std::underlying_type_t<T>>::max()};
+}
+
+} // namespace minix::fs
+
+namespace legacy {
+using ::minix::fs::DefaultFsConstants;
+} // namespace legacy

--- a/include/minix/fs/inode.hpp
+++ b/include/minix/fs/inode.hpp
@@ -1,0 +1,411 @@
+#pragma once
+
+/**
+ * @file inode.hpp
+ * @brief C++23 modernized inode management with enhanced safety and semantics
+ */
+
+#include "buffer.hpp"
+#include "const.hpp"
+#include "extent.hpp"
+#include <atomic>
+#include <chrono>
+#include <concepts>
+#include <expected>
+#include <memory>
+#include <optional>
+#include <span>
+#include <string_view>
+
+namespace minix::fs {
+/**
+ * @enum InodeError
+ * @brief Error conditions for inode operations
+ */
+
+enum class InodeError {
+    TableFull,
+    NotFound,
+    AlreadyExists,
+    PermissionDenied,
+    InvalidOperation,
+    DiskError,
+    CorruptedData,
+    OutOfSpace,
+    InvalidArgument,
+    ResourceBusy
+};
+
+/**
+ * @concept FileType
+ * @brief Concept defining valid file types
+ */
+template <typename T>
+concept FileType = requires {
+    std::is_enum_v<T>;
+    T::Regular;
+    T::Directory;
+    T::CharSpecial;
+    T::BlockSpecial;
+    T::Pipe;
+};
+/**
+ * @enum InodeType
+ * @brief Modern file type enumeration with enhanced semantics
+ */
+
+enum class InodeType : mask_bits {
+    Regular = std::to_underlying(FileTypes::kRegular),
+    Directory = std::to_underlying(FileTypes::kDirectory),
+    CharSpecial = std::to_underlying(FileTypes::kCharSpecial),
+    BlockSpecial = std::to_underlying(FileTypes::kBlockSpecial),
+    Pipe = std::to_underlying(FileTypes::kPipe)
+};
+/**
+ * @class Permissions
+ * @brief Permission set with type-safe operations
+ */
+
+class Permissions {
+  private:
+    mask_bits bits_;
+
+  public:
+    constexpr explicit Permissions(mask_bits bits = mask_bits{0}) : bits_{bits} {}
+
+    [[nodiscard]] static constexpr auto owner_read_write() -> Permissions {
+        return Permissions{mask_bits{0600}};
+    }
+
+    [[nodiscard]] static constexpr auto owner_all() -> Permissions {
+        return Permissions{mask_bits{0700}};
+    }
+
+    [[nodiscard]] static constexpr auto all_read() -> Permissions {
+        return Permissions{mask_bits{0444}};
+    }
+
+    [[nodiscard]] static constexpr auto all_read_write() -> Permissions {
+        return Permissions{mask_bits{0666}};
+    }
+
+    [[nodiscard]] constexpr bool can_read(bool owner, bool group) const noexcept {
+        const auto shift = owner ? 6 : (group ? 3 : 0);
+        return (std::to_underlying(bits_) >> shift) & std::to_underlying(Permissions::kReadBit);
+    }
+
+    [[nodiscard]] constexpr bool can_write(bool owner, bool group) const noexcept {
+        const auto shift = owner ? 6 : (group ? 3 : 0);
+        return (std::to_underlying(bits_) >> shift) & std::to_underlying(Permissions::kWriteBit);
+    }
+
+    [[nodiscard]] constexpr bool can_execute(bool owner, bool group) const noexcept {
+        const auto shift = owner ? 6 : (group ? 3 : 0);
+        return (std::to_underlying(bits_) >> shift) & std::to_underlying(Permissions::kExecBit);
+    }
+
+    [[nodiscard]] constexpr auto operator|(const Permissions &other) const -> Permissions {
+        return Permissions{mask_bits{std::to_underlying(bits_) | std::to_underlying(other.bits_)}};
+    }
+
+    [[nodiscard]] constexpr auto operator&(const Permissions &other) const -> Permissions {
+        return Permissions{mask_bits{std::to_underlying(bits_) & std::to_underlying(other.bits_)}};
+    }
+
+    [[nodiscard]] constexpr auto raw() const noexcept -> mask_bits { return bits_; }
+};
+/**
+ * @class FileTime
+ * @brief Modern time management for inodes
+ */
+
+class FileTime {
+  private:
+    std::chrono::system_clock::time_point time_point_;
+
+  public:
+    FileTime() : time_point_{std::chrono::system_clock::now()} {}
+
+    explicit FileTime(real_time legacy_time)
+        : time_point_{std::chrono::system_clock::from_time_t(
+              static_cast<std::time_t>(std::to_underlying(legacy_time)))} {}
+
+    [[nodiscard]] auto to_legacy() const -> real_time {
+        return real_time{std::chrono::system_clock::to_time_t(time_point_)};
+    }
+
+    [[nodiscard]] auto time_point() const -> std::chrono::system_clock::time_point {
+        return time_point_;
+    }
+
+    void update() { time_point_ = std::chrono::system_clock::now(); }
+
+    [[nodiscard]] auto operator<=>(const FileTime &) const = default;
+};
+
+class InodeTable;
+
+/**
+ * @class InodeHandle
+ * @brief RAII inode handle with automatic reference management
+ */
+class InodeHandle {
+  private:
+    class Inode *inode_;
+    bool owned_;
+
+  public:
+    explicit InodeHandle(Inode *inode = nullptr, bool owned = true)
+        : inode_{inode}, owned_{owned} {}
+
+    ~InodeHandle();
+
+    InodeHandle(const InodeHandle &) = delete;
+    InodeHandle &operator=(const InodeHandle &) = delete;
+
+    InodeHandle(InodeHandle &&other) noexcept
+        : inode_{std::exchange(other.inode_, nullptr)}, owned_{std::exchange(other.owned_, false)} {
+    }
+
+    InodeHandle &operator=(InodeHandle &&other) noexcept {
+        if (this != &other) {
+            reset();
+            inode_ = std::exchange(other.inode_, nullptr);
+            owned_ = std::exchange(other.owned_, false);
+        }
+        return *this;
+    }
+
+    [[nodiscard]] auto get() -> Inode * { return inode_; }
+    [[nodiscard]] auto get() const -> const Inode * { return inode_; }
+
+    [[nodiscard]] auto operator->() -> Inode * { return inode_; }
+    [[nodiscard]] auto operator->() const -> const Inode * { return inode_; }
+
+    [[nodiscard]] auto operator*() -> Inode & { return *inode_; }
+    [[nodiscard]] auto operator*() const -> const Inode & { return *inode_; }
+
+    [[nodiscard]] bool valid() const noexcept { return inode_ != nullptr; }
+    explicit operator bool() const noexcept { return valid(); }
+
+    void reset();
+    [[nodiscard]] auto release() -> Inode *;
+};
+/**
+ * @class Inode
+ * @brief Modern inode with enhanced type safety and functionality
+ */
+
+class Inode {
+  private:
+    friend class InodeTable;
+    friend class InodeHandle;
+
+    InodeType type_{InodeType::Regular};
+    uid owner_{uid{0}};
+    file_pos size_{file_pos{0}};
+    file_pos64 size64_{file_pos64{0}};
+    FileTime modification_time_{};
+    gid group_{gid{0}};
+    links link_count_{links{1}};
+    std::array<zone_nr, DefaultFsConstants::kNrZoneNums> zones_{};
+
+    dev_nr device_{kNoDev};
+    inode_nr number_{kNoInode};
+    std::atomic<std::int32_t> reference_count_{0};
+    std::atomic<bool> dirty_{false};
+    std::atomic<bool> pipe_{false};
+    std::atomic<bool> mounted_{false};
+    std::atomic<bool> seek_flag_{false};
+
+    std::unique_ptr<ExtentTable> extents_;
+
+  public:
+    Inode() = default;
+
+    explicit Inode(InodeType type, uid owner, gid group)
+        : type_{type}, owner_{owner}, group_{group} {
+        modification_time_.update();
+        std::fill(zones_.begin(), zones_.end(), kNoZone);
+    }
+
+    [[nodiscard]] auto type() const noexcept -> InodeType { return type_; }
+
+    [[nodiscard]] constexpr bool is_regular_file() const noexcept {
+        return type_ == InodeType::Regular;
+    }
+
+    [[nodiscard]] constexpr bool is_directory() const noexcept {
+        return type_ == InodeType::Directory;
+    }
+
+    [[nodiscard]] constexpr bool is_special_file() const noexcept {
+        return type_ == InodeType::CharSpecial || type_ == InodeType::BlockSpecial;
+    }
+
+    [[nodiscard]] constexpr bool is_pipe() const noexcept {
+        return pipe_.load(std::memory_order_acquire);
+    }
+
+    [[nodiscard]] auto owner() const noexcept -> uid { return owner_; }
+    [[nodiscard]] auto group() const noexcept -> gid { return group_; }
+
+    void set_owner(uid new_owner) noexcept {
+        owner_ = new_owner;
+        mark_dirty();
+    }
+
+    void set_group(gid new_group) noexcept {
+        group_ = new_group;
+        mark_dirty();
+    }
+
+    [[nodiscard]] auto size() const noexcept -> file_pos64 {
+        return size64_ != file_pos64{0} ? size64_ : file_pos64{std::to_underlying(size_)};
+    }
+
+    void set_size(file_pos64 new_size) noexcept {
+        size64_ = new_size;
+        size_ = file_pos{static_cast<std::int32_t>(std::to_underlying(new_size))};
+        modification_time_.update();
+        mark_dirty();
+    }
+
+    [[nodiscard]] auto link_count() const noexcept -> links { return link_count_; }
+
+    void increment_links() noexcept {
+        link_count_ = links{std::to_underlying(link_count_) + 1};
+        mark_dirty();
+    }
+
+    void decrement_links() noexcept {
+        if (std::to_underlying(link_count_) > 0) {
+            link_count_ = links{std::to_underlying(link_count_) - 1};
+            mark_dirty();
+        }
+    }
+
+    [[nodiscard]] auto modification_time() const -> FileTime { return modification_time_; }
+
+    void touch() {
+        modification_time_.update();
+        mark_dirty();
+    }
+
+    [[nodiscard]] auto zone(std::size_t index) const -> std::expected<zone_nr, InodeError> {
+        if (index >= zones_.size()) {
+            return std::unexpected(InodeError::InvalidArgument);
+        }
+        return zones_[index];
+    }
+
+    auto set_zone(std::size_t index, zone_nr zone) -> std::expected<void, InodeError> {
+        if (index >= zones_.size()) {
+            return std::unexpected(InodeError::InvalidArgument);
+        }
+        zones_[index] = zone;
+        mark_dirty();
+        return {};
+    }
+
+    [[nodiscard]] auto device() const noexcept -> dev_nr { return device_; }
+    [[nodiscard]] auto number() const noexcept -> inode_nr { return number_; }
+
+    [[nodiscard]] bool is_dirty() const noexcept { return dirty_.load(std::memory_order_acquire); }
+
+    void mark_dirty() noexcept { dirty_.store(true, std::memory_order_release); }
+
+    void mark_clean() noexcept { dirty_.store(false, std::memory_order_release); }
+
+    [[nodiscard]] bool is_mounted() const noexcept {
+        return mounted_.load(std::memory_order_acquire);
+    }
+
+    void set_mounted(bool mounted = true) noexcept {
+        mounted_.store(mounted, std::memory_order_release);
+    }
+
+    [[nodiscard]] auto reference_count() const noexcept -> std::int32_t {
+        return reference_count_.load(std::memory_order_acquire);
+    }
+
+    [[nodiscard]] auto check_permission(uid requesting_uid, gid requesting_gid,
+                                        Permissions required) const
+        -> std::expected<void, InodeError>;
+
+    [[nodiscard]] auto extent_table() const -> const ExtentTable * { return extents_.get(); }
+
+    auto allocate_extent_table(std::size_t initial_capacity) -> std::expected<void, InodeError>;
+
+  private:
+    void increment_references() noexcept {
+        reference_count_.fetch_add(1, std::memory_order_acq_rel);
+    }
+
+    void decrement_references() noexcept {
+        reference_count_.fetch_sub(1, std::memory_order_acq_rel);
+    }
+
+    void set_device_and_number(dev_nr device, inode_nr number) noexcept {
+        device_ = device;
+        number_ = number;
+    }
+};
+/**
+ * @class InodeTable
+ * @brief Modern inode table with enhanced resource management
+ */
+
+class InodeTable {
+  private:
+    static constexpr std::size_t kTableSize = DefaultFsConstants::kNrInodes;
+
+    std::array<Inode, kTableSize> inodes_{};
+    std::atomic<std::size_t> inodes_in_use_{0};
+
+    [[nodiscard]] auto find_free_slot() -> std::optional<std::size_t>;
+
+    [[nodiscard]] auto find_inode(dev_nr device, inode_nr number) -> Inode *;
+
+  public:
+    InodeTable() = default;
+    ~InodeTable() = default;
+
+    InodeTable(const InodeTable &) = delete;
+    InodeTable &operator=(const InodeTable &) = delete;
+    InodeTable(InodeTable &&) = default;
+    InodeTable &operator=(InodeTable &&) = default;
+
+    [[nodiscard]] auto get_inode(dev_nr device, inode_nr number)
+        -> std::expected<InodeHandle, InodeError>;
+
+    [[nodiscard]] auto allocate_inode(dev_nr device, InodeType type, uid owner, gid group)
+        -> std::expected<InodeHandle, InodeError>;
+
+    void release_inode(Inode *inode) noexcept;
+
+    [[nodiscard]] auto flush_dirty_inodes() -> std::size_t;
+
+    [[nodiscard]] auto inodes_in_use() const noexcept -> std::size_t {
+        return inodes_in_use_.load(std::memory_order_acquire);
+    }
+
+    [[nodiscard]] auto available_inodes() const noexcept -> std::size_t {
+        return kTableSize - inodes_in_use();
+    }
+
+    [[nodiscard]] auto begin() noexcept -> Inode * { return inodes_.data(); }
+    [[nodiscard]] auto end() noexcept -> Inode * { return inodes_.data() + kTableSize; }
+    [[nodiscard]] auto begin() const noexcept -> const Inode * { return inodes_.data(); }
+    [[nodiscard]] auto end() const noexcept -> const Inode * { return inodes_.data() + kTableSize; }
+};
+
+extern InodeTable g_inode_table;
+
+[[nodiscard]] auto get_inode(dev_nr device, inode_nr number)
+    -> std::expected<InodeHandle, InodeError>;
+
+[[nodiscard]] auto allocate_inode(dev_nr device, InodeType type, uid owner, gid group)
+    -> std::expected<InodeHandle, InodeError>;
+
+} // namespace minix::fs


### PR DESCRIPTION
## Summary
- add modernized fs header implementations for constants, inodes and buffers
- document all new types using Doxygen comments
- apply clang-format for consistent style

## Testing
- `clang-format -i include/minix/fs/buffer.hpp include/minix/fs/const.hpp include/minix/fs/inode.hpp`


------
https://chatgpt.com/codex/tasks/task_e_6851cce0ea8c8331824d5dd58e441a03