### PR TITLE
Modernize buffer cache APIs

### DIFF
--- a/fs/inode.cpp
+++ b/fs/inode.cpp
@@ -22,6 +22,9 @@
 #include "extent.hpp"
 #include "file.hpp"
 #include "fproc.hpp"
+#include <minix/fs/const.hpp>
+
+using IoMode = minix::fs::DefaultFsConstants::IoMode;
 #include "glo.hpp"
 #include "super.hpp"
 #include "type.hpp"
@@ -211,7 +214,7 @@ PUBLIC void rw_inode(struct inode *rip, int rw_flag) { // Added void return, mod
     // Result of calculation should fit block_nr (uint16_t).
     b = static_cast<uint16_t>((static_cast<uint32_t>(rip->i_num - 1) / INODES_PER_BLOCK) +
                               sp->s_imap_blocks + sp->s_zmap_blocks + 2);
-    bp = get_block(rip->i_dev, b, NORMAL); // b is block_nr (uint16_t)
+    bp = get_block(rip->i_dev, b, IoMode::Normal); // b is block_nr (uint16_t)
     // Assuming bp->b_inode is d_inode*. rip->i_num is inode_nr (uint16_t).
     dip = bp->b_inode + (rip->i_num - 1) % INODES_PER_BLOCK;
 

--- a/fs/link.cpp
+++ b/fs/link.cpp
@@ -22,6 +22,9 @@
 #include "inode.hpp"
 #include "param.hpp"
 #include "type.hpp"
+#include <minix/fs/const.hpp>
+
+using IoMode = minix::fs::DefaultFsConstants::IoMode;
 
 /*===========================================================================*
  *				do_link					     *
@@ -178,7 +181,7 @@ register struct inode *rip; /* pointer to inode to be truncated */
     free_zone(dev, rip->i_zone[NR_DZONE_NUM]); /* single indirect zone */
     if ((z = rip->i_zone[NR_DZONE_NUM + 1]) != kNoZone) {
         b = (block_nr)z << scale;
-        bp = get_block(dev, b, NORMAL); /* get double indirect zone */
+        bp = get_block(dev, b, IoMode::Normal); /* get double indirect zone */
         for (iz = &bp->b_ind[0]; iz < &bp->b_ind[NR_INDIRECTS]; iz++) {
             free_zone(dev, *iz);
         }

--- a/fs/main.cpp
+++ b/fs/main.cpp
@@ -21,6 +21,9 @@
 #include "param.hpp"
 #include "super.hpp"
 #include "type.hpp"
+#include <minix/fs/const.hpp>
+
+using IoMode = minix::fs::DefaultFsConstants::IoMode;
 #include <cstddef>    // For std::size_t
 #include <cstdint>    // For uint16_t, uint32_t, uint64_t, int64_t, int32_t, uint8_t
 #include <inttypes.h> // For PRId64
@@ -209,7 +212,7 @@ static void load_ram() {
     init_data_clicks = data_org[INFO + 2];
 
     /* Get size of RAM disk by reading root file system's super block */
-    bp = get_block(BOOT_DEV, SUPER_BLOCK, NORMAL); /* get RAM super block */
+    bp = get_block(BOOT_DEV, SUPER_BLOCK, IoMode::Normal); /* get RAM super block */
     copy(super_block, bp->b_data, sizeof(struct super_block));
     sp = &super_block[0];
     if (sp->s_magic != SUPER_MAGIC)
@@ -250,8 +253,8 @@ static void load_ram() {
     printf("Loading RAM disk from root diskette.      Loaded:   0K ");
     for (i = 0; i < count; i++) { // i is uint16_t, count is uint32_t
         bp = get_block(BOOT_DEV, static_cast<uint16_t>(i),
-                       NORMAL); // get_block takes block_nr (uint16_t)
-        bp1 = get_block(ROOT_DEV, i, NO_READ);
+                       IoMode::Normal); // get_block takes block_nr (uint16_t)
+        bp1 = get_block(ROOT_DEV, i, IoMode::NoRead);
         copy(bp1->b_data, bp->b_data, BLOCK_SIZE);
         bp1->b_dirt = DIRTY;
         put_block(bp, I_MAP_BLOCK);

--- a/fs/path.cpp
+++ b/fs/path.cpp
@@ -20,6 +20,9 @@
 #include "inode.hpp"
 #include "super.hpp"
 #include "type.hpp"
+#include <minix/fs/const.hpp>
+
+using IoMode = minix::fs::DefaultFsConstants::IoMode;
 
 /*===========================================================================*
  *				eat_path				     *
@@ -242,7 +245,7 @@ int search_dir(struct inode *ldir_ptr, char string[NAME_SIZE], inode_nr *numb, i
         b = read_map(ldir_ptr, pos); /* get block number */
 
         /* Since directories don't have holes, 'b' cannot be NO_BLOCK. */
-        bp = get_block(ldir_ptr->i_dev, b, NORMAL); /* get a dir block */
+        bp = get_block(ldir_ptr->i_dev, b, IoMode::Normal); /* get a dir block */
 
         /* Search a directory block. */
         for (dp = &bp->b_dir[0]; dp < &bp->b_dir[NR_DIR_ENTRIES]; dp++) {

--- a/fs/read.cpp
+++ b/fs/read.cpp
@@ -27,6 +27,9 @@
 #include "param.hpp"
 #include "super.hpp"
 #include "type.hpp"
+#include <minix/fs/const.hpp>
+
+using IoMode = minix::fs::DefaultFsConstants::IoMode;
 #include <algorithm> // For std::min
 #include <cstddef>   // For std::size_t
 #include <cstdint>   // For uint16_t, int32_t, int64_t etc.
@@ -234,7 +237,7 @@ static int rw_chunk(struct inode *rip, int32_t position, std::size_t off, std::s
     if (!block_spec && b == kNoBlock) { // kNoBlock is block_nr (uint16_t)
         if (rw_flag == READING) {
             /* Reading from a nonexistent block.  Must read as all zeros. */
-            bp = get_block(kNoDev, kNoBlock, NORMAL);
+            bp = get_block(kNoDev, kNoBlock, IoMode::Normal);
             /* get a buffer */ // kNoDev is dev_nr (uint16_t)
             zero_block(bp);
         } else {
@@ -248,12 +251,12 @@ static int rw_chunk(struct inode *rip, int32_t position, std::size_t off, std::s
          * the cache, acquire it, otherwise just acquire a free buffer.
          */
         // chunk is std::size_t, BLOCK_SIZE is int
-        n = (rw_flag == WRITING && chunk == static_cast<std::size_t>(BLOCK_SIZE) ? NO_READ
-                                                                                 : NORMAL);
+        n = (rw_flag == WRITING && chunk == static_cast<std::size_t>(BLOCK_SIZE) ? IoMode::NoRead
+                                                                                 : IoMode::Normal);
         // position is int32_t, compat_get_size returns file_pos64 (int64_t), off is std::size_t
         if (rw_flag == WRITING && off == 0 &&
             static_cast<int64_t>(position) >= compat_get_size(rip))
-            n = NO_READ;
+            n = IoMode::NoRead;
         bp = get_block(dev, b, n); // dev, b are uint16_t
     }
 
@@ -322,7 +325,7 @@ PUBLIC uint16_t read_map(struct inode *rip,
         excess -= static_cast<int32_t>(NR_INDIRECTS); /* single indir doesn't count */
         // z is uint16_t, b is uint16_t
         b = static_cast<uint16_t>(static_cast<uint32_t>(z) << scale);
-        bp = get_block(rip->i_dev, b, NORMAL);
+        bp = get_block(rip->i_dev, b, IoMode::Normal);
         /* get double indirect block */ // rip->i_dev is dev_nr (uint16_t)
         // bp->b_ind is zone_nr[] (uint16_t[]). excess / NR_INDIRECTS is int32_t / size_t.
         z = bp->b_ind[static_cast<std::size_t>(excess / static_cast<int32_t>(NR_INDIRECTS))];
@@ -335,7 +338,7 @@ PUBLIC uint16_t read_map(struct inode *rip,
         return (kNoBlock);
     // z is uint16_t, b is uint16_t
     b = static_cast<uint16_t>(static_cast<uint32_t>(z) << scale);
-    bp = get_block(rip->i_dev, b, NORMAL);           /* get single indirect block */
+    bp = get_block(rip->i_dev, b, IoMode::Normal);   /* get single indirect block */
     z = bp->b_ind[static_cast<std::size_t>(excess)]; // excess is int32_t
     put_block(bp, INDIRECT_BLOCK);                   /* release single indirect blk */
     if (z == kNoZone)
@@ -401,6 +404,6 @@ PUBLIC void read_ahead() { // Modernized signature (was already using ())
     if ((b = read_map(rip, rdahedpos)) == kNoBlock) // kNoBlock is block_nr (uint16_t)
         return;                                     /* at EOF */
     // rip->i_dev is dev_nr (uint16_t). b is uint16_t.
-    bp = get_block(rip->i_dev, b, NORMAL);
+    bp = get_block(rip->i_dev, b, IoMode::Normal);
     put_block(bp, PARTIAL_DATA_BLOCK);
 }

--- a/fs/super.cpp
+++ b/fs/super.cpp
@@ -22,6 +22,9 @@
 #include "const.hpp"
 #include "inode.hpp"
 #include "type.hpp"
+#include <minix/fs/const.hpp>
+
+using IoMode = minix::fs::DefaultFsConstants::IoMode;
 
 #define INT_BITS (sizeof(int) << 3)
 #define BIT_MAP_SHIFT 13 /* (log2 of BLOCK_SIZE) + 3; 13 for 1k blocks */
@@ -48,12 +51,12 @@ dev_nr dev; /* which device? */
 
     /* Load the inode map from the disk. */
     for (i = 0; i < sp->s_imap_blocks; i++)
-        sp->s_imap[i] = get_block(dev, SUPER_BLOCK + 1 + i, NORMAL);
+        sp->s_imap[i] = get_block(dev, SUPER_BLOCK + 1 + i, IoMode::Normal);
 
     /* Load the zone map from the disk. */
     zbase = SUPER_BLOCK + 1 + sp->s_imap_blocks;
     for (i = 0; i < sp->s_zmap_blocks; i++)
-        sp->s_zmap[i] = get_block(dev, zbase + i, NORMAL);
+        sp->s_zmap[i] = get_block(dev, zbase + i, IoMode::Normal);
 
     /* inodes 0 and 1, and zone 0 are never allocated.  Mark them as busy. */
     sp->s_imap[0]->b_int[0] |= 3; /* inodes 0, 1 busy */
@@ -237,12 +240,12 @@ int rw_flag;                     /* READING or WRITING */
     /* Check if this is a read or write, and do it. */
     if (rw_flag == READING) {
         dev = sp->s_dev; /* save device; it will be overwritten by copy*/
-        bp = get_block(sp->s_dev, (block_nr)SUPER_BLOCK, NORMAL);
+        bp = get_block(sp->s_dev, (block_nr)SUPER_BLOCK, IoMode::Normal);
         copy((char *)sp, bp->b_data, SUPER_SIZE);
         sp->s_dev = dev; /* restore device number */
     } else {
         /* On a write, it is not necessary to go read superblock from disk. */
-        bp = get_block(sp->s_dev, (block_nr)SUPER_BLOCK, NO_READ);
+        bp = get_block(sp->s_dev, (block_nr)SUPER_BLOCK, IoMode::NoRead);
         copy(bp->b_data, (char *)sp, SUPER_SIZE);
         bp->b_dirt = DIRTY;
     }

--- a/fs/write.cpp
+++ b/fs/write.cpp
@@ -22,6 +22,9 @@
 #include "inode.hpp"
 #include "super.hpp"
 #include "type.hpp"
+#include <minix/fs/const.hpp>
+
+using IoMode = minix::fs::DefaultFsConstants::IoMode;
 #include <cstddef> // For std::size_t, nullptr
 #include <cstdint> // For uint16_t, int32_t, uint32_t, int64_t
 
@@ -98,7 +101,7 @@ static int write_map(struct inode *rip, int32_t position, uint16_t new_zone) {
         // z is uint16_t, b is uint16_t. scale is int.
         b = static_cast<uint16_t>(static_cast<uint32_t>(z) << scale);
         // rip->i_dev is dev_nr (uint16_t), b is block_nr (uint16_t).
-        bp = get_block(rip->i_dev, b, (new_dbl ? NO_READ : NORMAL));
+        bp = get_block(rip->i_dev, b, (new_dbl ? IoMode::NoRead : IoMode::Normal));
         if (new_dbl)
             zero_block(bp);
         zp = &bp->b_ind[index]; // bp->b_ind is zone_nr[] (uint16_t[])
@@ -121,7 +124,7 @@ static int write_map(struct inode *rip, int32_t position, uint16_t new_zone) {
     /* 'zp' now points to indirect block's zone number. */
     // *zp is uint16_t, b is uint16_t, scale is int
     b = static_cast<uint16_t>(static_cast<uint32_t>(*zp) << scale);
-    bp = get_block(rip->i_dev, b, (new_ind ? NO_READ : NORMAL));
+    bp = get_block(rip->i_dev, b, (new_ind ? IoMode::NoRead : IoMode::Normal));
     if (new_ind)
         zero_block(bp);
     // bp->b_ind is uint16_t[]. excess is int32_t (small index). new_zone is uint16_t.
@@ -177,7 +180,7 @@ PUBLIC void clear_zone(struct inode *rip, int32_t pos, int flag) {
     /* Clear all the blocks between 'blo' and 'bhi'. */
     for (b = blo; b <= bhi; b++) { // b, blo, bhi are uint16_t
         // rip->i_dev is dev_nr (uint16_t)
-        bp = get_block(rip->i_dev, b, NO_READ);
+        bp = get_block(rip->i_dev, b, IoMode::NoRead);
         zero_block(bp);
         put_block(bp, FULL_DATA_BLOCK);
     }
@@ -238,7 +241,7 @@ PUBLIC struct buf *new_block(struct inode *rip, int32_t position) {
             static_cast<uint16_t>((static_cast<uint32_t>(position) % zone_size) / BLOCK_SIZE);
     }
 
-    bp = get_block(rip->i_dev, b, NO_READ); // rip->i_dev is dev_nr, b is block_nr
+    bp = get_block(rip->i_dev, b, IoMode::NoRead); // rip->i_dev is dev_nr, b is block_nr
     zero_block(bp);
     return (bp);
 }


### PR DESCRIPTION
## Summary
- modernize fs/cache.cpp with modern signatures and RAII comments
- replace legacy PUBLIC macros and K&R style
- adopt IoMode enumeration across filesystem callers
- format sources with clang-format

## Testing
- `ctest --output-on-failure` *(fails: No tests were found)*

------
https://chatgpt.com/codex/tasks/task_e_6851d8f5d57483319ef73e725e9ff954