### PR TITLE
Add configurable node ID directory

### DIFF
--- a/docs/sphinx/networking.rst
+++ b/docs/sphinx/networking.rst
@@ -48,7 +48,8 @@ Node Identity
 -------------
 Each node assigns itself a numeric ``node_t`` identifier when
 :cpp:func:`net::init` executes.  The ``node_id`` and UDP port are
-provided via the configuration structure.  After initialization,
+provided via the configuration structure along with ``node_id_dir``
+which specifies where the identifier is persisted.  After initialization,
 :cpp:func:`net::local_node` reports this identifier and all outgoing
 packets carry it as the source ID so peers can validate who originated
 each message.
@@ -64,8 +65,10 @@ Windows—and hashes the first active device that is not a loopback interface.
 Should this process fail, the driver falls back to hashing the local host name.
 The computed identifier is non-zero and remains constant for the lifetime of
 the process. When the identifier is computed it is written to
-``/etc/xinim/node_id`` so that subsequent invocations of :cpp:func:`net::init`
-reuse the same value.
+``node_id_dir/node_id`` so that subsequent invocations of :cpp:func:`net::init`
+reuse the same value. If running without root privileges and
+``node_id_dir`` is unspecified, the driver defaults to
+``$XDG_STATE_HOME/xinim`` or ``$HOME/.xinim``.
 
 Implementation Steps
 ~~~~~~~~~~~~~~~~~~~~

--- a/kernel/net_driver.cpp
+++ b/kernel/net_driver.cpp
@@ -16,6 +16,7 @@
 #include <array>
 #include <atomic>
 #include <cerrno>
+#include <cstdlib>
 #include <cstring>
 #include <deque>
 #include <filesystem>
@@ -29,8 +30,6 @@
 
 namespace net {
 namespace {
-
-constexpr char NODE_ID_FILE[] = "/etc/xinim/node_id";
 
 static Config g_cfg{};
 static int g_udp_sock = -1;
@@ -52,14 +51,35 @@ static RecvCallback g_callback;
 static std::atomic<bool> g_running{false};
 static std::jthread g_udp_thread, g_tcp_thread;
 
+/**
+ * @brief Determine the file used to persist the node identifier.
+ */
+[[nodiscard]] static std::filesystem::path node_id_file() {
+    if (!g_cfg.node_id_dir.empty()) {
+        return g_cfg.node_id_dir / "node_id";
+    }
+    if (::geteuid() == 0) {
+        return std::filesystem::path{"/etc/xinim"} / "node_id";
+    }
+    if (const char *xdg = std::getenv("XDG_STATE_HOME")) {
+        return std::filesystem::path{xdg} / "xinim" / "node_id";
+    }
+    if (const char *home = std::getenv("HOME")) {
+        return std::filesystem::path{home} / ".xinim" / "node_id";
+    }
+    return std::filesystem::path{"node_id"};
+}
+
 [[nodiscard]] static bool connection_lost(int err) noexcept {
     return err == EPIPE || err == ECONNRESET || err == ENOTCONN || err == ECONNABORTED;
 }
 
 static void reconnect_tcp(Remote &rem) {
-    if (rem.tcp_fd >= 0) ::close(rem.tcp_fd);
+    if (rem.tcp_fd >= 0)
+        ::close(rem.tcp_fd);
     rem.tcp_fd = ::socket(rem.addr.ss_family, SOCK_STREAM, 0);
-    if (rem.tcp_fd < 0) throw std::system_error(errno, std::generic_category(), "net_driver: socket");
+    if (rem.tcp_fd < 0)
+        throw std::system_error(errno, std::generic_category(), "net_driver: socket");
     if (::connect(rem.tcp_fd, reinterpret_cast<sockaddr *>(&rem.addr), rem.addr_len) != 0) {
         int err = errno;
         ::close(rem.tcp_fd);
@@ -79,11 +99,13 @@ static void reconnect_tcp(Remote &rem) {
 static void enqueue_packet(Packet &&pkt) {
     std::lock_guard lock{g_mutex};
     if (g_cfg.max_queue_length > 0 && g_queue.size() >= g_cfg.max_queue_length) {
-        if (g_cfg.overflow == OverflowPolicy::DropNewest) return;
+        if (g_cfg.overflow == OverflowPolicy::DropNewest)
+            return;
         g_queue.pop_front(); // DropOldest
     }
     g_queue.push_back(std::move(pkt));
-    if (g_callback) g_callback(g_queue.back());
+    if (g_callback)
+        g_callback(g_queue.back());
 }
 
 static void udp_recv_loop() {
@@ -93,7 +115,8 @@ static void udp_recv_loop() {
         socklen_t len = sizeof(peer);
         ssize_t n = ::recvfrom(g_udp_sock, buf.data(), buf.size(), 0,
                                reinterpret_cast<sockaddr *>(&peer), &len);
-        if (n <= static_cast<ssize_t>(sizeof(node_t))) continue;
+        if (n <= static_cast<ssize_t>(sizeof(node_t)))
+            continue;
 
         Packet pkt;
         std::memcpy(&pkt.src_node, buf.data(), sizeof(pkt.src_node));
@@ -108,12 +131,14 @@ static void tcp_accept_loop() {
         sockaddr_storage peer{};
         socklen_t len = sizeof(peer);
         int client = ::accept(g_tcp_listen, reinterpret_cast<sockaddr *>(&peer), &len);
-        if (client < 0) continue;
+        if (client < 0)
+            continue;
 
         std::array<std::byte, 2048> buf;
         while (true) {
             ssize_t n = ::recv(client, buf.data(), buf.size(), 0);
-            if (n <= static_cast<ssize_t>(sizeof(node_t))) break;
+            if (n <= static_cast<ssize_t>(sizeof(node_t)))
+                break;
             Packet pkt;
             std::memcpy(&pkt.src_node, buf.data(), sizeof(pkt.src_node));
             pkt.payload.assign(buf.begin() + sizeof(pkt.src_node), buf.begin() + n);
@@ -129,12 +154,14 @@ void init(const Config &cfg) {
     g_cfg = cfg;
 
     if (g_cfg.node_id == 0) {
-        std::ifstream in{NODE_ID_FILE};
-        if (in) in >> g_cfg.node_id;
+        std::ifstream in{node_id_file()};
+        if (in)
+            in >> g_cfg.node_id;
     }
 
     g_udp_sock = ::socket(AF_INET6, SOCK_DGRAM, 0);
-    if (g_udp_sock < 0) throw std::system_error(errno, std::generic_category(), "UDP socket");
+    if (g_udp_sock < 0)
+        throw std::system_error(errno, std::generic_category(), "UDP socket");
     int off = 0;
     ::setsockopt(g_udp_sock, IPPROTO_IPV6, IPV6_V6ONLY, &off, sizeof(off));
     sockaddr_in6 addr6{};
@@ -145,7 +172,8 @@ void init(const Config &cfg) {
         throw std::system_error(errno, std::generic_category(), "UDP bind");
 
     g_tcp_listen = ::socket(AF_INET6, SOCK_STREAM, 0);
-    if (g_tcp_listen < 0) throw std::system_error(errno, std::generic_category(), "TCP socket");
+    if (g_tcp_listen < 0)
+        throw std::system_error(errno, std::generic_category(), "TCP socket");
     ::setsockopt(g_tcp_listen, SOL_SOCKET, SO_REUSEADDR, &off, sizeof(off));
     ::setsockopt(g_tcp_listen, IPPROTO_IPV6, IPV6_V6ONLY, &off, sizeof(off));
     if (::bind(g_tcp_listen, reinterpret_cast<sockaddr *>(&addr6), sizeof(addr6)) < 0)
@@ -158,10 +186,19 @@ void init(const Config &cfg) {
 
 void shutdown() noexcept {
     g_running.store(false, std::memory_order_relaxed);
-    if (g_udp_sock != -1) { ::close(g_udp_sock); g_udp_sock = -1; }
-    if (g_tcp_listen != -1) { ::shutdown(g_tcp_listen, SHUT_RDWR); ::close(g_tcp_listen); g_tcp_listen = -1; }
-    if (g_udp_thread.joinable()) g_udp_thread.join();
-    if (g_tcp_thread.joinable()) g_tcp_thread.join();
+    if (g_udp_sock != -1) {
+        ::close(g_udp_sock);
+        g_udp_sock = -1;
+    }
+    if (g_tcp_listen != -1) {
+        ::shutdown(g_tcp_listen, SHUT_RDWR);
+        ::close(g_tcp_listen);
+        g_tcp_listen = -1;
+    }
+    if (g_udp_thread.joinable())
+        g_udp_thread.join();
+    if (g_tcp_thread.joinable())
+        g_tcp_thread.join();
 
     std::lock_guard lock{g_mutex};
     g_queue.clear();
@@ -200,7 +237,8 @@ void add_remote(node_t node, const std::string &host, uint16_t port, Protocol pr
         }
     }
     ::freeaddrinfo(res);
-    if (rem.addr_len == 0) throw std::invalid_argument("host address resolution failed");
+    if (rem.addr_len == 0)
+        throw std::invalid_argument("host address resolution failed");
 
     if (proto == Protocol::TCP) {
         reconnect_tcp(rem);
@@ -210,23 +248,24 @@ void add_remote(node_t node, const std::string &host, uint16_t port, Protocol pr
     g_remotes[node] = rem;
 }
 
-void set_recv_callback(RecvCallback cb) {
-    g_callback = std::move(cb);
-}
+void set_recv_callback(RecvCallback cb) { g_callback = std::move(cb); }
 
 node_t local_node() noexcept {
-    if (g_cfg.node_id != 0) return g_cfg.node_id;
+    if (g_cfg.node_id != 0)
+        return g_cfg.node_id;
 
-    std::ifstream in{NODE_ID_FILE};
+    std::ifstream in{node_id_file()};
     if (in) {
         in >> g_cfg.node_id;
-        if (g_cfg.node_id != 0) return g_cfg.node_id;
+        if (g_cfg.node_id != 0)
+            return g_cfg.node_id;
     }
 
     ifaddrs *ifa = nullptr;
     if (::getifaddrs(&ifa) == 0) {
         for (auto *cur = ifa; cur != nullptr; cur = cur->ifa_next) {
-            if (!(cur->ifa_flags & IFF_UP) || (cur->ifa_flags & IFF_LOOPBACK)) continue;
+            if (!(cur->ifa_flags & IFF_UP) || (cur->ifa_flags & IFF_LOOPBACK))
+                continue;
 
             if (cur->ifa_addr && cur->ifa_addr->sa_family == AF_PACKET) {
                 auto *ll = reinterpret_cast<sockaddr_ll *>(cur->ifa_addr);
@@ -235,8 +274,9 @@ node_t local_node() noexcept {
                     val = val * 131 + ll->sll_addr[i];
                 ::freeifaddrs(ifa);
                 g_cfg.node_id = static_cast<node_t>(val & 0x7fffffff);
-                std::filesystem::create_directories("/etc/xinim");
-                std::ofstream out{NODE_ID_FILE};
+                auto path = node_id_file();
+                std::filesystem::create_directories(path.parent_path());
+                std::ofstream out{path};
                 out << g_cfg.node_id;
                 return g_cfg.node_id;
             }
@@ -245,11 +285,13 @@ node_t local_node() noexcept {
                 auto *sin = reinterpret_cast<sockaddr_in *>(cur->ifa_addr);
                 const auto *b = reinterpret_cast<const uint8_t *>(&sin->sin_addr);
                 std::size_t val = 0;
-                for (int i = 0; i < 4; ++i) val = val * 131 + b[i];
+                for (int i = 0; i < 4; ++i)
+                    val = val * 131 + b[i];
                 ::freeifaddrs(ifa);
                 g_cfg.node_id = static_cast<node_t>(val & 0x7fffffff);
-                std::filesystem::create_directories("/etc/xinim");
-                std::ofstream out{NODE_ID_FILE};
+                auto path = node_id_file();
+                std::filesystem::create_directories(path.parent_path());
+                std::ofstream out{path};
                 out << g_cfg.node_id;
                 return g_cfg.node_id;
             }
@@ -260,8 +302,9 @@ node_t local_node() noexcept {
     char host[256]{};
     if (::gethostname(host, sizeof(host)) == 0) {
         g_cfg.node_id = static_cast<node_t>(std::hash<std::string_view>{}(host) & 0x7fffffff);
-        std::filesystem::create_directories("/etc/xinim");
-        std::ofstream out{NODE_ID_FILE};
+        auto path = node_id_file();
+        std::filesystem::create_directories(path.parent_path());
+        std::ofstream out{path};
         out << g_cfg.node_id;
         return g_cfg.node_id;
     }
@@ -274,7 +317,8 @@ std::errc send(node_t node, std::span<const std::byte> data) {
     {
         std::lock_guard lock{g_remotes_mutex};
         auto it = g_remotes.find(node);
-        if (it == g_remotes.end()) return std::errc::host_unreachable;
+        if (it == g_remotes.end())
+            return std::errc::host_unreachable;
         rem = it->second;
     }
 
@@ -286,8 +330,10 @@ std::errc send(node_t node, std::span<const std::byte> data) {
 
         if (transient) {
             fd = ::socket(rem.addr.ss_family, SOCK_STREAM, 0);
-            if (fd < 0 || ::connect(fd, reinterpret_cast<sockaddr *>(&rem.addr), rem.addr_len) != 0) {
-                if (fd >= 0) ::close(fd);
+            if (fd < 0 ||
+                ::connect(fd, reinterpret_cast<sockaddr *>(&rem.addr), rem.addr_len) != 0) {
+                if (fd >= 0)
+                    ::close(fd);
                 return std::errc::connection_refused;
             }
         }
@@ -296,13 +342,15 @@ std::errc send(node_t node, std::span<const std::byte> data) {
         while (sent < buf.size()) {
             ssize_t n = ::send(fd, buf.data() + sent, buf.size() - sent, 0);
             if (n < 0) {
-                if (transient) ::close(fd);
+                if (transient)
+                    ::close(fd);
                 return std::errc::io_error;
             }
             sent += static_cast<std::size_t>(n);
         }
 
-        if (transient) ::close(fd);
+        if (transient)
+            ::close(fd);
         return std::errc{};
     }
 
@@ -316,7 +364,8 @@ std::errc send(node_t node, std::span<const std::byte> data) {
 
 bool recv(Packet &out) {
     std::lock_guard lock{g_mutex};
-    if (g_queue.empty()) return false;
+    if (g_queue.empty())
+        return false;
     out = std::move(g_queue.front());
     g_queue.pop_front();
     return true;

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -291,6 +291,19 @@ target_link_libraries(minix_test_net_driver_persistent_id PRIVATE Threads::Threa
 add_test(NAME minix_test_net_driver_persistent_id COMMAND minix_test_net_driver_persistent_id)
 
 # -----------------------------------------------------------------------------
+# minix_test_net_driver_unpriv_id
+# -----------------------------------------------------------------------------
+add_executable(minix_test_net_driver_unpriv_id
+  test_net_driver_unpriv_id.cpp
+  ${CMAKE_SOURCE_DIR}/kernel/net_driver.cpp
+)
+target_include_directories(minix_test_net_driver_unpriv_id PUBLIC
+  ${CMAKE_SOURCE_DIR}/kernel
+)
+target_link_libraries(minix_test_net_driver_unpriv_id PRIVATE Threads::Threads)
+add_test(NAME minix_test_net_driver_unpriv_id COMMAND minix_test_net_driver_unpriv_id)
+
+# -----------------------------------------------------------------------------
 # Crypto library
 # -----------------------------------------------------------------------------
 add_subdirectory(crypto)

--- a/tests/test_net_driver_persistent_id.cpp
+++ b/tests/test_net_driver_persistent_id.cpp
@@ -6,21 +6,26 @@
 #include "../kernel/net_driver.hpp"
 
 #include <cassert>
+#include <filesystem>
 #include <unistd.h>
 
 int main() {
-    ::unlink("/etc/xinim/node_id");
+    std::filesystem::path dir{"/tmp/xinim_persist"};
+    std::filesystem::remove_all(dir);
+    std::filesystem::create_directories(dir);
+    const auto file = dir / "node_id";
+    ::unlink(file.c_str());
 
-    net::init(net::Config{0, 16000});
+    net::init(net::Config{0, 16000, 0, net::OverflowPolicy::DropNewest, dir});
     const auto first = net::local_node();
     assert(first != 0);
     net::shutdown();
 
-    net::init(net::Config{0, 16000});
+    net::init(net::Config{0, 16000, 0, net::OverflowPolicy::DropNewest, dir});
     const auto second = net::local_node();
     assert(first == second);
     net::shutdown();
 
-    ::unlink("/etc/xinim/node_id");
+    std::filesystem::remove_all(dir);
     return 0;
 }

--- a/tests/test_net_driver_unpriv_id.cpp
+++ b/tests/test_net_driver_unpriv_id.cpp
@@ -1,0 +1,36 @@
+/**
+ * @file test_net_driver_unpriv_id.cpp
+ * @brief Verify node identifier persistence in unprivileged directories.
+ */
+
+#include "../kernel/net_driver.hpp"
+
+#include <cassert>
+#include <cstdlib>
+#include <filesystem>
+#include <unistd.h>
+
+int main() {
+    const char *tmp = std::getenv("TMPDIR");
+    if (!tmp)
+        tmp = "/tmp";
+    std::filesystem::path dir = std::filesystem::path{tmp} / "xinim_unpriv";
+    std::filesystem::remove_all(dir);
+    std::filesystem::create_directories(dir);
+    setenv("XDG_STATE_HOME", dir.c_str(), 1);
+    setuid(65534); // drop privileges
+
+    net::init({0, 16010});
+    const auto first = net::local_node();
+    assert(first != 0);
+    net::shutdown();
+
+    net::init({0, 16010});
+    const auto second = net::local_node();
+    assert(second == first);
+    net::shutdown();
+
+    assert(std::filesystem::exists(dir / "xinim" / "node_id"));
+    std::filesystem::remove_all(dir);
+    return 0;
+}


### PR DESCRIPTION
## Summary
- allow `net::init` to specify `node_id_dir` for identifier persistence
- persist node identifiers in user directories when unprivileged
- document new behaviour
- add tests for persistent ID and unprivileged operation

## Testing
- `cmake --build build --target minix_test_net_driver_persistent_id minix_test_net_driver_unpriv_id`
- `timeout 5s ./tests/minix_test_net_driver_persistent_id; echo exit_code:$?`
- `timeout 5s ./tests/minix_test_net_driver_unpriv_id; echo exit_code:$?`

------
https://chatgpt.com/codex/tasks/task_e_6851e628e0fc8331a5d261a43235a609