### PR TITLE
Refine fs server sources

### DIFF
--- a/fs/CMakeLists.txt
+++ b/fs/CMakeLists.txt
@@ -1,4 +1,31 @@
-file(GLOB FS_SRC "*.cpp") # Use quotes for robustness
+##
+# List all source files for the file system server explicitly.  Using an
+# explicit list avoids surprises when new files are added and makes
+# dependencies clear.
+##
+set(FS_SRC
+  cache.cpp
+  compat.cpp
+  device.cpp
+  filedes.cpp
+  inode.cpp
+  link.cpp
+  main.cpp
+  misc.cpp
+  mount.cpp
+  open.cpp
+  path.cpp
+  pipe.cpp
+  protect.cpp
+  putc.cpp
+  read.cpp
+  stadir.cpp
+  super.cpp
+  table.cpp
+  time.cpp
+  utility.cpp
+  write.cpp
+)
 
 add_executable(minix_fs_server ${FS_SRC})
 


### PR DESCRIPTION
## Summary
- enumerate the FS server source files instead of globbing
- keep CMake formatting consistent

## Testing
- `make check` *(fails: No rule to make target 'obj/fsck.o')*

------
https://chatgpt.com/codex/tasks/task_e_6851d8f7f7a48331a486e477e0e31aec