### PR TITLE
Fix formatting in pre-commit hook

### DIFF
--- a/tools/pre-commit-clang-format.sh
+++ b/tools/pre-commit-clang-format.sh
@@ -13,8 +13,8 @@
 
 FILES=$(git diff --cached --name-only --diff-filter=ACM | grep -E '\.(cpp|hpp)$')
 if [ -n "$FILES" ]; then
-    clang-format -i $FILES
-    git add $FILES
+    echo "$FILES" | xargs clang-format -i
+    echo "$FILES" | xargs git add
 fi
 
 exit 0


### PR DESCRIPTION
## Summary
- adjust pre-commit hook to pipe file list through `xargs`

## Testing
- `make check` *(fails: No rule to make target 'obj/fsck.o')*

------
https://chatgpt.com/codex/tasks/task_e_6851d90d3a648331bfc13413466c5a47