### PR TITLE
Refactor network driver into class

### DIFF
--- a/docs/sphinx/lattice_ipc.rst
+++ b/docs/sphinx/lattice_ipc.rst
@@ -37,8 +37,8 @@ Each `message` is serialized as:
 **Pipeline**:
 1. **Frame**: prefix with `src_pid` and `dst_pid` (both ints)  
 2. **Encrypt**: XOR‐stream with the channel’s shared secret  
-3. **Transmit**: `net::send()` (UDP or TCP)  
-4. **Receive**: `net::recv()`  
+3. **Transmit**: `net::driver.send()` (UDP or TCP)
+4. **Receive**: `net::driver.recv()`
 5. **Reintegrate**: `lattice::poll_network()` decrypts and enqueues  
 
 Network Driver Behavior
@@ -65,12 +65,12 @@ Configuration (`net::Config`):
 Network Driver
 --------------
 The networking backend transports packets over UDP or TCP. Calling
-:cpp:func:`net::init` binds the UDP socket and spawns background threads for
+:cpp:func:`net::Driver::init` binds the UDP socket and spawns background threads for
 receives and TCP connection handling. Each remote node registers its address
-with :cpp:func:`net::add_remote`. Frames are transmitted by
-:cpp:func:`net::send`. For TCP peers the function establishes a transient
+with :cpp:func:`net::Driver::add_remote`. Frames are transmitted by
+:cpp:func:`net::Driver::send`. For TCP peers the function establishes a transient
 connection when necessary and automatically reconnects persistent sockets
-when writes fail due to ``EPIPE`` or connection reset. ``net::send`` now
+when writes fail due to ``EPIPE`` or connection reset. ``net::Driver::send`` now
 returns a ``std::errc`` value
 where ``std::errc::success`` indicates success. Socket failures such as
 ``ECONNREFUSED`` propagate as ``std::system_error`` exceptions. Incoming
@@ -81,8 +81,8 @@ Example
 ^^^^^^^
 .. code-block:: cpp
 
-   net::init({0, 15000});
-net::add_remote(1, "127.0.0.1", 15001);
+   net::driver.init({0, 15000});
+net::driver.add_remote(1, "127.0.0.1", 15001);
 lattice_connect(1, 1, 1);
 
 message ping{};
@@ -95,7 +95,7 @@ for (;;) {
         break;
     }
 }
-net::shutdown();
+net::driver.shutdown();
 
 Local Node Identification
 -------------------------

--- a/kernel/net_driver.cpp
+++ b/kernel/net_driver.cpp
@@ -158,10 +158,6 @@ void Driver::shutdown() noexcept {
         ::close(tcp_listen_);
         tcp_listen_ = -1;
     }
-    if (udp_thread_.joinable())
-        udp_thread_.join();
-    if (tcp_thread_.joinable())
-        tcp_thread_.join();
 
     {
         std::lock_guard lock{mutex_};

--- a/kernel/net_driver.hpp
+++ b/kernel/net_driver.hpp
@@ -8,11 +8,11 @@
  * node ID and routed using a mutex-protected peer registry.
  *
  * Usage:
- *   1. net::init({0, 12000}); // autodetect node_id
- *   2. net::add_remote(2, "192.168.1.4", 12000, Protocol::TCP);
- *   3. net::send(2, payload); // sends [local_node|payload]
- *   4. while (net::recv(pkt)) { process(pkt); }
- *   5. net::shutdown();
+ *   1. net::driver.init({0, 12000});
+ *   2. net::driver.add_remote(2, "192.168.1.4", 12000, Protocol::TCP);
+ *   3. net::driver.send(2, payload); // sends [local_node|payload]
+ *   4. while (net::driver.recv(pkt)) { process(pkt); }
+ *   5. net::driver.shutdown();
  *
  * Thread Safety: All APIs are thread-safe and may be called from multiple threads.
  */
@@ -38,8 +38,8 @@ using node_t = int;
  * received as a Packet with the `src_node` field and a payload vector.
  */
 struct Packet {
-    node_t src_node;                  ///< Originating node ID
-    std::vector<std::byte> payload;  ///< Message payload (excluding prefix)
+    node_t src_node;                ///< Originating node ID
+    std::vector<std::byte> payload; ///< Message payload (excluding prefix)
 };
 
 /**
@@ -65,14 +65,12 @@ enum class Protocol {
  * Use `node_id = 0` to auto-detect the ID and persist it to `/etc/xinim/node_id`.
  */
 struct Config {
-    node_t node_id;                 ///< Preferred node identifier (0 = auto-detect)
-    std::uint16_t port;            ///< Local port to bind UDP/TCP sockets
-    std::size_t max_queue_length;  ///< Maximum packets in the receive queue
-    OverflowPolicy overflow;       ///< Policy when the receive queue overflows
+    node_t node_id;               ///< Preferred node identifier (0 = auto-detect)
+    std::uint16_t port;           ///< Local port to bind UDP/TCP sockets
+    std::size_t max_queue_length; ///< Maximum packets in the receive queue
+    OverflowPolicy overflow;      ///< Policy when the receive queue overflows
 
-    constexpr Config(node_t node_id_ = 0,
-                     std::uint16_t port_ = 0,
-                     std::size_t max_len = 0,
+    constexpr Config(node_t node_id_ = 0, std::uint16_t port_ = 0, std::size_t max_len = 0,
                      OverflowPolicy policy = OverflowPolicy::DropNewest) noexcept
         : node_id(node_id_), port(port_), max_queue_length(max_len), overflow(policy) {}
 };
@@ -83,86 +81,95 @@ struct Config {
 using RecvCallback = std::function<void(const Packet &)>;
 
 /**
- * @brief Initialize the network driver.
- *
- * Initializes dual-stack (IPv4/IPv6) UDP and TCP sockets and launches
- * background receiver threads. The function binds to `cfg.port` for both protocols.
- *
- * @param cfg Driver configuration including port, node ID, and overflow policy.
- * @throws std::system_error on socket failure, bind failure, or thread launch failure.
+ * @brief Networking driver managing sockets, queues, and threads.
  */
-void init(const Config &cfg);
+class Driver {
+  public:
+    Driver() = default;
+    ~Driver();
 
-/**
- * @brief Add a remote peer for subsequent ::send calls.
- *
- * Resolves a host string (IPv4, IPv6, or hostname) and registers the remote node
- * for sending framed messages. TCP peers can reuse persistent sockets.
- *
- * @param node Logical identifier of the remote peer.
- * @param host Hostname or IP address to connect to.
- * @param port Port to use when sending.
- * @param proto Transport protocol (UDP or TCP).
- * @throws std::invalid_argument if the address is invalid.
- * @throws std::system_error if TCP socket or connect fails.
- */
-void add_remote(node_t node, const std::string &host, uint16_t port,
-                Protocol proto = Protocol::UDP);
+    /**
+     * @brief Initialize the driver and spawn worker threads.
+     *
+     * @param cfg Driver configuration including port, node ID, and overflow policy.
+     * @throws std::system_error on socket or thread failure.
+     */
+    void init(const Config &cfg);
 
-/**
- * @brief Register a callback to be invoked on packet arrival.
- *
- * If set, the callback runs in the context of the receiver thread.
- * It is safe to omit this and instead poll with ::recv().
- *
- * @param cb Callback function taking a const Packet&
- */
-void set_recv_callback(RecvCallback cb);
+    /**
+     * @brief Register a remote peer for subsequent transmissions.
+     *
+     * @param node  Logical identifier of the remote peer.
+     * @param host  Hostname or IP address to connect to.
+     * @param port  Port number for sending.
+     * @param proto Transport protocol.
+     */
+    void add_remote(node_t node, const std::string &host, uint16_t port,
+                    Protocol proto = Protocol::UDP);
 
-/**
- * @brief Shutdown the network driver and clean up all resources.
- *
- * Closes all sockets, terminates background threads, clears peer state and queue.
- */
-void shutdown() noexcept;
+    /**
+     * @brief Register a callback invoked on packet arrival.
+     *
+     * @param cb Callback function executed by the receive thread.
+     */
+    void set_recv_callback(RecvCallback cb);
 
-/**
- * @brief Returns the local node identifier.
- *
- * If a node ID was provided in Config, that value is returned.
- * Otherwise, the following procedure is used:
- *   1. Try reading `/etc/xinim/node_id`
- *   2. Derive from first active non-loopback interface (MAC or IP)
- *   3. Fallback to hash of hostname
- *
- * @return Stable integer node identifier (never 0 unless initialization failed).
- */
-[[nodiscard]] node_t local_node() noexcept;
+    /**
+     * @brief Shut down the driver and release all resources.
+     */
+    void shutdown() noexcept;
 
-/**
- * @brief Send a framed message to the specified peer.
- *
- * Frames the payload as `[local_node | data...]` and transmits over UDP
- * or TCP. For TCP, the function will establish a new socket if needed.
- *
- * @param node Destination node ID
- * @param data Payload to send (without prefix)
- * @return std::errc::success on success or a descriptive error code
- * @throws std::system_error for POSIX socket failures (send, connect, etc)
- */
-[[nodiscard]] std::errc send(node_t node, std::span<const std::byte> data);
+    /**
+     * @brief Return the local node identifier.
+     */
+    [[nodiscard]] node_t local_node() noexcept;
 
-/**
- * @brief Retrieve the next available incoming packet.
- *
- * @param out Packet structure to fill in.
- * @return true if a packet was retrieved, false if queue is empty.
- */
-[[nodiscard]] bool recv(Packet &out);
+    /**
+     * @brief Send a framed message to the specified peer.
+     */
+    [[nodiscard]] std::errc send(node_t node, std::span<const std::byte> data);
 
-/**
- * @brief Clear all pending packets in the receive queue.
- */
-void reset() noexcept;
+    /**
+     * @brief Retrieve the next queued packet.
+     */
+    [[nodiscard]] bool recv(Packet &out);
+
+    /**
+     * @brief Clear all pending packets from the queue.
+     */
+    void reset() noexcept;
+
+  private:
+    Config cfg_{};
+    int udp_sock_{-1};
+    int tcp_listen_{-1};
+
+    struct Remote {
+        sockaddr_storage addr{};
+        socklen_t addr_len{};
+        Protocol proto{};
+        int tcp_fd{-1};
+    };
+
+    std::unordered_map<node_t, Remote> remotes_;
+    std::mutex remotes_mutex_;
+
+    std::deque<Packet> queue_;
+    std::mutex mutex_;
+    RecvCallback callback_;
+    std::atomic<bool> running_{false};
+    std::jthread udp_thread_;
+    std::jthread tcp_thread_;
+
+    [[nodiscard]] static bool connection_lost(int err) noexcept;
+    void reconnect_tcp(Remote &rem);
+    [[nodiscard]] static std::vector<std::byte> frame_payload(std::span<const std::byte> data);
+    void enqueue_packet(Packet &&pkt);
+    void udp_recv_loop();
+    void tcp_accept_loop();
+};
+
+/// Global driver instance replacing previous static variables
+extern Driver driver;
 
 } // namespace net

--- a/tests/test_lattice.cpp
+++ b/tests/test_lattice.cpp
@@ -23,11 +23,11 @@ int main() {
     msg.m_type = 42;
 
     assert(lattice_connect(1, 2) == OK);
-    assert(g_graph.find(1, 2, net::local_node()) != nullptr);
+    assert(g_graph.find(1, 2, net::driver.local_node()) != nullptr);
 
     // Destination not listening -> message enqueued
     assert(lattice_send(1, 2, msg) == OK);
-    auto *ch = g_graph.find(1, 2, net::local_node());
+    auto *ch = g_graph.find(1, 2, net::driver.local_node());
     assert(ch && ch->queue.size() == 1);
 
     message out{};

--- a/tests/test_lattice_ipv6.cpp
+++ b/tests/test_lattice_ipv6.cpp
@@ -54,8 +54,8 @@ void packet_hook(const net::Packet &pkt) {
  * @return Status code from the child.
  */
 static int parent_proc(pid_t child) {
-    net::init(net::Config{PARENT_NODE, PARENT_PORT});
-    net::add_remote(CHILD_NODE, "::1", CHILD_PORT);
+    net::driver.init(net::Config{PARENT_NODE, PARENT_PORT});
+    net::driver.add_remote(CHILD_NODE, "::1", CHILD_PORT);
 
     g_graph = Graph{};
     lattice_connect(1, 2, CHILD_NODE);
@@ -76,7 +76,7 @@ static int parent_proc(pid_t child) {
 
     int status = 0;
     waitpid(child, &status, 0);
-    net::shutdown();
+    net::driver.shutdown();
     return status;
 }
 
@@ -86,9 +86,9 @@ static int parent_proc(pid_t child) {
  * @return Exit status code.
  */
 static int child_proc() {
-    net::init(net::Config{CHILD_NODE, CHILD_PORT});
-    net::add_remote(PARENT_NODE, "::1", PARENT_PORT);
-    net::set_recv_callback(packet_hook);
+    net::driver.init(net::Config{CHILD_NODE, CHILD_PORT});
+    net::driver.add_remote(PARENT_NODE, "::1", PARENT_PORT);
+    net::driver.set_recv_callback(packet_hook);
 
     g_graph = Graph{};
     lattice_connect(2, 1, PARENT_NODE);
@@ -134,7 +134,7 @@ static int child_proc() {
     assert(lattice_send(2, 1, ack) == OK);
 
     std::this_thread::sleep_for(std::chrono::milliseconds(50));
-    net::shutdown();
+    net::driver.shutdown();
     return 0;
 }
 

--- a/tests/test_lattice_network.cpp
+++ b/tests/test_lattice_network.cpp
@@ -23,8 +23,8 @@ static constexpr uint16_t CHILD_PORT = 12001;
 
 /** Parent side logic sending a message and waiting for a reply. */
 static int parent_proc(pid_t child) {
-    net::init({PARENT_NODE, PARENT_PORT});
-    net::add_remote(CHILD_NODE, "127.0.0.1", CHILD_PORT);
+    net::driver.init({PARENT_NODE, PARENT_PORT});
+    net::driver.add_remote(CHILD_NODE, "127.0.0.1", CHILD_PORT);
 
     g_graph = Graph{};
     lattice_connect(1, 2, CHILD_NODE);
@@ -45,14 +45,14 @@ static int parent_proc(pid_t child) {
 
     int status = 0;
     waitpid(child, &status, 0);
-    net::shutdown();
+    net::driver.shutdown();
     return status;
 }
 
 /** Child process responding to the parent's message. */
 static int child_proc() {
-    net::init({CHILD_NODE, CHILD_PORT});
-    net::add_remote(PARENT_NODE, "127.0.0.1", PARENT_PORT);
+    net::driver.init({CHILD_NODE, CHILD_PORT});
+    net::driver.add_remote(PARENT_NODE, "127.0.0.1", PARENT_PORT);
 
     g_graph = Graph{};
     lattice_connect(2, 1, PARENT_NODE);
@@ -72,7 +72,7 @@ static int child_proc() {
     assert(lattice_send(2, 1, ack) == OK);
 
     std::this_thread::sleep_for(std::chrono::milliseconds(50));
-    net::shutdown();
+    net::driver.shutdown();
     return 0;
 }
 

--- a/tests/test_lattice_network_encrypted.cpp
+++ b/tests/test_lattice_network_encrypted.cpp
@@ -49,8 +49,8 @@ void packet_hook(const net::Packet &pkt) {
  * @brief Parent process sending a message and waiting for acknowledgement.
  */
 static int parent_proc(pid_t child) {
-    net::init({PARENT_NODE, PARENT_PORT});
-    net::add_remote(CHILD_NODE, "127.0.0.1", CHILD_PORT);
+    net::driver.init({PARENT_NODE, PARENT_PORT});
+    net::driver.add_remote(CHILD_NODE, "127.0.0.1", CHILD_PORT);
 
     g_graph = Graph{};
     lattice_connect(1, 2, CHILD_NODE);
@@ -71,7 +71,7 @@ static int parent_proc(pid_t child) {
 
     int status = 0;
     waitpid(child, &status, 0);
-    net::shutdown();
+    net::driver.shutdown();
     return status;
 }
 
@@ -79,9 +79,9 @@ static int parent_proc(pid_t child) {
  * @brief Child process validating encryption and responding to the parent.
  */
 static int child_proc() {
-    net::init({CHILD_NODE, CHILD_PORT});
-    net::add_remote(PARENT_NODE, "127.0.0.1", PARENT_PORT);
-    net::set_recv_callback(packet_hook);
+    net::driver.init({CHILD_NODE, CHILD_PORT});
+    net::driver.add_remote(PARENT_NODE, "127.0.0.1", PARENT_PORT);
+    net::driver.set_recv_callback(packet_hook);
 
     g_graph = Graph{};
     lattice_connect(2, 1, PARENT_NODE);
@@ -120,7 +120,7 @@ static int child_proc() {
     assert(lattice_send(2, 1, ack) == OK);
 
     std::this_thread::sleep_for(std::chrono::milliseconds(50));
-    net::shutdown();
+    net::driver.shutdown();
     return 0;
 }
 

--- a/tests/test_net_driver.cpp
+++ b/tests/test_net_driver.cpp
@@ -22,29 +22,29 @@ static constexpr uint16_t CHILD_PORT = 14001;
 /** Parent process: verifies unknown‐peer send fails, then exchanges payloads. */
 int parent_proc(pid_t child_pid) {
     // Initialize UDP driver for parent
-    net::init(net::Config{PARENT_NODE, PARENT_PORT});
+    net::driver.init(net::Config{PARENT_NODE, PARENT_PORT});
 
     // Unknown destination should be rejected
     std::array<std::byte, 1> bogus{std::byte{0}};
-    assert(net::send(99, bogus) == std::errc::host_unreachable);
+    assert(net::driver.send(99, bogus) == std::errc::host_unreachable);
 
     // Register child as UDP peer
-    net::add_remote(CHILD_NODE, "127.0.0.1", CHILD_PORT, net::Protocol::UDP);
-    assert(net::local_node() != 0);
+    net::driver.add_remote(CHILD_NODE, "127.0.0.1", CHILD_PORT, net::Protocol::UDP);
+    assert(net::driver.local_node() != 0);
 
     // Wait for child's readiness signal
     net::Packet pkt;
-    while (!net::recv(pkt)) {
+    while (!net::driver.recv(pkt)) {
         std::this_thread::sleep_for(10ms);
     }
     assert(pkt.src_node == CHILD_NODE);
 
     // Send a 3-byte message
     std::array<std::byte, 3> data{std::byte{1}, std::byte{2}, std::byte{3}};
-    assert(net::send(CHILD_NODE, data) == std::errc{});
+    assert(net::driver.send(CHILD_NODE, data) == std::errc{});
 
     // Await and verify child's reply
-    while (!net::recv(pkt)) {
+    while (!net::driver.recv(pkt)) {
         std::this_thread::sleep_for(10ms);
     }
     assert(pkt.src_node == CHILD_NODE);
@@ -55,29 +55,29 @@ int parent_proc(pid_t child_pid) {
 
     // Clean up
     waitpid(child_pid, nullptr, 0);
-    net::shutdown();
+    net::driver.shutdown();
     return 0;
 }
 
 /** Child process: signals readiness, echoes back a 3-byte reply. */
 int child_proc() {
     // Initialize UDP driver for child
-    net::init(net::Config{CHILD_NODE, CHILD_PORT});
+    net::driver.init(net::Config{CHILD_NODE, CHILD_PORT});
 
     // Unknown destination should be rejected
     std::array<std::byte, 1> bogus{std::byte{0}};
-    assert(net::send(77, bogus) == std::errc::host_unreachable);
+    assert(net::driver.send(77, bogus) == std::errc::host_unreachable);
 
     // Register parent as UDP peer
-    net::add_remote(PARENT_NODE, "127.0.0.1", PARENT_PORT, net::Protocol::UDP);
+    net::driver.add_remote(PARENT_NODE, "127.0.0.1", PARENT_PORT, net::Protocol::UDP);
 
     // Signal readiness to parent
     std::array<std::byte, 1> ready{std::byte{0}};
-    assert(net::send(PARENT_NODE, ready) == std::errc{});
+    assert(net::driver.send(PARENT_NODE, ready) == std::errc{});
 
     // Receive parent's message
     net::Packet pkt;
-    while (!net::recv(pkt)) {
+    while (!net::driver.recv(pkt)) {
         std::this_thread::sleep_for(10ms);
     }
     assert(pkt.src_node == PARENT_NODE);
@@ -85,11 +85,11 @@ int child_proc() {
 
     // Send back reply [9,8,7]
     std::array<std::byte, 3> reply{std::byte{9}, std::byte{8}, std::byte{7}};
-    assert(net::send(PARENT_NODE, reply) == std::errc{});
+    assert(net::driver.send(PARENT_NODE, reply) == std::errc{});
 
     // Give parent time to receive
     std::this_thread::sleep_for(50ms);
-    net::shutdown();
+    net::driver.shutdown();
     return 0;
 }
 

--- a/tests/test_net_driver_concurrency.cpp
+++ b/tests/test_net_driver_concurrency.cpp
@@ -19,16 +19,16 @@ int main() {
     constexpr uint16_t PORT = 16550;
     constexpr int THREADS = 4;
 
-    net::init(net::Config{SELF, PORT});
+    net::driver.init(net::Config{SELF, PORT});
 
     std::atomic<int> received{0};
-    net::set_recv_callback([&](const net::Packet &) { received.fetch_add(1); });
+    net::driver.set_recv_callback([&](const net::Packet &) { received.fetch_add(1); });
 
     auto worker = [&](int idx) {
         net::node_t node = static_cast<net::node_t>(idx + 1);
-        net::add_remote(node, "127.0.0.1", PORT);
+        net::driver.add_remote(node, "127.0.0.1", PORT);
         std::array<std::byte, 1> payload{std::byte{static_cast<unsigned char>(idx)}};
-        assert(net::send(node, payload) == std::errc{});
+        assert(net::driver.send(node, payload) == std::errc{});
     };
 
     std::vector<std::thread> threads;
@@ -46,6 +46,6 @@ int main() {
 
     assert(received.load() == THREADS);
 
-    net::shutdown();
+    net::driver.shutdown();
     return 0;
 }

--- a/tests/test_net_driver_id.cpp
+++ b/tests/test_net_driver_id.cpp
@@ -143,9 +143,9 @@ namespace {
  */
 int main() {
     const auto expect = compute_expected();
-    net::init({0, 15000});
-    const auto actual = net::local_node();
+    net::driver.init({0, 15000});
+    const auto actual = net::driver.local_node();
     assert(actual == expect);
-    net::shutdown();
+    net::driver.shutdown();
     return 0;
 }

--- a/tests/test_net_driver_ipv6.cpp
+++ b/tests/test_net_driver_ipv6.cpp
@@ -27,24 +27,24 @@ constexpr uint16_t TCP_CHILD_PORT = 17003;
  * @brief Child process for the UDP phase.
  */
 int udp_child() {
-    net::init(net::Config{CHILD_NODE, UDP_CHILD_PORT});
-    net::add_remote(PARENT_NODE, "::1", UDP_PARENT_PORT, net::Protocol::UDP);
+    net::driver.init(net::Config{CHILD_NODE, UDP_CHILD_PORT});
+    net::driver.add_remote(PARENT_NODE, "::1", UDP_PARENT_PORT, net::Protocol::UDP);
 
     std::array<std::byte, 1> ready{std::byte{0}};
-    assert(net::send(PARENT_NODE, ready) == std::errc{});
+    assert(net::driver.send(PARENT_NODE, ready) == std::errc{});
 
     net::Packet pkt;
-    while (!net::recv(pkt)) {
+    while (!net::driver.recv(pkt)) {
         std::this_thread::sleep_for(10ms);
     }
     assert(pkt.src_node == PARENT_NODE);
     assert(pkt.payload.size() == 3);
 
     std::array<std::byte, 3> reply{std::byte{9}, std::byte{8}, std::byte{7}};
-    assert(net::send(PARENT_NODE, reply) == std::errc{});
+    assert(net::driver.send(PARENT_NODE, reply) == std::errc{});
 
     std::this_thread::sleep_for(50ms);
-    net::shutdown();
+    net::driver.shutdown();
     return 0;
 }
 
@@ -52,28 +52,28 @@ int udp_child() {
  * @brief Parent process for the UDP phase.
  */
 int udp_parent(pid_t child) {
-    net::init(net::Config{PARENT_NODE, UDP_PARENT_PORT});
-    net::add_remote(CHILD_NODE, "::1", UDP_CHILD_PORT, net::Protocol::UDP);
+    net::driver.init(net::Config{PARENT_NODE, UDP_PARENT_PORT});
+    net::driver.add_remote(CHILD_NODE, "::1", UDP_CHILD_PORT, net::Protocol::UDP);
 
     net::Packet pkt;
-    while (!net::recv(pkt)) {
+    while (!net::driver.recv(pkt)) {
         std::this_thread::sleep_for(10ms);
     }
     assert(pkt.src_node == CHILD_NODE);
 
     std::array<std::byte, 3> payload{std::byte{1}, std::byte{2}, std::byte{3}};
-    assert(net::send(CHILD_NODE, payload) == std::errc{});
+    assert(net::driver.send(CHILD_NODE, payload) == std::errc{});
 
     do {
         std::this_thread::sleep_for(10ms);
-    } while (!net::recv(pkt));
+    } while (!net::driver.recv(pkt));
 
     assert(pkt.src_node == CHILD_NODE);
     assert(pkt.payload.size() == payload.size());
 
     int status = 0;
     waitpid(child, &status, 0);
-    net::shutdown();
+    net::driver.shutdown();
     return status;
 }
 
@@ -81,24 +81,24 @@ int udp_parent(pid_t child) {
  * @brief Child process for the TCP phase.
  */
 int tcp_child() {
-    net::init(net::Config{CHILD_NODE, TCP_CHILD_PORT});
-    net::add_remote(PARENT_NODE, "::1", TCP_PARENT_PORT, net::Protocol::TCP);
+    net::driver.init(net::Config{CHILD_NODE, TCP_CHILD_PORT});
+    net::driver.add_remote(PARENT_NODE, "::1", TCP_PARENT_PORT, net::Protocol::TCP);
 
     std::array<std::byte, 1> ready{std::byte{0}};
-    assert(net::send(PARENT_NODE, ready) == std::errc{});
+    assert(net::driver.send(PARENT_NODE, ready) == std::errc{});
 
     net::Packet pkt;
-    while (!net::recv(pkt)) {
+    while (!net::driver.recv(pkt)) {
         std::this_thread::sleep_for(10ms);
     }
     assert(pkt.src_node == PARENT_NODE);
     assert(pkt.payload.size() == 3);
 
     std::array<std::byte, 3> reply{std::byte{9}, std::byte{8}, std::byte{7}};
-    assert(net::send(PARENT_NODE, reply) == std::errc{});
+    assert(net::driver.send(PARENT_NODE, reply) == std::errc{});
 
     std::this_thread::sleep_for(50ms);
-    net::shutdown();
+    net::driver.shutdown();
     return 0;
 }
 
@@ -106,28 +106,28 @@ int tcp_child() {
  * @brief Parent process for the TCP phase.
  */
 int tcp_parent(pid_t child) {
-    net::init(net::Config{PARENT_NODE, TCP_PARENT_PORT});
-    net::add_remote(CHILD_NODE, "::1", TCP_CHILD_PORT, net::Protocol::TCP);
+    net::driver.init(net::Config{PARENT_NODE, TCP_PARENT_PORT});
+    net::driver.add_remote(CHILD_NODE, "::1", TCP_CHILD_PORT, net::Protocol::TCP);
 
     net::Packet pkt;
-    while (!net::recv(pkt)) {
+    while (!net::driver.recv(pkt)) {
         std::this_thread::sleep_for(10ms);
     }
     assert(pkt.src_node == CHILD_NODE);
 
     std::array<std::byte, 3> payload{std::byte{1}, std::byte{2}, std::byte{3}};
-    assert(net::send(CHILD_NODE, payload) == std::errc{});
+    assert(net::driver.send(CHILD_NODE, payload) == std::errc{});
 
     do {
         std::this_thread::sleep_for(10ms);
-    } while (!net::recv(pkt));
+    } while (!net::driver.recv(pkt));
 
     assert(pkt.src_node == CHILD_NODE);
     assert(pkt.payload.size() == payload.size());
 
     int status = 0;
     waitpid(child, &status, 0);
-    net::shutdown();
+    net::driver.shutdown();
     return status;
 }
 

--- a/tests/test_net_driver_loopback.cpp
+++ b/tests/test_net_driver_loopback.cpp
@@ -17,14 +17,14 @@ int main() {
     constexpr uint16_t PORT = 16050;
 
     net::Config cfg{SELF, PORT};
-    net::init(cfg);
-    net::add_remote(SELF, "127.0.0.1", PORT);
+    net::driver.init(cfg);
+    net::driver.add_remote(SELF, "127.0.0.1", PORT);
 
     std::array<std::byte, 2> payload{std::byte{0xAA}, std::byte{0x55}};
-    assert(net::send(SELF, payload) == std::errc{});
+    assert(net::driver.send(SELF, payload) == std::errc{});
 
     net::Packet pkt{};
-    for (int i = 0; i < 100 && !net::recv(pkt); ++i) {
+    for (int i = 0; i < 100 && !net::driver.recv(pkt); ++i) {
         std::this_thread::sleep_for(10ms);
     }
     assert(pkt.src_node == SELF);
@@ -32,6 +32,6 @@ int main() {
     assert(pkt.payload[0] == payload[0]);
     assert(pkt.payload[1] == payload[1]);
 
-    net::shutdown();
+    net::driver.shutdown();
     return 0;
 }

--- a/tests/test_net_driver_persistent_id.cpp
+++ b/tests/test_net_driver_persistent_id.cpp
@@ -11,15 +11,15 @@
 int main() {
     ::unlink("/etc/xinim/node_id");
 
-    net::init(net::Config{0, 16000});
-    const auto first = net::local_node();
+    net::driver.init(net::Config{0, 16000});
+    const auto first = net::driver.local_node();
     assert(first != 0);
-    net::shutdown();
+    net::driver.shutdown();
 
-    net::init(net::Config{0, 16000});
-    const auto second = net::local_node();
+    net::driver.init(net::Config{0, 16000});
+    const auto second = net::driver.local_node();
     assert(first == second);
-    net::shutdown();
+    net::driver.shutdown();
 
     ::unlink("/etc/xinim/node_id");
     return 0;

--- a/tests/test_net_driver_reconnect.cpp
+++ b/tests/test_net_driver_reconnect.cpp
@@ -23,38 +23,38 @@ constexpr uint16_t CHILD_PORT = 15501;
 
 /** Child process: signal ready then exit to drop the connection. */
 int child_once() {
-    net::init(net::Config{CHILD_NODE, CHILD_PORT});
-    net::add_remote(PARENT_NODE, "127.0.0.1", PARENT_PORT, net::Protocol::TCP);
+    net::driver.init(net::Config{CHILD_NODE, CHILD_PORT});
+    net::driver.add_remote(PARENT_NODE, "127.0.0.1", PARENT_PORT, net::Protocol::TCP);
 
     std::array<std::byte, 1> ready{std::byte{0}};
-    assert(net::send(PARENT_NODE, ready) == std::errc{});
+    assert(net::driver.send(PARENT_NODE, ready) == std::errc{});
     std::this_thread::sleep_for(50ms);
-    net::shutdown();
+    net::driver.shutdown();
     return 0;
 }
 
 /** Child process: wait for payload after reconnect and acknowledge. */
 int child_second() {
-    net::init(net::Config{CHILD_NODE, CHILD_PORT});
-    net::add_remote(PARENT_NODE, "127.0.0.1", PARENT_PORT, net::Protocol::TCP);
+    net::driver.init(net::Config{CHILD_NODE, CHILD_PORT});
+    net::driver.add_remote(PARENT_NODE, "127.0.0.1", PARENT_PORT, net::Protocol::TCP);
 
     net::Packet pkt;
-    while (!net::recv(pkt)) {
+    while (!net::driver.recv(pkt)) {
         std::this_thread::sleep_for(10ms);
     }
     assert(pkt.src_node == PARENT_NODE);
     assert(pkt.payload.size() == 3);
 
     std::array<std::byte, 1> ack{std::byte{1}};
-    assert(net::send(PARENT_NODE, ack) == std::errc{});
+    assert(net::driver.send(PARENT_NODE, ack) == std::errc{});
     std::this_thread::sleep_for(50ms);
-    net::shutdown();
+    net::driver.shutdown();
     return 0;
 }
 
 /** Parent routine orchestrating reconnection. */
 int parent_proc() {
-    net::init(net::Config{PARENT_NODE, PARENT_PORT});
+    net::driver.init(net::Config{PARENT_NODE, PARENT_PORT});
     pid_t first_child = fork();
     if (first_child == 0) {
         return child_once();
@@ -62,7 +62,7 @@ int parent_proc() {
 
     for (int attempt = 0;; ++attempt) {
         try {
-            net::add_remote(CHILD_NODE, "127.0.0.1", CHILD_PORT, net::Protocol::TCP);
+            net::driver.add_remote(CHILD_NODE, "127.0.0.1", CHILD_PORT, net::Protocol::TCP);
             break;
         } catch (const std::system_error &) {
             if (attempt > 50) {
@@ -73,7 +73,7 @@ int parent_proc() {
     }
 
     net::Packet pkt;
-    while (!net::recv(pkt)) {
+    while (!net::driver.recv(pkt)) {
         std::this_thread::sleep_for(10ms);
     }
     assert(pkt.src_node == CHILD_NODE);
@@ -87,15 +87,15 @@ int parent_proc() {
     }
 
     std::array<std::byte, 3> payload{std::byte{1}, std::byte{2}, std::byte{3}};
-    assert(net::send(CHILD_NODE, payload) == std::errc{});
+    assert(net::driver.send(CHILD_NODE, payload) == std::errc{});
 
     do {
         std::this_thread::sleep_for(10ms);
-    } while (!net::recv(pkt));
+    } while (!net::driver.recv(pkt));
     assert(pkt.src_node == CHILD_NODE);
 
     waitpid(second_child, &status, 0);
-    net::shutdown();
+    net::driver.shutdown();
     return status;
 }
 


### PR DESCRIPTION
## Summary
- encapsulate sockets and threads inside `net::Driver`
- replace global variables with the global `net::driver` instance
- update documentation and usage examples to new interface
- adapt all tests to the new class API

## Testing
- `cmake -S . -B build`
- `cmake --build build -j $(nproc)` *(fails: fatal error: '../h/signal.h' not found)*

------
https://chatgpt.com/codex/tasks/task_e_6851e634cb1c833184f695fa8e1ecef4

## Summary by Sourcery

Refactor the network driver into a class-based design by encapsulating all driver state (sockets, threads, remotes, receive queue, and callback) within net::Driver, and provide a single global instance net::driver in place of free functions and global variables. Update the public API, documentation, and tests to use the new driver instance and its member methods.

Enhancements:
- Encapsulate UDP/TCP sockets, threads, peer registry, and packet queue inside net::Driver class
- Replace global variables and free functions with methods on the global net::driver instance
- Update API calls (init, add_remote, send, recv, shutdown, set_recv_callback, reset) to use net::driver
- Refactor header and implementation to move driver logic into class members and private methods

Documentation:
- Revise header comments and Sphinx documentation to illustrate the new net::driver interface

Tests:
- Adapt all existing tests to invoke driver methods instead of top-level free functions