### PR TITLE
Add ServiceManager DAG test

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -133,6 +133,16 @@ target_include_directories(minix_test_service_contract PRIVATE
 )
 add_test(NAME minix_test_service_contract COMMAND minix_test_service_contract)
 
+add_executable(minix_test_service_manager_dag
+    test_service_manager_dag.cpp
+    ${FASTPATH_SOURCES}
+)
+target_include_directories(minix_test_service_manager_dag PRIVATE
+    ${CMAKE_SOURCE_DIR}/kernel
+    ${CMAKE_SOURCE_DIR}/include
+)
+add_test(NAME minix_test_service_manager_dag COMMAND minix_test_service_manager_dag)
+
 # -----------------------------------------------------------------------------
 # Lattice IPC tests
 # -----------------------------------------------------------------------------

--- a/tests/test_service_manager_dag.cpp
+++ b/tests/test_service_manager_dag.cpp
@@ -1,0 +1,53 @@
+/**
+ * @file test_service_manager_dag.cpp
+ * @brief Validate ServiceManager dependency cycles and restart ordering.
+ */
+
+#include "../kernel/schedule.hpp"
+#include "../kernel/service.hpp"
+#include <cassert>
+
+/**
+ * @brief Exercise dependency management and crash handling.
+ */
+int main() {
+    using sched::scheduler;
+    using svc::service_manager;
+
+    service_manager.register_service(1);
+    service_manager.register_service(2, {1});
+    service_manager.register_service(3, {2});
+
+    // Remove queued entries to start with a clean scheduler state.
+    scheduler = sched::Scheduler{};
+
+    // Adding 1 -> 3 would introduce a cycle and must be ignored.
+    service_manager.add_dependency(1, 3);
+
+    // Crash service 3 and ensure only it restarts.
+    scheduler.crash(3);
+    auto next = scheduler.preempt();
+    assert(next && *next == 3);
+    assert(service_manager.contract(1).restarts == 0);
+    assert(service_manager.contract(2).restarts == 0);
+    assert(service_manager.contract(3).restarts == 1);
+
+    // Prepare a clean run queue for the ordering test.
+    scheduler = sched::Scheduler{};
+
+    // Crashing service 1 must restart dependents in topological order.
+    scheduler.crash(1);
+    next = scheduler.preempt();
+    assert(next && *next == 1);
+    next = scheduler.preempt();
+    assert(next && *next == 2);
+    next = scheduler.preempt();
+    assert(next && *next == 3);
+
+    // Verify cumulative restart counters.
+    assert(service_manager.contract(1).restarts == 1);
+    assert(service_manager.contract(2).restarts == 1);
+    assert(service_manager.contract(3).restarts == 2);
+
+    return 0;
+}


### PR DESCRIPTION
## Summary
- add `minix_test_service_manager_dag` to verify dependency cycle rejection and restart ordering
- enable test in `tests/CMakeLists.txt`

## Testing
- `cmake --build build --target minix_test_service_manager_dag`
- `build/tests/minix_test_service_manager_dag`
- `ctest --test-dir build --output-on-failure` *(fails: executables missing)*

------
https://chatgpt.com/codex/tasks/task_e_6851e65b6abc83318d5d4672fd6d46b0