### PR TITLE
Add service deregistration and dependency removal

### DIFF
--- a/docs/sphinx/service_manager.rst
+++ b/docs/sphinx/service_manager.rst
@@ -18,6 +18,20 @@ Dependencies
 Dependencies form a directed acyclic graph. The manager verifies new edges do not
 introduce cycles using an internal search routine.
 
+Unregistering Services
+----------------------
+
+Services may be removed from the manager with
+:cpp:func:`svc::ServiceManager::unregister_service`. Deregistration drops all
+metadata and removes any dependency edges referencing the service.
+
+Removing Dependencies
+---------------------
+
+Existing edges in the dependency graph can be erased using
+:cpp:func:`svc::ServiceManager::remove_dependency`. After removal the affected
+service no longer restarts when the former parent crashes.
+
 Automatic Restarts
 ------------------
 

--- a/kernel/service.hpp
+++ b/kernel/service.hpp
@@ -60,12 +60,31 @@ class ServiceManager {
     void add_dependency(xinim::pid_t pid, xinim::pid_t dep);
 
     /**
+     * @brief Remove a dependency from a service.
+     *
+     * If the dependency does not exist the call is ignored.
+     *
+     * @param pid Service that originally depended on @p dep.
+     * @param dep Dependency to remove.
+     */
+    void remove_dependency(xinim::pid_t pid, xinim::pid_t dep);
+
+    /**
      * @brief Change the restart limit for a service.
      *
      * @param pid   Service to update.
      * @param limit New restart limit.
      */
     void set_restart_limit(xinim::pid_t pid, std::uint32_t limit);
+
+    /**
+     * @brief Unregister a service entirely.
+     *
+     * Any dependency edges pointing to @p pid are removed.
+     *
+     * @param pid Identifier of the service to unregister.
+     */
+    void unregister_service(xinim::pid_t pid);
 
     /**
      * @brief Restart a crashed service and its dependents if allowed.

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -133,6 +133,16 @@ target_include_directories(minix_test_service_contract PRIVATE
 )
 add_test(NAME minix_test_service_contract COMMAND minix_test_service_contract)
 
+add_executable(minix_test_service_manager_updates
+    test_service_manager_updates.cpp
+    ${FASTPATH_SOURCES}
+)
+target_include_directories(minix_test_service_manager_updates PRIVATE
+    ${CMAKE_SOURCE_DIR}/kernel
+    ${CMAKE_SOURCE_DIR}/include
+)
+add_test(NAME minix_test_service_manager_updates COMMAND minix_test_service_manager_updates)
+
 # -----------------------------------------------------------------------------
 # Lattice IPC tests
 # -----------------------------------------------------------------------------

--- a/tests/test_service_manager_updates.cpp
+++ b/tests/test_service_manager_updates.cpp
@@ -1,0 +1,35 @@
+/**
+ * @file test_service_manager_updates.cpp
+ * @brief Unit tests for service deregistration and dependency removal.
+ */
+
+#include "../kernel/schedule.hpp"
+#include "../kernel/service.hpp"
+#include <cassert>
+
+int main() {
+    using sched::scheduler;
+    using svc::service_manager;
+
+    // Verify that unregistered services disappear from the manager.
+    service_manager.register_service(42);
+    service_manager.unregister_service(42);
+    assert(!service_manager.is_running(42));
+    assert(service_manager.contract(42).id == 0);
+    assert(!service_manager.handle_crash(42));
+
+    // Verify dependency removal stops chained restarts.
+    service_manager.register_service(1);
+    service_manager.register_service(2, {1});
+
+    scheduler.preempt();
+    scheduler.preempt();
+
+    service_manager.remove_dependency(2, 1);
+
+    scheduler.crash(1);
+    scheduler.preempt();
+    assert(service_manager.contract(2).restarts == 0);
+
+    return 0;
+}


### PR DESCRIPTION
## Summary
- extend ServiceManager with `unregister_service` and `remove_dependency`
- skip absent entries in `restart_tree`
- document service removal API
- test deregistration and dependency removal

## Testing
- `cmake --build . --target minix_test_service_manager_updates`
- `ctest --output-on-failure -R minix_test_service_manager_updates`

------
https://chatgpt.com/codex/tasks/task_e_6851e6407d848331be4540ca03533ddb