### PR TITLE
Modernize buffer header and usage

### DIFF
--- a/fs/buf.hpp
+++ b/fs/buf.hpp
@@ -1,3 +1,6 @@
+#pragma once
+// Modernized for C++23
+
 /* Buffer (block) cache.  To acquire a block, a routine calls get_block(),
  * telling which block it wants.  The block is then regarded as "in use"
  * and has its 'b_count' field incremented.  All the blocks, whether in use
@@ -11,24 +14,27 @@
  * will eventually be rewritten to the disk.
  */
 
+/**
+ * @brief Descriptor for a cached disk block.
+ */
 EXTERN struct buf {
-    /* Data portion of the buffer. */
+    /** Data portion of the buffer. */
     union {
-        char b__data[BLOCK_SIZE];           /* ordinary user data */
-        dir_struct b__dir[NR_DIR_ENTRIES];  /* directory block */
-        zone_nr b__ind[NR_INDIRECTS];       /* indirect block */
-        d_inode b__inode[INODES_PER_BLOCK]; /* inode block */
-        int b__int[INTS_PER_BLOCK];         /* block full of integers */
+        char b__data[BLOCK_SIZE];           /**< Ordinary user data. */
+        dir_struct b__dir[NR_DIR_ENTRIES];  /**< Directory block. */
+        zone_nr b__ind[NR_INDIRECTS];       /**< Indirect block. */
+        d_inode b__inode[INODES_PER_BLOCK]; /**< Inode block. */
+        int b__int[INTS_PER_BLOCK];         /**< Block full of integers. */
     } b;
 
-    /* Header portion of the buffer. */
-    struct buf *b_next; /* used to link bufs in a chain */
-    struct buf *b_prev; /* used to link bufs the other way */
-    struct buf *b_hash; /* used to link bufs on hash chains */
-    block_nr b_blocknr; /* block number of its (minor) device */
-    dev_nr b_dev;       /* major | minor device where block resides */
-    char b_dirt;        /* CLEAN or DIRTY */
-    char b_count;       /* number of users of this buffer */
+    /** Header portion of the buffer. */
+    struct buf *b_next; /**< Used to link buffers in a chain. */
+    struct buf *b_prev; /**< Used to link buffers the other way. */
+    struct buf *b_hash; /**< Used to link buffers on hash chains. */
+    block_nr b_blocknr; /**< Block number of its (minor) device. */
+    dev_nr b_dev;       /**< Major | minor device where block resides. */
+    char b_dirt;        /**< CLEAN or DIRTY. */
+    char b_count;       /**< Number of users of this buffer. */
 } buf[NR_BUFS];
 
 /* A block is free if b_dev == NO_DEV. */
@@ -42,20 +48,30 @@ EXTERN struct buf {
 #define b_inode b.b__inode
 #define b_int b.b__int
 
-EXTERN struct buf *buf_hash[NR_BUF_HASH]; /* the buffer hash table */
+/** Hash table for quick buffer lookup by block number. */
+EXTERN struct buf *buf_hash[NR_BUF_HASH];
 
-EXTERN struct buf *front; /* points to least recently used free block */
-EXTERN struct buf *rear;  /* points to most recently used free block */
-EXTERN int bufs_in_use;   /* # bufs currently in use (not on free list) */
+/** Points to the least recently used free block. */
+EXTERN struct buf *front;
 
-/* When a block is released, the type of usage is passed to put_block(). */
-#define WRITE_IMMED 0100                       /* block should be written to disk now */
-#define ONE_SHOT 0200                          /* set if block not likely to be needed soon */
-#define INODE_BLOCK 0 + WRITE_IMMED            /* inode block */
-#define DIRECTORY_BLOCK 1 + WRITE_IMMED        /* directory block */
-#define INDIRECT_BLOCK 2 + WRITE_IMMED         /* pointer block */
-#define I_MAP_BLOCK 3 + WRITE_IMMED + ONE_SHOT /* inode bit map */
-#define ZMAP_BLOCK 4 + WRITE_IMMED + ONE_SHOT  /* free zone map */
-#define ZUPER_BLOCK 5 + WRITE_IMMED + ONE_SHOT /* super block */
-#define FULL_DATA_BLOCK 6                      /* data, fully used */
-#define PARTIAL_DATA_BLOCK 7                   /* data, partly used */
+/** Points to the most recently used free block. */
+EXTERN struct buf *rear;
+
+/** Number of buffers currently in use (not on free list). */
+EXTERN int bufs_in_use;
+
+/**
+ * @brief Usage hint flags and classifications for cached blocks.
+ */
+enum class BlockType : int {
+    WriteImmediate = 0100,                /**< Block should be written to disk now. */
+    OneShot = 0200,                       /**< Block not likely to be needed soon. */
+    Inode = 0 + WriteImmediate,           /**< Inode block. */
+    Directory = 1 + WriteImmediate,       /**< Directory block. */
+    Indirect = 2 + WriteImmediate,        /**< Pointer block. */
+    IMap = 3 + WriteImmediate + OneShot,  /**< Inode bit map. */
+    ZMap = 4 + WriteImmediate + OneShot,  /**< Free zone map. */
+    Zuper = 5 + WriteImmediate + OneShot, /**< Super block. */
+    FullData = 6,                         /**< Data, fully used. */
+    PartialData = 7                       /**< Data, partly used. */
+};

--- a/fs/cache.cpp
+++ b/fs/cache.cpp
@@ -112,7 +112,7 @@ int only_search;         /* if NO_READ, don't read, else act normal */
  *===========================================================================*/
 PUBLIC put_block(bp, block_type)
 register struct buf *bp; /* pointer to the buffer to be released */
-int block_type;          /* INODE_BLOCK, DIRECTORY_BLOCK, or whatever */
+BlockType block_type;    /* BlockType classification for this buffer */
 {
     /* Return a block to the list of available blocks.   Depending on 'block_type'
      * it may be put on the front or rear of the LRU chain.  Blocks that are
@@ -146,12 +146,12 @@ int block_type;          /* INODE_BLOCK, DIRECTORY_BLOCK, or whatever */
     else
         rear = prev_ptr; /* this block was at rear of chain */
 
-    /* Put this block back on the LRU chain.  If the ONE_SHOT bit is set in
+    /* Put this block back on the LRU chain.  If the BlockType::OneShot bit is set in
      * 'block_type', the block is not likely to be needed again shortly, so put
      * it on the front of the LRU chain where it will be the first one to be
      * taken when a free buffer is needed later.
      */
-    if (block_type & ONE_SHOT) {
+    if (static_cast<int>(block_type) & static_cast<int>(BlockType::OneShot)) {
         /* Block probably won't be needed quickly. Put it on front of chain.
          * It will be the next block to be evicted from the cache.
          */
@@ -179,11 +179,12 @@ int block_type;          /* INODE_BLOCK, DIRECTORY_BLOCK, or whatever */
      * should be written to the disk immediately to avoid messing up the file
      * system in the event of a crash.
      */
-    if ((block_type & WRITE_IMMED) && bp->b_dirt == DIRTY && bp->b_dev != kNoDev)
+    if ((static_cast<int>(block_type) & static_cast<int>(BlockType::WriteImmediate)) &&
+        bp->b_dirt == DIRTY && bp->b_dev != kNoDev)
         rw_block(bp, WRITING);
 
     /* Super blocks must not be cached, lest mount use cached block. */
-    if (block_type == ZUPER_BLOCK)
+    if (block_type == BlockType::Zuper)
         bp->b_dev = kNoDev;
 }
 

--- a/fs/inode.cpp
+++ b/fs/inode.cpp
@@ -223,7 +223,7 @@ PUBLIC void rw_inode(struct inode *rip, int rw_flag) { // Added void return, mod
         bp->b_dirt = DIRTY;
     }
 
-    put_block(bp, INODE_BLOCK);
+    put_block(bp, BlockType::Inode);
     rip->i_dirt = CLEAN;
 }
 

--- a/fs/link.cpp
+++ b/fs/link.cpp
@@ -184,7 +184,7 @@ register struct inode *rip; /* pointer to inode to be truncated */
         }
 
         /* Now free the double indirect zone itself. */
-        put_block(bp, INDIRECT_BLOCK);
+        put_block(bp, BlockType::Indirect);
         free_zone(dev, z);
     }
 

--- a/fs/main.cpp
+++ b/fs/main.cpp
@@ -220,7 +220,7 @@ static void load_ram() {
         panic("RAM disk is too big. # blocks = ", static_cast<int>(count)); // panic takes int
     // count is uint32_t, BLOCK_SIZE/CLICK_SIZE are int. Result fits uint64_t.
     ram_clicks = static_cast<uint64_t>(count) * (BLOCK_SIZE / CLICK_SIZE);
-    put_block(bp, FULL_DATA_BLOCK);
+    put_block(bp, BlockType::FullData);
 
     /* Tell MM the origin and size of INIT, and the amount of memory used for the
      * system plus RAM disk combined, so it can remove all of it from the map.
@@ -254,8 +254,8 @@ static void load_ram() {
         bp1 = get_block(ROOT_DEV, i, NO_READ);
         copy(bp1->b_data, bp->b_data, BLOCK_SIZE);
         bp1->b_dirt = DIRTY;
-        put_block(bp, I_MAP_BLOCK);
-        put_block(bp1, I_MAP_BLOCK);
+        put_block(bp, BlockType::IMap);
+        put_block(bp1, BlockType::IMap);
         // i is uint16_t, BLOCK_SIZE is int. Result of mult fits int64_t.
         k_loaded = (static_cast<int64_t>(i) * BLOCK_SIZE) / 1024L; /* K loaded so far */
         if (k_loaded % 5 == 0)

--- a/fs/path.cpp
+++ b/fs/path.cpp
@@ -259,7 +259,7 @@ int search_dir(struct inode *ldir_ptr, char string[NAME_SIZE], inode_nr *numb, i
                     ldir_ptr->i_modtime = clock_time();
                 } else
                     *numb = dp->d_inum; /* 'flag' is LOOK_UP */
-                put_block(bp, DIRECTORY_BLOCK);
+                put_block(bp, BlockType::Directory);
                 return (OK);
             }
 
@@ -272,8 +272,8 @@ int search_dir(struct inode *ldir_ptr, char string[NAME_SIZE], inode_nr *numb, i
 
         /* The whole block has been searched or ENTER has a free slot. */
         if (e_hit)
-            break;                      /* e_hit set if ENTER can be performed now */
-        put_block(bp, DIRECTORY_BLOCK); /* otherwise, continue searching dir */
+            break;                           /* e_hit set if ENTER can be performed now */
+        put_block(bp, BlockType::Directory); /* otherwise, continue searching dir */
     }
 
     /* The whole directory has now been searched. */
@@ -296,7 +296,7 @@ int search_dir(struct inode *ldir_ptr, char string[NAME_SIZE], inode_nr *numb, i
     copy(dp->d_name, string, NAME_SIZE);
     dp->d_inum = *numb;
     bp->b_dirt = DIRTY;
-    put_block(bp, DIRECTORY_BLOCK);
+    put_block(bp, BlockType::Directory);
     ldir_ptr->i_modtime = clock_time();
     if (new_slots > old_slots)
         compat_set_size(ldir_ptr, (file_pos)new_slots * DIR_ENTRY_SIZE);

--- a/fs/read.cpp
+++ b/fs/read.cpp
@@ -269,8 +269,8 @@ static int rw_chunk(struct inode *rip, int32_t position, std::size_t off, std::s
     if (rw_flag == WRITING)
         bp->b_dirt = DIRTY;
     // off and chunk are std::size_t, BLOCK_SIZE is int
-    n = (off + chunk == static_cast<std::size_t>(BLOCK_SIZE) ? FULL_DATA_BLOCK
-                                                             : PARTIAL_DATA_BLOCK);
+    n = (off + chunk == static_cast<std::size_t>(BLOCK_SIZE) ? BlockType::FullData
+                                                             : BlockType::PartialData);
     put_block(bp, n);
     return (r);
 }
@@ -326,7 +326,7 @@ PUBLIC uint16_t read_map(struct inode *rip,
         /* get double indirect block */ // rip->i_dev is dev_nr (uint16_t)
         // bp->b_ind is zone_nr[] (uint16_t[]). excess / NR_INDIRECTS is int32_t / size_t.
         z = bp->b_ind[static_cast<std::size_t>(excess / static_cast<int32_t>(NR_INDIRECTS))];
-        put_block(bp, INDIRECT_BLOCK);                        /* release double ind block */
+        put_block(bp, BlockType::Indirect);                   /* release double ind block */
         excess = excess % static_cast<int32_t>(NR_INDIRECTS); /* index into single ind blk */
     }
 
@@ -337,7 +337,7 @@ PUBLIC uint16_t read_map(struct inode *rip,
     b = static_cast<uint16_t>(static_cast<uint32_t>(z) << scale);
     bp = get_block(rip->i_dev, b, NORMAL);           /* get single indirect block */
     z = bp->b_ind[static_cast<std::size_t>(excess)]; // excess is int32_t
-    put_block(bp, INDIRECT_BLOCK);                   /* release single indirect blk */
+    put_block(bp, BlockType::Indirect);              /* release single indirect blk */
     if (z == kNoZone)
         return (kNoBlock);
     // z is uint16_t, boff is int32_t. b is uint16_t.
@@ -402,5 +402,5 @@ PUBLIC void read_ahead() { // Modernized signature (was already using ())
         return;                                     /* at EOF */
     // rip->i_dev is dev_nr (uint16_t). b is uint16_t.
     bp = get_block(rip->i_dev, b, NORMAL);
-    put_block(bp, PARTIAL_DATA_BLOCK);
+    put_block(bp, BlockType::PartialData);
 }

--- a/fs/super.cpp
+++ b/fs/super.cpp
@@ -77,9 +77,9 @@ dev_nr dev; /* which device is being unmounted? */
     sp = get_super(dev); /* get the superblock pointer */
     bufs_in_use -= sp->s_imap_blocks + sp->s_zmap_blocks;
     for (i = 0; i < sp->s_imap_blocks; i++)
-        put_block(sp->s_imap[i], I_MAP_BLOCK);
+        put_block(sp->s_imap[i], BlockType::IMap);
     for (i = 0; i < sp->s_zmap_blocks; i++)
-        put_block(sp->s_zmap[i], ZMAP_BLOCK);
+        put_block(sp->s_zmap[i], BlockType::ZMap);
     return (OK);
 }
 
@@ -248,5 +248,5 @@ int rw_flag;                     /* READING or WRITING */
     }
 
     sp->s_dirt = CLEAN;
-    put_block(bp, ZUPER_BLOCK);
+    put_block(bp, BlockType::Zuper);
 }

--- a/fs/write.cpp
+++ b/fs/write.cpp
@@ -112,11 +112,11 @@ static int write_map(struct inode *rip, int32_t position, uint16_t new_zone) {
         if (bp != NIL_BUF)      // NIL_BUF is (struct buf*)nullptr
             bp->b_dirt = DIRTY; /* if double ind, it is dirty */
         if (*zp == kNoZone) {
-            put_block(bp, INDIRECT_BLOCK); /* release dbl indirect blk */
-            return (err_code);             /* couldn't create single ind */
+            put_block(bp, BlockType::Indirect); /* release dbl indirect blk */
+            return (err_code);                  /* couldn't create single ind */
         }
     }
-    put_block(bp, INDIRECT_BLOCK); /* release double indirect blk */
+    put_block(bp, BlockType::Indirect); /* release double indirect blk */
 
     /* 'zp' now points to indirect block's zone number. */
     // *zp is uint16_t, b is uint16_t, scale is int
@@ -128,7 +128,7 @@ static int write_map(struct inode *rip, int32_t position, uint16_t new_zone) {
     bp->b_ind[static_cast<std::size_t>(excess)] = new_zone;
     rip->i_modtime = clock_time(); // real_time (int64_t)
     bp->b_dirt = DIRTY;
-    put_block(bp, INDIRECT_BLOCK);
+    put_block(bp, BlockType::Indirect);
 
     return (OK);
 }
@@ -179,7 +179,7 @@ PUBLIC void clear_zone(struct inode *rip, int32_t pos, int flag) {
         // rip->i_dev is dev_nr (uint16_t)
         bp = get_block(rip->i_dev, b, NO_READ);
         zero_block(bp);
-        put_block(bp, FULL_DATA_BLOCK);
+        put_block(bp, BlockType::FullData);
     }
 }
 


### PR DESCRIPTION
## Summary
- add `#pragma once` to fs/buf.hpp
- replace old macros with a typed `enum class BlockType`
- document buf structures and globals with Doxygen
- update all callers to use the new `BlockType`

## Testing
- `make check` *(fails: No rule to make target 'obj/fsck.o')*

------
https://chatgpt.com/codex/tasks/task_e_6851d8f6e1888331b97576f401931a73

## Summary by Sourcery

Modernize the buffer cache interface by introducing strong typing, documentation, and modern C++ header practices.

Enhancements:
- Replace legacy block type macros with a scoped enum class BlockType for type safety.
- Add Doxygen comments to buffer structures, globals, and classification flags.
- Introduce #pragma once and update the buffer header to conform to C++23 style.
- Update all buffer access calls to use the new BlockType enum instead of raw macros.