### PR TITLE
Fix Doxygen brief comments

### DIFF
--- a/h/type.hpp
+++ b/h/type.hpp
@@ -11,13 +11,13 @@
 #include <xinim/core_types.hpp> // New include for xinim types
 
 // Utility functions -------------------------------------------------------*/
-/*!
- * rief Return the larger of two values.
+/**
+ * @brief Return the larger of two values.
  */
 template <typename T> constexpr T max(T a, T b) noexcept { return a > b ? a : b; }
 
-/*!
- * rief Return the smaller of two values.
+/**
+ * @brief Return the smaller of two values.
  */
 template <typename T> constexpr T min(T a, T b) noexcept { return a < b ? a : b; }
 


### PR DESCRIPTION
## Summary
- correct Doxygen comment markers in `h/type.hpp`
- run clang-format

## Testing
- `make check` *(fails: No rule to make target 'obj/fsck.o')*

------
https://chatgpt.com/codex/tasks/task_e_6851d90ae0f8833195af3d1d00c25910