### PR TITLE
Add configurable node ID path

### DIFF
--- a/docs/sphinx/lattice_ipc.rst
+++ b/docs/sphinx/lattice_ipc.rst
@@ -81,7 +81,8 @@ Example
 ^^^^^^^
 .. code-block:: cpp
 
-   net::init({0, 15000});
+   net::init({0, 15000, 0,
+              net::OverflowPolicy::DropNewest, "/etc/xinim/node_id"});
 net::add_remote(1, "127.0.0.1", 15001);
 lattice_connect(1, 1, 1);
 

--- a/kernel/net_driver.cpp
+++ b/kernel/net_driver.cpp
@@ -30,7 +30,7 @@
 namespace net {
 namespace {
 
-constexpr char NODE_ID_FILE[] = "/etc/xinim/node_id";
+constexpr char DEFAULT_NODE_ID_FILE[] = "/etc/xinim/node_id";
 
 static Config g_cfg{};
 static int g_udp_sock = -1;
@@ -57,9 +57,11 @@ static std::jthread g_udp_thread, g_tcp_thread;
 }
 
 static void reconnect_tcp(Remote &rem) {
-    if (rem.tcp_fd >= 0) ::close(rem.tcp_fd);
+    if (rem.tcp_fd >= 0)
+        ::close(rem.tcp_fd);
     rem.tcp_fd = ::socket(rem.addr.ss_family, SOCK_STREAM, 0);
-    if (rem.tcp_fd < 0) throw std::system_error(errno, std::generic_category(), "net_driver: socket");
+    if (rem.tcp_fd < 0)
+        throw std::system_error(errno, std::generic_category(), "net_driver: socket");
     if (::connect(rem.tcp_fd, reinterpret_cast<sockaddr *>(&rem.addr), rem.addr_len) != 0) {
         int err = errno;
         ::close(rem.tcp_fd);
@@ -79,11 +81,13 @@ static void reconnect_tcp(Remote &rem) {
 static void enqueue_packet(Packet &&pkt) {
     std::lock_guard lock{g_mutex};
     if (g_cfg.max_queue_length > 0 && g_queue.size() >= g_cfg.max_queue_length) {
-        if (g_cfg.overflow == OverflowPolicy::DropNewest) return;
+        if (g_cfg.overflow == OverflowPolicy::DropNewest)
+            return;
         g_queue.pop_front(); // DropOldest
     }
     g_queue.push_back(std::move(pkt));
-    if (g_callback) g_callback(g_queue.back());
+    if (g_callback)
+        g_callback(g_queue.back());
 }
 
 static void udp_recv_loop() {
@@ -93,7 +97,8 @@ static void udp_recv_loop() {
         socklen_t len = sizeof(peer);
         ssize_t n = ::recvfrom(g_udp_sock, buf.data(), buf.size(), 0,
                                reinterpret_cast<sockaddr *>(&peer), &len);
-        if (n <= static_cast<ssize_t>(sizeof(node_t))) continue;
+        if (n <= static_cast<ssize_t>(sizeof(node_t)))
+            continue;
 
         Packet pkt;
         std::memcpy(&pkt.src_node, buf.data(), sizeof(pkt.src_node));
@@ -108,12 +113,14 @@ static void tcp_accept_loop() {
         sockaddr_storage peer{};
         socklen_t len = sizeof(peer);
         int client = ::accept(g_tcp_listen, reinterpret_cast<sockaddr *>(&peer), &len);
-        if (client < 0) continue;
+        if (client < 0)
+            continue;
 
         std::array<std::byte, 2048> buf;
         while (true) {
             ssize_t n = ::recv(client, buf.data(), buf.size(), 0);
-            if (n <= static_cast<ssize_t>(sizeof(node_t))) break;
+            if (n <= static_cast<ssize_t>(sizeof(node_t)))
+                break;
             Packet pkt;
             std::memcpy(&pkt.src_node, buf.data(), sizeof(pkt.src_node));
             pkt.payload.assign(buf.begin() + sizeof(pkt.src_node), buf.begin() + n);
@@ -127,14 +134,19 @@ static void tcp_accept_loop() {
 
 void init(const Config &cfg) {
     g_cfg = cfg;
+    if (g_cfg.node_id_path.empty()) {
+        g_cfg.node_id_path = DEFAULT_NODE_ID_FILE;
+    }
 
     if (g_cfg.node_id == 0) {
-        std::ifstream in{NODE_ID_FILE};
-        if (in) in >> g_cfg.node_id;
+        std::ifstream in{g_cfg.node_id_path};
+        if (in)
+            in >> g_cfg.node_id;
     }
 
     g_udp_sock = ::socket(AF_INET6, SOCK_DGRAM, 0);
-    if (g_udp_sock < 0) throw std::system_error(errno, std::generic_category(), "UDP socket");
+    if (g_udp_sock < 0)
+        throw std::system_error(errno, std::generic_category(), "UDP socket");
     int off = 0;
     ::setsockopt(g_udp_sock, IPPROTO_IPV6, IPV6_V6ONLY, &off, sizeof(off));
     sockaddr_in6 addr6{};
@@ -145,7 +157,8 @@ void init(const Config &cfg) {
         throw std::system_error(errno, std::generic_category(), "UDP bind");
 
     g_tcp_listen = ::socket(AF_INET6, SOCK_STREAM, 0);
-    if (g_tcp_listen < 0) throw std::system_error(errno, std::generic_category(), "TCP socket");
+    if (g_tcp_listen < 0)
+        throw std::system_error(errno, std::generic_category(), "TCP socket");
     ::setsockopt(g_tcp_listen, SOL_SOCKET, SO_REUSEADDR, &off, sizeof(off));
     ::setsockopt(g_tcp_listen, IPPROTO_IPV6, IPV6_V6ONLY, &off, sizeof(off));
     if (::bind(g_tcp_listen, reinterpret_cast<sockaddr *>(&addr6), sizeof(addr6)) < 0)
@@ -158,10 +171,19 @@ void init(const Config &cfg) {
 
 void shutdown() noexcept {
     g_running.store(false, std::memory_order_relaxed);
-    if (g_udp_sock != -1) { ::close(g_udp_sock); g_udp_sock = -1; }
-    if (g_tcp_listen != -1) { ::shutdown(g_tcp_listen, SHUT_RDWR); ::close(g_tcp_listen); g_tcp_listen = -1; }
-    if (g_udp_thread.joinable()) g_udp_thread.join();
-    if (g_tcp_thread.joinable()) g_tcp_thread.join();
+    if (g_udp_sock != -1) {
+        ::close(g_udp_sock);
+        g_udp_sock = -1;
+    }
+    if (g_tcp_listen != -1) {
+        ::shutdown(g_tcp_listen, SHUT_RDWR);
+        ::close(g_tcp_listen);
+        g_tcp_listen = -1;
+    }
+    if (g_udp_thread.joinable())
+        g_udp_thread.join();
+    if (g_tcp_thread.joinable())
+        g_tcp_thread.join();
 
     std::lock_guard lock{g_mutex};
     g_queue.clear();
@@ -200,7 +222,8 @@ void add_remote(node_t node, const std::string &host, uint16_t port, Protocol pr
         }
     }
     ::freeaddrinfo(res);
-    if (rem.addr_len == 0) throw std::invalid_argument("host address resolution failed");
+    if (rem.addr_len == 0)
+        throw std::invalid_argument("host address resolution failed");
 
     if (proto == Protocol::TCP) {
         reconnect_tcp(rem);
@@ -210,23 +233,24 @@ void add_remote(node_t node, const std::string &host, uint16_t port, Protocol pr
     g_remotes[node] = rem;
 }
 
-void set_recv_callback(RecvCallback cb) {
-    g_callback = std::move(cb);
-}
+void set_recv_callback(RecvCallback cb) { g_callback = std::move(cb); }
 
 node_t local_node() noexcept {
-    if (g_cfg.node_id != 0) return g_cfg.node_id;
+    if (g_cfg.node_id != 0)
+        return g_cfg.node_id;
 
-    std::ifstream in{NODE_ID_FILE};
+    std::ifstream in{g_cfg.node_id_path};
     if (in) {
         in >> g_cfg.node_id;
-        if (g_cfg.node_id != 0) return g_cfg.node_id;
+        if (g_cfg.node_id != 0)
+            return g_cfg.node_id;
     }
 
     ifaddrs *ifa = nullptr;
     if (::getifaddrs(&ifa) == 0) {
         for (auto *cur = ifa; cur != nullptr; cur = cur->ifa_next) {
-            if (!(cur->ifa_flags & IFF_UP) || (cur->ifa_flags & IFF_LOOPBACK)) continue;
+            if (!(cur->ifa_flags & IFF_UP) || (cur->ifa_flags & IFF_LOOPBACK))
+                continue;
 
             if (cur->ifa_addr && cur->ifa_addr->sa_family == AF_PACKET) {
                 auto *ll = reinterpret_cast<sockaddr_ll *>(cur->ifa_addr);
@@ -235,8 +259,9 @@ node_t local_node() noexcept {
                     val = val * 131 + ll->sll_addr[i];
                 ::freeifaddrs(ifa);
                 g_cfg.node_id = static_cast<node_t>(val & 0x7fffffff);
-                std::filesystem::create_directories("/etc/xinim");
-                std::ofstream out{NODE_ID_FILE};
+                std::filesystem::create_directories(
+                    std::filesystem::path(g_cfg.node_id_path).parent_path());
+                std::ofstream out{g_cfg.node_id_path};
                 out << g_cfg.node_id;
                 return g_cfg.node_id;
             }
@@ -245,11 +270,13 @@ node_t local_node() noexcept {
                 auto *sin = reinterpret_cast<sockaddr_in *>(cur->ifa_addr);
                 const auto *b = reinterpret_cast<const uint8_t *>(&sin->sin_addr);
                 std::size_t val = 0;
-                for (int i = 0; i < 4; ++i) val = val * 131 + b[i];
+                for (int i = 0; i < 4; ++i)
+                    val = val * 131 + b[i];
                 ::freeifaddrs(ifa);
                 g_cfg.node_id = static_cast<node_t>(val & 0x7fffffff);
-                std::filesystem::create_directories("/etc/xinim");
-                std::ofstream out{NODE_ID_FILE};
+                std::filesystem::create_directories(
+                    std::filesystem::path(g_cfg.node_id_path).parent_path());
+                std::ofstream out{g_cfg.node_id_path};
                 out << g_cfg.node_id;
                 return g_cfg.node_id;
             }
@@ -260,8 +287,9 @@ node_t local_node() noexcept {
     char host[256]{};
     if (::gethostname(host, sizeof(host)) == 0) {
         g_cfg.node_id = static_cast<node_t>(std::hash<std::string_view>{}(host) & 0x7fffffff);
-        std::filesystem::create_directories("/etc/xinim");
-        std::ofstream out{NODE_ID_FILE};
+        std::filesystem::create_directories(
+            std::filesystem::path(g_cfg.node_id_path).parent_path());
+        std::ofstream out{g_cfg.node_id_path};
         out << g_cfg.node_id;
         return g_cfg.node_id;
     }
@@ -274,7 +302,8 @@ std::errc send(node_t node, std::span<const std::byte> data) {
     {
         std::lock_guard lock{g_remotes_mutex};
         auto it = g_remotes.find(node);
-        if (it == g_remotes.end()) return std::errc::host_unreachable;
+        if (it == g_remotes.end())
+            return std::errc::host_unreachable;
         rem = it->second;
     }
 
@@ -286,8 +315,10 @@ std::errc send(node_t node, std::span<const std::byte> data) {
 
         if (transient) {
             fd = ::socket(rem.addr.ss_family, SOCK_STREAM, 0);
-            if (fd < 0 || ::connect(fd, reinterpret_cast<sockaddr *>(&rem.addr), rem.addr_len) != 0) {
-                if (fd >= 0) ::close(fd);
+            if (fd < 0 ||
+                ::connect(fd, reinterpret_cast<sockaddr *>(&rem.addr), rem.addr_len) != 0) {
+                if (fd >= 0)
+                    ::close(fd);
                 return std::errc::connection_refused;
             }
         }
@@ -296,13 +327,15 @@ std::errc send(node_t node, std::span<const std::byte> data) {
         while (sent < buf.size()) {
             ssize_t n = ::send(fd, buf.data() + sent, buf.size() - sent, 0);
             if (n < 0) {
-                if (transient) ::close(fd);
+                if (transient)
+                    ::close(fd);
                 return std::errc::io_error;
             }
             sent += static_cast<std::size_t>(n);
         }
 
-        if (transient) ::close(fd);
+        if (transient)
+            ::close(fd);
         return std::errc{};
     }
 
@@ -316,7 +349,8 @@ std::errc send(node_t node, std::span<const std::byte> data) {
 
 bool recv(Packet &out) {
     std::lock_guard lock{g_mutex};
-    if (g_queue.empty()) return false;
+    if (g_queue.empty())
+        return false;
     out = std::move(g_queue.front());
     g_queue.pop_front();
     return true;

--- a/kernel/net_driver.hpp
+++ b/kernel/net_driver.hpp
@@ -38,8 +38,8 @@ using node_t = int;
  * received as a Packet with the `src_node` field and a payload vector.
  */
 struct Packet {
-    node_t src_node;                  ///< Originating node ID
-    std::vector<std::byte> payload;  ///< Message payload (excluding prefix)
+    node_t src_node;                ///< Originating node ID
+    std::vector<std::byte> payload; ///< Message payload (excluding prefix)
 };
 
 /**
@@ -62,19 +62,22 @@ enum class Protocol {
  * @brief Network driver configuration structure.
  *
  * This struct defines the initialization parameters for the network stack.
- * Use `node_id = 0` to auto-detect the ID and persist it to `/etc/xinim/node_id`.
+ * Use `node_id = 0` to auto-detect the ID and persist it. The location is
+ * determined by ``node_id_path`` and defaults to ``/etc/xinim/node_id`` when the
+ * path string is empty.
  */
 struct Config {
-    node_t node_id;                 ///< Preferred node identifier (0 = auto-detect)
-    std::uint16_t port;            ///< Local port to bind UDP/TCP sockets
-    std::size_t max_queue_length;  ///< Maximum packets in the receive queue
-    OverflowPolicy overflow;       ///< Policy when the receive queue overflows
+    node_t node_id;               ///< Preferred node identifier (0 = auto-detect)
+    std::uint16_t port;           ///< Local port to bind UDP/TCP sockets
+    std::size_t max_queue_length; ///< Maximum packets in the receive queue
+    OverflowPolicy overflow;      ///< Policy when the receive queue overflows
+    std::string node_id_path;     ///< File storing the persistent node ID
 
-    constexpr Config(node_t node_id_ = 0,
-                     std::uint16_t port_ = 0,
-                     std::size_t max_len = 0,
-                     OverflowPolicy policy = OverflowPolicy::DropNewest) noexcept
-        : node_id(node_id_), port(port_), max_queue_length(max_len), overflow(policy) {}
+    constexpr Config(node_t node_id_ = 0, std::uint16_t port_ = 0, std::size_t max_len = 0,
+                     OverflowPolicy policy = OverflowPolicy::DropNewest,
+                     std::string_view path = {}) noexcept
+        : node_id(node_id_), port(port_), max_queue_length(max_len), overflow(policy),
+          node_id_path(path) {}
 };
 
 /**

--- a/tests/test_lattice_ipv6.cpp
+++ b/tests/test_lattice_ipv6.cpp
@@ -17,6 +17,9 @@
 
 using namespace lattice;
 
+/// Path for the persistent node identifier during tests
+static constexpr char NODE_ID_FILE[] = "/tmp/xinim_node_id";
+
 /// Identifier for the parent node.
 static constexpr net::node_t PARENT_NODE = 0;
 /// Identifier for the child node.
@@ -54,7 +57,8 @@ void packet_hook(const net::Packet &pkt) {
  * @return Status code from the child.
  */
 static int parent_proc(pid_t child) {
-    net::init(net::Config{PARENT_NODE, PARENT_PORT});
+    net::init(
+        net::Config{PARENT_NODE, PARENT_PORT, 0, net::OverflowPolicy::DropNewest, NODE_ID_FILE});
     net::add_remote(CHILD_NODE, "::1", CHILD_PORT);
 
     g_graph = Graph{};
@@ -86,7 +90,8 @@ static int parent_proc(pid_t child) {
  * @return Exit status code.
  */
 static int child_proc() {
-    net::init(net::Config{CHILD_NODE, CHILD_PORT});
+    net::init(
+        net::Config{CHILD_NODE, CHILD_PORT, 0, net::OverflowPolicy::DropNewest, NODE_ID_FILE});
     net::add_remote(PARENT_NODE, "::1", PARENT_PORT);
     net::set_recv_callback(packet_hook);
 

--- a/tests/test_lattice_network.cpp
+++ b/tests/test_lattice_network.cpp
@@ -16,6 +16,9 @@
 
 using namespace lattice;
 
+/// Path for the persistent node identifier during tests
+static constexpr char NODE_ID_FILE[] = "/tmp/xinim_node_id";
+
 static constexpr net::node_t PARENT_NODE = 0;
 static constexpr net::node_t CHILD_NODE = 1;
 static constexpr uint16_t PARENT_PORT = 12000;
@@ -23,7 +26,7 @@ static constexpr uint16_t CHILD_PORT = 12001;
 
 /** Parent side logic sending a message and waiting for a reply. */
 static int parent_proc(pid_t child) {
-    net::init({PARENT_NODE, PARENT_PORT});
+    net::init({PARENT_NODE, PARENT_PORT, 0, net::OverflowPolicy::DropNewest, NODE_ID_FILE});
     net::add_remote(CHILD_NODE, "127.0.0.1", CHILD_PORT);
 
     g_graph = Graph{};
@@ -51,7 +54,7 @@ static int parent_proc(pid_t child) {
 
 /** Child process responding to the parent's message. */
 static int child_proc() {
-    net::init({CHILD_NODE, CHILD_PORT});
+    net::init({CHILD_NODE, CHILD_PORT, 0, net::OverflowPolicy::DropNewest, NODE_ID_FILE});
     net::add_remote(PARENT_NODE, "127.0.0.1", PARENT_PORT);
 
     g_graph = Graph{};

--- a/tests/test_lattice_network_encrypted.cpp
+++ b/tests/test_lattice_network_encrypted.cpp
@@ -18,6 +18,9 @@
 
 using namespace lattice;
 
+/// Path for the persistent node identifier during tests
+static constexpr char NODE_ID_FILE[] = "/tmp/xinim_node_id";
+
 /// Local and remote node identifiers used in the test
 static constexpr net::node_t PARENT_NODE = 0;
 static constexpr net::node_t CHILD_NODE = 1;
@@ -49,7 +52,7 @@ void packet_hook(const net::Packet &pkt) {
  * @brief Parent process sending a message and waiting for acknowledgement.
  */
 static int parent_proc(pid_t child) {
-    net::init({PARENT_NODE, PARENT_PORT});
+    net::init({PARENT_NODE, PARENT_PORT, 0, net::OverflowPolicy::DropNewest, NODE_ID_FILE});
     net::add_remote(CHILD_NODE, "127.0.0.1", CHILD_PORT);
 
     g_graph = Graph{};
@@ -79,7 +82,7 @@ static int parent_proc(pid_t child) {
  * @brief Child process validating encryption and responding to the parent.
  */
 static int child_proc() {
-    net::init({CHILD_NODE, CHILD_PORT});
+    net::init({CHILD_NODE, CHILD_PORT, 0, net::OverflowPolicy::DropNewest, NODE_ID_FILE});
     net::add_remote(PARENT_NODE, "127.0.0.1", PARENT_PORT);
     net::set_recv_callback(packet_hook);
 

--- a/tests/test_net_driver.cpp
+++ b/tests/test_net_driver.cpp
@@ -14,6 +14,9 @@
 
 using namespace std::chrono_literals;
 
+/// Path for the persistent node identifier during tests
+static constexpr char NODE_ID_FILE[] = "/tmp/xinim_node_id";
+
 static constexpr net::node_t PARENT_NODE = 0;
 static constexpr net::node_t CHILD_NODE = 1;
 static constexpr uint16_t PARENT_PORT = 14000;
@@ -22,7 +25,8 @@ static constexpr uint16_t CHILD_PORT = 14001;
 /** Parent process: verifies unknown‐peer send fails, then exchanges payloads. */
 int parent_proc(pid_t child_pid) {
     // Initialize UDP driver for parent
-    net::init(net::Config{PARENT_NODE, PARENT_PORT});
+    net::init(
+        net::Config{PARENT_NODE, PARENT_PORT, 0, net::OverflowPolicy::DropNewest, NODE_ID_FILE});
 
     // Unknown destination should be rejected
     std::array<std::byte, 1> bogus{std::byte{0}};
@@ -62,7 +66,8 @@ int parent_proc(pid_t child_pid) {
 /** Child process: signals readiness, echoes back a 3-byte reply. */
 int child_proc() {
     // Initialize UDP driver for child
-    net::init(net::Config{CHILD_NODE, CHILD_PORT});
+    net::init(
+        net::Config{CHILD_NODE, CHILD_PORT, 0, net::OverflowPolicy::DropNewest, NODE_ID_FILE});
 
     // Unknown destination should be rejected
     std::array<std::byte, 1> bogus{std::byte{0}};

--- a/tests/test_net_driver_concurrency.cpp
+++ b/tests/test_net_driver_concurrency.cpp
@@ -14,12 +14,15 @@
 
 using namespace std::chrono_literals;
 
+/// Path for the persistent node identifier during tests
+static constexpr char NODE_ID_FILE[] = "/tmp/xinim_node_id";
+
 int main() {
     constexpr net::node_t SELF = 50;
     constexpr uint16_t PORT = 16550;
     constexpr int THREADS = 4;
 
-    net::init(net::Config{SELF, PORT});
+    net::init(net::Config{SELF, PORT, 0, net::OverflowPolicy::DropNewest, NODE_ID_FILE});
 
     std::atomic<int> received{0};
     net::set_recv_callback([&](const net::Packet &) { received.fetch_add(1); });

--- a/tests/test_net_driver_drop_newest.cpp
+++ b/tests/test_net_driver_drop_newest.cpp
@@ -14,6 +14,9 @@
 
 using namespace std::chrono_literals;
 
+/// Path for the persistent node identifier during tests
+static constexpr char NODE_ID_FILE[] = "/tmp/xinim_node_id";
+
 namespace {
 
 constexpr net::node_t PARENT_NODE = 0;
@@ -32,7 +35,8 @@ constexpr std::uint16_t CHILD_PORT = 14201;
  * @return Exit status from the child.
  */
 int parent_proc(pid_t child) {
-    net::init(net::Config{PARENT_NODE, PARENT_PORT, 1, net::OverflowPolicy::DropNewest});
+    net::init(
+        net::Config{PARENT_NODE, PARENT_PORT, 1, net::OverflowPolicy::DropNewest, NODE_ID_FILE});
     net::add_remote(CHILD_NODE, "127.0.0.1", CHILD_PORT);
 
     net::Packet pkt{};
@@ -76,7 +80,8 @@ int parent_proc(pid_t child) {
  * @return Always zero on success.
  */
 int child_proc() {
-    net::init(net::Config{CHILD_NODE, CHILD_PORT});
+    net::init(
+        net::Config{CHILD_NODE, CHILD_PORT, 0, net::OverflowPolicy::DropNewest, NODE_ID_FILE});
     net::add_remote(PARENT_NODE, "127.0.0.1", PARENT_PORT);
 
     net::Packet pkt{};

--- a/tests/test_net_driver_id.cpp
+++ b/tests/test_net_driver_id.cpp
@@ -143,7 +143,8 @@ namespace {
  */
 int main() {
     const auto expect = compute_expected();
-    net::init({0, 15000});
+    static constexpr char NODE_ID_FILE[] = "/tmp/xinim_node_id";
+    net::init({0, 15000, 0, net::OverflowPolicy::DropNewest, NODE_ID_FILE});
     const auto actual = net::local_node();
     assert(actual == expect);
     net::shutdown();

--- a/tests/test_net_driver_ipv6.cpp
+++ b/tests/test_net_driver_ipv6.cpp
@@ -14,6 +14,9 @@
 
 using namespace std::chrono_literals;
 
+/// Path for the persistent node identifier during tests
+static constexpr char NODE_ID_FILE[] = "/tmp/xinim_node_id";
+
 namespace {
 
 constexpr net::node_t PARENT_NODE = 0;
@@ -27,7 +30,8 @@ constexpr uint16_t TCP_CHILD_PORT = 17003;
  * @brief Child process for the UDP phase.
  */
 int udp_child() {
-    net::init(net::Config{CHILD_NODE, UDP_CHILD_PORT});
+    net::init(
+        net::Config{CHILD_NODE, UDP_CHILD_PORT, 0, net::OverflowPolicy::DropNewest, NODE_ID_FILE});
     net::add_remote(PARENT_NODE, "::1", UDP_PARENT_PORT, net::Protocol::UDP);
 
     std::array<std::byte, 1> ready{std::byte{0}};
@@ -52,7 +56,8 @@ int udp_child() {
  * @brief Parent process for the UDP phase.
  */
 int udp_parent(pid_t child) {
-    net::init(net::Config{PARENT_NODE, UDP_PARENT_PORT});
+    net::init(net::Config{PARENT_NODE, UDP_PARENT_PORT, 0, net::OverflowPolicy::DropNewest,
+                          NODE_ID_FILE});
     net::add_remote(CHILD_NODE, "::1", UDP_CHILD_PORT, net::Protocol::UDP);
 
     net::Packet pkt;
@@ -81,7 +86,8 @@ int udp_parent(pid_t child) {
  * @brief Child process for the TCP phase.
  */
 int tcp_child() {
-    net::init(net::Config{CHILD_NODE, TCP_CHILD_PORT});
+    net::init(
+        net::Config{CHILD_NODE, TCP_CHILD_PORT, 0, net::OverflowPolicy::DropNewest, NODE_ID_FILE});
     net::add_remote(PARENT_NODE, "::1", TCP_PARENT_PORT, net::Protocol::TCP);
 
     std::array<std::byte, 1> ready{std::byte{0}};
@@ -106,7 +112,8 @@ int tcp_child() {
  * @brief Parent process for the TCP phase.
  */
 int tcp_parent(pid_t child) {
-    net::init(net::Config{PARENT_NODE, TCP_PARENT_PORT});
+    net::init(net::Config{PARENT_NODE, TCP_PARENT_PORT, 0, net::OverflowPolicy::DropNewest,
+                          NODE_ID_FILE});
     net::add_remote(CHILD_NODE, "::1", TCP_CHILD_PORT, net::Protocol::TCP);
 
     net::Packet pkt;

--- a/tests/test_net_driver_loopback.cpp
+++ b/tests/test_net_driver_loopback.cpp
@@ -12,11 +12,14 @@
 
 using namespace std::chrono_literals;
 
+/// Path for the persistent node identifier during tests
+static constexpr char NODE_ID_FILE[] = "/tmp/xinim_node_id";
+
 int main() {
     constexpr net::node_t SELF = 42;
     constexpr uint16_t PORT = 16050;
 
-    net::Config cfg{SELF, PORT};
+    net::Config cfg{SELF, PORT, 0, net::OverflowPolicy::DropNewest, NODE_ID_FILE};
     net::init(cfg);
     net::add_remote(SELF, "127.0.0.1", PORT);
 

--- a/tests/test_net_driver_overflow.cpp
+++ b/tests/test_net_driver_overflow.cpp
@@ -13,6 +13,9 @@
 
 using namespace std::chrono_literals;
 
+/// Path for the persistent node identifier during tests
+static constexpr char NODE_ID_FILE[] = "/tmp/xinim_node_id";
+
 namespace {
 
 constexpr net::node_t PARENT_NODE = 0;
@@ -32,7 +35,8 @@ constexpr std::uint16_t CHILD_PORT = 14101;
  * @return Exit status from the child.
  */
 int parent_proc(pid_t child) {
-    net::init(net::Config{PARENT_NODE, PARENT_PORT, 1, net::OverflowPolicy::DropOldest});
+    net::init(
+        net::Config{PARENT_NODE, PARENT_PORT, 1, net::OverflowPolicy::DropOldest, NODE_ID_FILE});
     net::add_remote(CHILD_NODE, "127.0.0.1", CHILD_PORT);
 
     net::Packet pkt{};
@@ -79,7 +83,8 @@ int parent_proc(pid_t child) {
  * @return Always zero on success.
  */
 int child_proc() {
-    net::init(net::Config{CHILD_NODE, CHILD_PORT});
+    net::init(
+        net::Config{CHILD_NODE, CHILD_PORT, 0, net::OverflowPolicy::DropNewest, NODE_ID_FILE});
     net::add_remote(PARENT_NODE, "127.0.0.1", PARENT_PORT);
 
     net::Packet pkt{};

--- a/tests/test_net_driver_persistent_id.cpp
+++ b/tests/test_net_driver_persistent_id.cpp
@@ -9,18 +9,19 @@
 #include <unistd.h>
 
 int main() {
-    ::unlink("/etc/xinim/node_id");
+    static constexpr char NODE_ID_FILE[] = "/tmp/xinim_node_id";
+    ::unlink(NODE_ID_FILE);
 
-    net::init(net::Config{0, 16000});
+    net::init(net::Config{0, 16000, 0, net::OverflowPolicy::DropNewest, NODE_ID_FILE});
     const auto first = net::local_node();
     assert(first != 0);
     net::shutdown();
 
-    net::init(net::Config{0, 16000});
+    net::init(net::Config{0, 16000, 0, net::OverflowPolicy::DropNewest, NODE_ID_FILE});
     const auto second = net::local_node();
     assert(first == second);
     net::shutdown();
 
-    ::unlink("/etc/xinim/node_id");
+    ::unlink(NODE_ID_FILE);
     return 0;
 }

--- a/tests/test_net_driver_tcp.cpp
+++ b/tests/test_net_driver_tcp.cpp
@@ -14,6 +14,9 @@
 
 using namespace std::chrono_literals;
 
+/// Path for the persistent node identifier during tests
+static constexpr char NODE_ID_FILE[] = "/tmp/xinim_node_id";
+
 namespace {
 
 constexpr net::node_t PARENT_NODE = 0;
@@ -23,7 +26,8 @@ constexpr uint16_t CHILD_PORT = 15001;
 
 /** Parent process: receives a “ready” packet, sends payload, and checks reply. */
 int parent_proc(pid_t child_pid) {
-    net::init(net::Config{PARENT_NODE, PARENT_PORT});
+    net::init(
+        net::Config{PARENT_NODE, PARENT_PORT, 0, net::OverflowPolicy::DropNewest, NODE_ID_FILE});
     net::add_remote(CHILD_NODE, "127.0.0.1", CHILD_PORT, net::Protocol::TCP);
 
     // Wait for child to signal readiness
@@ -57,7 +61,8 @@ int parent_proc(pid_t child_pid) {
 
 /** Child process: signals ready, echoes back a 3-byte reply. */
 int child_proc() {
-    net::init(net::Config{CHILD_NODE, CHILD_PORT});
+    net::init(
+        net::Config{CHILD_NODE, CHILD_PORT, 0, net::OverflowPolicy::DropNewest, NODE_ID_FILE});
     net::add_remote(PARENT_NODE, "127.0.0.1", PARENT_PORT, net::Protocol::TCP);
 
     // Signal readiness

--- a/tests/test_net_two_node.cpp
+++ b/tests/test_net_two_node.cpp
@@ -26,6 +26,9 @@
 
 using namespace lattice;
 
+/// Path for the persistent node identifier during tests
+static constexpr char NODE_ID_FILE[] = "/tmp/xinim_node_id";
+
 /// Local node identifier for the parent process
 static constexpr net::node_t PARENT_NODE = 0;
 /// Local node identifier for the child process
@@ -44,7 +47,7 @@ static constexpr std::uint16_t CHILD_PORT = 13001;
  * @return Process exit code used by the parent.
  */
 static int child_proc() {
-    net::init({CHILD_NODE, CHILD_PORT});
+    net::init({CHILD_NODE, CHILD_PORT, 0, net::OverflowPolicy::DropNewest, NODE_ID_FILE});
     net::add_remote(PARENT_NODE, "127.0.0.1", PARENT_PORT);
 
     g_graph = Graph{};
@@ -76,7 +79,7 @@ static int child_proc() {
  * @return Status code returned from waitpid.
  */
 static int parent_proc(pid_t child) {
-    net::init({PARENT_NODE, PARENT_PORT});
+    net::init({PARENT_NODE, PARENT_PORT, 0, net::OverflowPolicy::DropNewest, NODE_ID_FILE});
     net::add_remote(CHILD_NODE, "127.0.0.1", CHILD_PORT);
 
     g_graph = Graph{};

--- a/tests/test_poll_network.cpp
+++ b/tests/test_poll_network.cpp
@@ -27,6 +27,9 @@
 
 using namespace lattice;
 
+/// Path for the persistent node identifier during tests
+static constexpr char NODE_ID_FILE[] = "/tmp/xinim_node_id";
+
 /// Local node identifier for the parent process
 static constexpr net::node_t PARENT_NODE = 0;
 /// Local node identifier for the child process
@@ -45,7 +48,8 @@ static constexpr std::uint16_t CHILD_PORT = 15001;
  * @return Process exit code used by the parent.
  */
 static int child_proc() {
-    net::init(net::Config{CHILD_NODE, CHILD_PORT});
+    net::init(
+        net::Config{CHILD_NODE, CHILD_PORT, 0, net::OverflowPolicy::DropNewest, NODE_ID_FILE});
     net::add_remote(PARENT_NODE, "127.0.0.1", PARENT_PORT);
 
     g_graph = Graph{};
@@ -77,7 +81,8 @@ static int child_proc() {
  * @return Status code returned from waitpid.
  */
 static int parent_proc(pid_t child) {
-    net::init(net::Config{PARENT_NODE, PARENT_PORT});
+    net::init(
+        net::Config{PARENT_NODE, PARENT_PORT, 0, net::OverflowPolicy::DropNewest, NODE_ID_FILE});
     net::add_remote(CHILD_NODE, "127.0.0.1", CHILD_PORT);
 
     g_graph = Graph{};


### PR DESCRIPTION
## Summary
- add `node_id_path` to `net::Config`
- persist node identity using the new path
- update all docs and tests to specify the path

## Testing
- `clang-format -i kernel/net_driver.cpp kernel/net_driver.hpp tests/test_*.cpp tests/test_lattice_*.cpp`

------
https://chatgpt.com/codex/tasks/task_e_6851e66ccb908331b328717b4baa1297