### PR TITLE
Add service manager persistence support

### DIFF
--- a/docs/sphinx/service_manager.rst
+++ b/docs/sphinx/service_manager.rst
@@ -26,6 +26,26 @@ manager. Contracts track how many times each service has been restarted via the
 ``RestartContract`` structure. Dependents of the crashed service are restarted in
 order to preserve required ordering.
 
+Persistent Configuration
+-----------------------
+
+Service state is written to ``/etc/xinim/services.json`` on shutdown. The file
+contains a list of services with their dependencies and liveness contracts::
+
+    {
+      "services": [
+        {
+          "pid": 1,
+          "running": true,
+          "deps": [2],
+          "contract": {"id": 1, "limit": 3, "restarts": 0}
+        }
+      ]
+    }
+
+The manager loads this file during initialization to restore the dependency
+graph and restart counters.
+
 .. doxygenclass:: svc::ServiceManager
    :project: XINIM
    :members:

--- a/kernel/service.cpp
+++ b/kernel/service.cpp
@@ -2,6 +2,8 @@
 #include "schedule.hpp"
 
 #include <algorithm>
+#include <fstream>
+#include <nlohmann/json.hpp>
 #include <ranges>
 
 namespace svc {
@@ -164,6 +166,65 @@ bool ServiceManager::is_running(xinim::pid_t pid) const noexcept {
         return it->second.running;
     }
     return false;
+}
+
+/**
+ * @brief Construct the service manager and restore persisted configuration.
+ */
+ServiceManager::ServiceManager() { load(); }
+
+/**
+ * @brief Persist configuration when the manager is destroyed.
+ */
+ServiceManager::~ServiceManager() { save(); }
+
+/**
+ * @brief Serialize the service map to a JSON file.
+ */
+void ServiceManager::save(std::string_view path) const {
+    nlohmann::json root;
+    for (const auto &[pid, info] : services_) {
+        root["services"].push_back({{"pid", pid},
+                                    {"running", info.running},
+                                    {"deps", info.deps},
+                                    {"contract",
+                                     {{"id", info.contract.id},
+                                      {"limit", info.contract.policy.limit},
+                                      {"restarts", info.contract.restarts}}}});
+    }
+    std::ofstream out{std::string{path}};
+    if (out) {
+        out << root.dump(2);
+    }
+}
+
+/**
+ * @brief Load a service map from a JSON file.
+ */
+void ServiceManager::load(std::string_view path) {
+    services_.clear();
+    std::ifstream in{std::string{path}};
+    if (!in) {
+        return;
+    }
+    nlohmann::json root;
+    in >> root;
+    for (const auto &svc : root["services"]) {
+        ServiceInfo info;
+        xinim::pid_t pid = svc["pid"].get<xinim::pid_t>();
+        info.running = svc["running"].get<bool>();
+        info.deps = svc["deps"].get<std::vector<xinim::pid_t>>();
+        info.contract.id = svc["contract"]["id"].get<std::uint64_t>();
+        info.contract.policy.limit = svc["contract"]["limit"].get<std::uint32_t>();
+        info.contract.restarts = svc["contract"]["restarts"].get<std::uint32_t>();
+        services_.emplace(pid, std::move(info));
+    }
+
+    next_contract_id_ = 1;
+    for (const auto &[_, info] : services_) {
+        auto next = info.contract.id + 1;
+        next_contract_id_ = std::max(next_contract_id_.load(), next);
+    }
 }
 
 /// Global manager instance accessible throughout the kernel.

--- a/kernel/service.hpp
+++ b/kernel/service.hpp
@@ -7,6 +7,7 @@
 #include "../include/xinim/core_types.hpp"
 #include <atomic>
 #include <ranges>
+#include <string_view>
 #include <unordered_map>
 #include <unordered_set>
 #include <vector>
@@ -25,6 +26,21 @@ namespace svc {
  */
 class ServiceManager {
   public:
+    /**
+     * @brief Construct the manager and load persisted state.
+     */
+    ServiceManager();
+
+    /**
+     * @brief Persist service state on destruction.
+     */
+    ~ServiceManager();
+
+    /**
+     * @brief Path of the persistent services configuration.
+     */
+    static constexpr std::string_view kDefaultPath{"/etc/xinim/services.json"};
+
     /**
      * @brief Restart policy describing allowed automatic restarts.
      */
@@ -90,6 +106,16 @@ class ServiceManager {
      * @return @c true if running.
      */
     [[nodiscard]] bool is_running(xinim::pid_t pid) const noexcept;
+
+    /**
+     * @brief Save the current service configuration to @p path.
+     */
+    void save(std::string_view path = kDefaultPath) const;
+
+    /**
+     * @brief Load a service configuration from @p path.
+     */
+    void load(std::string_view path = kDefaultPath);
 
   private:
     /**

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -133,6 +133,16 @@ target_include_directories(minix_test_service_contract PRIVATE
 )
 add_test(NAME minix_test_service_contract COMMAND minix_test_service_contract)
 
+add_executable(minix_test_service_serialization
+    test_service_serialization.cpp
+    ${FASTPATH_SOURCES}
+)
+target_include_directories(minix_test_service_serialization PRIVATE
+    ${CMAKE_SOURCE_DIR}/kernel
+    ${CMAKE_SOURCE_DIR}/include
+)
+add_test(NAME minix_test_service_serialization COMMAND minix_test_service_serialization)
+
 # -----------------------------------------------------------------------------
 # Lattice IPC tests
 # -----------------------------------------------------------------------------

--- a/tests/test_service_serialization.cpp
+++ b/tests/test_service_serialization.cpp
@@ -1,0 +1,35 @@
+/**
+ * @file test_service_serialization.cpp
+ * @brief Verify that service state persists and reloads correctly.
+ */
+
+#include "../kernel/service.hpp"
+#include <cassert>
+#include <filesystem>
+
+/**
+ * @brief Entry point verifying persistence of service manager state.
+ */
+int main() {
+    using svc::ServiceManager;
+    const std::string path{"services_test.json"};
+
+    ServiceManager mgr;
+    mgr.register_service(1, {}, 2);
+    mgr.register_service(2, {1}, 1);
+    mgr.save(path);
+
+    ServiceManager loaded;
+    loaded.load(path);
+
+    assert(loaded.contract(1).policy.limit == 2);
+    assert(loaded.contract(2).policy.limit == 1);
+
+    // Crash service 1 and ensure dependent service 2 also restarts
+    loaded.handle_crash(1);
+    assert(loaded.contract(1).restarts == 1);
+    assert(loaded.contract(2).restarts == 1);
+
+    std::filesystem::remove(path);
+    return 0;
+}


### PR DESCRIPTION
## Summary
- allow ServiceManager to persist state to /etc/xinim/services.json
- load service configuration on initialization
- document JSON file layout in the service manager docs
- check persistence round‑trip in new test

## Testing
- `cmake -B build -DBUILD_SYSTEM=OFF` *(fails to build tests: missing printf declaration)*

------
https://chatgpt.com/codex/tasks/task_e_6851e642cf088331ba76552a7c53b3ff