### PR TITLE
Handle socket errors in net driver

### DIFF
--- a/kernel/net_driver.hpp
+++ b/kernel/net_driver.hpp
@@ -38,8 +38,8 @@ using node_t = int;
  * received as a Packet with the `src_node` field and a payload vector.
  */
 struct Packet {
-    node_t src_node;                  ///< Originating node ID
-    std::vector<std::byte> payload;  ///< Message payload (excluding prefix)
+    node_t src_node;                ///< Originating node ID
+    std::vector<std::byte> payload; ///< Message payload (excluding prefix)
 };
 
 /**
@@ -65,14 +65,12 @@ enum class Protocol {
  * Use `node_id = 0` to auto-detect the ID and persist it to `/etc/xinim/node_id`.
  */
 struct Config {
-    node_t node_id;                 ///< Preferred node identifier (0 = auto-detect)
-    std::uint16_t port;            ///< Local port to bind UDP/TCP sockets
-    std::size_t max_queue_length;  ///< Maximum packets in the receive queue
-    OverflowPolicy overflow;       ///< Policy when the receive queue overflows
+    node_t node_id;               ///< Preferred node identifier (0 = auto-detect)
+    std::uint16_t port;           ///< Local port to bind UDP/TCP sockets
+    std::size_t max_queue_length; ///< Maximum packets in the receive queue
+    OverflowPolicy overflow;      ///< Policy when the receive queue overflows
 
-    constexpr Config(node_t node_id_ = 0,
-                     std::uint16_t port_ = 0,
-                     std::size_t max_len = 0,
+    constexpr Config(node_t node_id_ = 0, std::uint16_t port_ = 0, std::size_t max_len = 0,
                      OverflowPolicy policy = OverflowPolicy::DropNewest) noexcept
         : node_id(node_id_), port(port_), max_queue_length(max_len), overflow(policy) {}
 };
@@ -164,5 +162,12 @@ void shutdown() noexcept;
  * @brief Clear all pending packets in the receive queue.
  */
 void reset() noexcept;
+
+/**
+ * @brief Intentionally close all network sockets to simulate failure.
+ *
+ * Used only by unit tests to trigger error-handling paths.
+ */
+void simulate_socket_failure() noexcept;
 
 } // namespace net

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -291,6 +291,19 @@ target_link_libraries(minix_test_net_driver_persistent_id PRIVATE Threads::Threa
 add_test(NAME minix_test_net_driver_persistent_id COMMAND minix_test_net_driver_persistent_id)
 
 # -----------------------------------------------------------------------------
+# minix_test_net_driver_socket_failure
+# -----------------------------------------------------------------------------
+add_executable(minix_test_net_driver_socket_failure
+  test_net_driver_socket_failure.cpp
+  ${CMAKE_SOURCE_DIR}/kernel/net_driver.cpp
+)
+target_include_directories(minix_test_net_driver_socket_failure PUBLIC
+  ${CMAKE_SOURCE_DIR}/kernel
+)
+target_link_libraries(minix_test_net_driver_socket_failure PRIVATE Threads::Threads)
+add_test(NAME minix_test_net_driver_socket_failure COMMAND minix_test_net_driver_socket_failure)
+
+# -----------------------------------------------------------------------------
 # Crypto library
 # -----------------------------------------------------------------------------
 add_subdirectory(crypto)

--- a/tests/test_net_driver_socket_failure.cpp
+++ b/tests/test_net_driver_socket_failure.cpp
@@ -1,0 +1,32 @@
+/**
+ * @file test_net_driver_socket_failure.cpp
+ * @brief Verify graceful handling of socket failures in the network driver.
+ */
+
+#include "../kernel/net_driver.hpp"
+
+#include <array>
+#include <cassert>
+#include <chrono>
+#include <thread>
+
+using namespace std::chrono_literals;
+
+int main() {
+    constexpr net::node_t SELF = 200;
+    constexpr net::node_t PEER = 201;
+    constexpr uint16_t PORT_SELF = 17050;
+    constexpr uint16_t PORT_PEER = 17051;
+
+    net::init(net::Config{SELF, PORT_SELF});
+    net::add_remote(PEER, "127.0.0.1", PORT_PEER);
+
+    net::simulate_socket_failure();
+    std::this_thread::sleep_for(50ms);
+
+    std::array<std::byte, 1> payload{std::byte{0}};
+    assert(net::send(PEER, payload) == std::errc::io_error);
+
+    net::shutdown();
+    return 0;
+}


### PR DESCRIPTION
## Summary
- add error checking and sleep backoff in network recv loops
- expose testing helper to close sockets
- test socket failure handling

## Testing
- `cmake --build build` *(fails: printf not declared)*

------
https://chatgpt.com/codex/tasks/task_e_6851e6332b0c8331b1b520da1e4c7f94

## Summary by Sourcery

Improve robustness of the net driver by adding error handling and recovery for socket failures, exposing a failure simulation hook for tests, and ensuring clean resource shutdown.

New Features:
- Expose simulate_socket_failure() API to programmatically close sockets for testing
- Add a new unit test executable and CMake target to verify graceful handling of socket failures

Bug Fixes:
- Detect TCP send failures, reconnect transient sockets, and retry transmissions
- Skip spurious short packets in receive loops to prevent stalled or invalid reads

Enhancements:
- Clean up shutdown procedure to join threads, clear queues, and close all remote sockets
- Streamline error messages and simplify one-line statements across the codebase

Documentation:
- Document simulate_socket_failure() in the public header and refine API comments for C++23 usage

Tests:
- Integrate test_net_driver_socket_failure into the CI build to assert io_error on closed sockets