### PR TITLE
Add constant-time equal helper

### DIFF
--- a/include/constant_time.hpp
+++ b/include/constant_time.hpp
@@ -1,0 +1,37 @@
+#pragma once
+
+/**
+ * @file constant_time.hpp
+ * @brief Constant time utility helpers for cryptographic operations.
+ */
+
+#include <cstddef>
+#include <span>
+
+namespace pqcrypto {
+
+/**
+ * @brief Constant time memory equality check.
+ *
+ * This function compares two memory regions of equal size without
+ * leaking timing information about matching prefixes. If the spans
+ * differ in size the comparison immediately fails.
+ *
+ * @param a First input buffer.
+ * @param b Second input buffer.
+ * @return True when the contents match, false otherwise.
+ */
+[[nodiscard]] inline bool constant_time_equal(std::span<const std::byte> a,
+                                              std::span<const std::byte> b) noexcept {
+    if (a.size() != b.size()) {
+        return false;
+    }
+
+    std::byte result{0};
+    for (std::size_t i = 0; i < a.size(); ++i) {
+        result |= a[i] ^ b[i];
+    }
+    return result == std::byte{0};
+}
+
+} // namespace pqcrypto

--- a/tests/crypto/CMakeLists.txt
+++ b/tests/crypto/CMakeLists.txt
@@ -26,3 +26,21 @@ target_include_directories(minix_test_shared_secret_failure PUBLIC
 target_link_libraries(minix_test_shared_secret_failure PRIVATE pqcrypto)
 
 add_test(NAME minix_test_shared_secret_failure COMMAND minix_test_shared_secret_failure)
+
+# -----------------------------------------------------------------------------
+# minix_test_constant_time_equal
+# -----------------------------------------------------------------------------
+add_executable(minix_test_constant_time_equal test_constant_time_equal.cpp)
+
+set_target_properties(minix_test_constant_time_equal PROPERTIES
+    CXX_STANDARD 23
+    CXX_STANDARD_REQUIRED ON)
+
+target_include_directories(minix_test_constant_time_equal PUBLIC
+    "${CMAKE_SOURCE_DIR}/crypto"
+    "${CMAKE_SOURCE_DIR}/include")
+
+target_link_libraries(minix_test_constant_time_equal PRIVATE pqcrypto)
+
+add_test(NAME minix_test_constant_time_equal COMMAND minix_test_constant_time_equal)
+

--- a/tests/crypto/test_constant_time_equal.cpp
+++ b/tests/crypto/test_constant_time_equal.cpp
@@ -1,0 +1,27 @@
+#include "constant_time.hpp"
+
+#include <array>
+#include <cassert>
+#include <cstddef>
+#include <span>
+
+/**
+ * @brief Unit test for pqcrypto::constant_time_equal.
+ */
+int main() {
+    std::array<std::byte, 16> a{};
+    std::array<std::byte, 16> b{};
+    std::array<std::byte, 16> c{};
+
+    for (std::size_t i = 0; i < a.size(); ++i) {
+        a[i] = std::byte{static_cast<unsigned char>(i)};
+        b[i] = a[i];
+        c[i] = std::byte{static_cast<unsigned char>(i + 1)};
+    }
+
+    assert(pqcrypto::constant_time_equal(a, b));
+    assert(!pqcrypto::constant_time_equal(a, c));
+    std::array<std::byte, 15> d{};
+    assert(!pqcrypto::constant_time_equal(std::span{a.data(), 15}, d));
+    return 0;
+}


### PR DESCRIPTION
## Summary
- implement `constant_time_equal` utility for timing-safe comparisons
- add unit test verifying constant time equality checks
- hook unit test into the crypto test suite

## Testing
- `cmake --build build --target minix_test_constant_time_equal`
- `./build/tests/crypto/minix_test_constant_time_equal`

------
https://chatgpt.com/codex/tasks/task_e_6851d825c0cc8331b24c26da839d4ba0

## Summary by Sourcery

Add a timing-safe memory comparison helper and integrate it into the crypto test suite.

New Features:
- Implement constant_time_equal for constant-time byte buffer comparisons.

Enhancements:
- Hook the new test into the existing crypto CMakeLists configuration.

Build:
- Update crypto CMakeLists to build and register the constant_time_equal test target.

Tests:
- Add unit tests verifying equal, unequal, and length-mismatch behaviors of constant_time_equal.