### PR TITLE
Add static analysis reporting script

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,41 +2,49 @@ name: CMake Build
 
 on:
   push:
-    branches: [ "master" ]
+    branches: ["master"]
   pull_request:
 
 jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
-    - name: Install build dependencies
-      run: |
-        sudo apt-get update
-        sudo apt-get install -y build-essential nasm
-    - name: Configure
-      run: cmake -B build -DBUILD_SYSTEM=OFF
-    - name: Build
-      run: cmake --build build -- -j$(nproc)
-    - name: Run unit tests
-      run: |
-        ctest --test-dir build --output-on-failure
+      - uses: actions/checkout@v3
+      - name: Install build dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y build-essential nasm cloc cppcheck cscope python3-pip
+          pip install lizard
+      - name: Configure
+        run: cmake -B build -DBUILD_SYSTEM=OFF
+      - name: Build
+        run: cmake --build build -- -j$(nproc)
+      - name: Run unit tests
+        run: |
+          ctest --test-dir build --output-on-failure
+      - name: Run static analysis
+        run: tools/run_cppcheck.sh
+      - name: Upload analysis reports
+        uses: actions/upload-artifact@v3
+        with:
+          name: analysis-reports
+          path: build/reports
 
   clang-tools:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
-    - name: Install clang tools
-      run: |
-        sudo apt-get update
-        sudo apt-get install -y clang clang-tidy clang-format cmake build-essential
-    - name: Generate compile commands
-      run: cmake -B build -DCMAKE_EXPORT_COMPILE_COMMANDS=ON
-    - name: Check formatting
-      run: |
-        FILES=$(git ls-files '*.cpp' '*.h')
-        clang-format --dry-run --Werror $FILES
-    - name: Run clang-tidy
-      run: |
-        FILES=$(git ls-files '*.cpp')
-        clang-tidy -p build -warnings-as-errors='*' $FILES
+      - uses: actions/checkout@v3
+      - name: Install clang tools
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y clang clang-tidy clang-format cmake build-essential
+      - name: Generate compile commands
+        run: cmake -B build -DCMAKE_EXPORT_COMPILE_COMMANDS=ON
+      - name: Check formatting
+        run: |
+          FILES=$(git ls-files '*.cpp' '*.h')
+          clang-format --dry-run --Werror $FILES
+      - name: Run clang-tidy
+        run: |
+          FILES=$(git ls-files '*.cpp')
+          clang-tidy -p build -warnings-as-errors='*' $FILES

--- a/BUILDING.md
+++ b/BUILDING.md
@@ -111,16 +111,12 @@ python3 -m pip install --user lizard
 
 ### Running the Tools
 
-Create a directory called `logs/` at the project root and store all reports
-there:
+Run the helper script `tools/run_cppcheck.sh` from the repository root to
+generate static analysis and metrics reports:
 
 ```sh
-mkdir -p logs
-cloc . > logs/cloc.log
-lizard -o logs/lizard.log .
-cppcheck --enable=all --std=c++23 --output-file=logs/cppcheck.log .
-cscope -Rb -q
+tools/run_cppcheck.sh
 ```
 
-`cscope` writes its database to `cscope.out`. The other commands generate log
-files in the `logs/` directory for later review.
+Reports are written to `build/reports/` in XML or JSON format. The cscope
+database is also generated in this directory.

--- a/tools/run_cppcheck.sh
+++ b/tools/run_cppcheck.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+## \file run_cppcheck.sh
+## \brief Generate static analysis and code metrics reports.
+##
+## This script runs cppcheck, cloc, lizard, and cscope using project defaults.
+## Results are stored under build/reports/ so CI can archive them.
+
+set -euo pipefail
+
+REPORT_DIR="build/reports"
+mkdir -p "$REPORT_DIR"
+
+# Run cppcheck with XML output for integration with review tools.
+cppcheck --enable=all --std=c++23 --xml --xml-version=2 . 2>"$REPORT_DIR/cppcheck.xml"
+
+# Count lines of code in JSON form.
+cloc . --json --out="$REPORT_DIR/cloc.json"
+
+# Generate complexity metrics.
+lizard -o "$REPORT_DIR/lizard.json" .
+
+# Build a cscope database for quick code search.
+cscope -Rb -q -f "$REPORT_DIR/cscope.out"
+
+printf 'Reports generated in %s\n' "$REPORT_DIR"
+


### PR DESCRIPTION
## Summary
- create `run_cppcheck.sh` to generate cppcheck, cloc, lizard, and cscope reports
- document the new script usage
- archive analysis reports in CI

## Testing
- `./tools/run_cppcheck.sh` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6851e647b3248331b2b8b8548d025484