### PR TITLE
Add AEAD encryption to lattice IPC

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -37,6 +37,7 @@ macro(add_lattice_test name test_src)
     target_include_directories(${name} PRIVATE
         ${XINIM_INCLUDES}
         ${CMAKE_SOURCE_DIR}/crypto
+        ${CMAKE_SOURCE_DIR}/tests
     )
     target_compile_definitions(${name} PRIVATE EXTERN=extern)
     target_link_libraries(${name} PRIVATE pqcrypto Threads::Threads)

--- a/tests/sodium.h
+++ b/tests/sodium.h
@@ -17,9 +17,22 @@ int crypto_aead_chacha20poly1305_ietf_decrypt(unsigned char *m, unsigned long lo
                                               unsigned long long clen, const unsigned char *ad,
                                               unsigned long long adlen, const unsigned char *npub,
                                               const unsigned char *k);
+int crypto_aead_xchacha20poly1305_ietf_encrypt(unsigned char *c, unsigned long long *clen,
+                                               const unsigned char *m, unsigned long long mlen,
+                                               const unsigned char *ad, unsigned long long adlen,
+                                               const unsigned char *nsec, const unsigned char *npub,
+                                               const unsigned char *k);
+int crypto_aead_xchacha20poly1305_ietf_decrypt(unsigned char *m, unsigned long long *mlen,
+                                               unsigned char *nsec, const unsigned char *c,
+                                               unsigned long long clen, const unsigned char *ad,
+                                               unsigned long long adlen, const unsigned char *npub,
+                                               const unsigned char *k);
 void randombytes_buf(void *buf, size_t size);
 
 #define crypto_aead_chacha20poly1305_ietf_ABYTES 16
+#define crypto_aead_xchacha20poly1305_ietf_ABYTES 16
+#define crypto_aead_xchacha20poly1305_ietf_KEYBYTES 32
+#define crypto_aead_xchacha20poly1305_ietf_NPUBBYTES 24
 
 #ifdef __cplusplus
 }

--- a/tests/sodium_stub.cpp
+++ b/tests/sodium_stub.cpp
@@ -41,6 +41,32 @@ int crypto_aead_chacha20poly1305_ietf_decrypt(unsigned char *m, unsigned long lo
     return 0;
 }
 
+/// Encrypt data by copying the plaintext and appending a zero tag (XChaCha20 variant).
+int crypto_aead_xchacha20poly1305_ietf_encrypt(unsigned char *c, unsigned long long *clen,
+                                               const unsigned char *m, unsigned long long mlen,
+                                               const unsigned char *, unsigned long long,
+                                               const unsigned char *, const unsigned char *,
+                                               const unsigned char *) {
+    std::memcpy(c, m, mlen);
+    std::memset(c + mlen, 0, crypto_aead_xchacha20poly1305_ietf_ABYTES);
+    *clen = mlen + crypto_aead_xchacha20poly1305_ietf_ABYTES;
+    return 0;
+}
+
+/// Decrypt data produced by the stub XChaCha20 encrypt routine.
+int crypto_aead_xchacha20poly1305_ietf_decrypt(unsigned char *m, unsigned long long *mlen,
+                                               unsigned char *, const unsigned char *c,
+                                               unsigned long long clen, const unsigned char *,
+                                               unsigned long long, const unsigned char *,
+                                               const unsigned char *) {
+    if (clen < crypto_aead_xchacha20poly1305_ietf_ABYTES) {
+        return -1;
+    }
+    *mlen = clen - crypto_aead_xchacha20poly1305_ietf_ABYTES;
+    std::memcpy(m, c, *mlen);
+    return 0;
+}
+
 /// Fill a buffer with pseudo random bytes using ``std::random_device``.
 void randombytes_buf(void *buf, size_t size) {
     static std::random_device rd;


### PR DESCRIPTION
## Summary
- adopt libsodium XChaCha20-Poly1305 for lattice IPC
- derive per-channel AEAD keys from post-quantum handshake
- update IPC send/recv paths with nonce and MAC handling
- document AEAD based security model
- update tests and build scripts for the new libsodium header

## Testing
- `cmake ..`
- `make minix_test_lattice_network_encrypted`

------
https://chatgpt.com/codex/tasks/task_e_6851e62f32fc8331b5167e6918266914