### PR TITLE
Implement service enumeration and dependency helpers

### DIFF
--- a/docs/sphinx/service_manager.rst
+++ b/docs/sphinx/service_manager.rst
@@ -26,6 +26,21 @@ manager. Contracts track how many times each service has been restarted via the
 ``RestartContract`` structure. Dependents of the crashed service are restarted in
 order to preserve required ordering.
 
+Querying Services
+-----------------
+
+The manager exposes helpers for inspection. Call
+:cpp:func:`svc::ServiceManager::list_services` to enumerate registered
+services and :cpp:func:`svc::ServiceManager::dependencies` to inspect a
+service's direct dependencies.
+
+.. code-block:: cpp
+
+   svc::service_manager.register_service(1);
+   svc::service_manager.register_service(2, {1});
+   auto ids = svc::service_manager.list_services();      // {1, 2}
+   auto deps = svc::service_manager.dependencies(2);     // {1}
+
 .. doxygenclass:: svc::ServiceManager
    :project: XINIM
    :members:

--- a/kernel/service.cpp
+++ b/kernel/service.cpp
@@ -166,6 +166,28 @@ bool ServiceManager::is_running(xinim::pid_t pid) const noexcept {
     return false;
 }
 
+/**
+ * @brief Enumerate all registered service identifiers.
+ */
+std::vector<xinim::pid_t> ServiceManager::list_services() const {
+    std::vector<xinim::pid_t> ids;
+    ids.reserve(services_.size());
+    for (const auto &[pid, _] : services_) {
+        ids.push_back(pid);
+    }
+    return ids;
+}
+
+/**
+ * @brief Return a copy of the dependency list for @p pid.
+ */
+std::vector<xinim::pid_t> ServiceManager::dependencies(xinim::pid_t pid) const {
+    if (auto it = services_.find(pid); it != services_.end()) {
+        return it->second.deps;
+    }
+    return {};
+}
+
 /// Global manager instance accessible throughout the kernel.
 ServiceManager service_manager{};
 

--- a/kernel/service.hpp
+++ b/kernel/service.hpp
@@ -91,6 +91,25 @@ class ServiceManager {
      */
     [[nodiscard]] bool is_running(xinim::pid_t pid) const noexcept;
 
+    /**
+     * @brief Enumerate all registered services.
+     *
+     * @return Vector of service identifiers currently managed by the service
+     *         manager.
+     */
+    [[nodiscard]] std::vector<xinim::pid_t> list_services() const;
+
+    /**
+     * @brief Retrieve the dependency list for a service.
+     *
+     * The returned vector contains the services that @p pid directly depends
+     * on. If the service is unknown an empty vector is returned.
+     *
+     * @param pid Identifier of the service to query.
+     * @return Vector of dependencies for @p pid.
+     */
+    [[nodiscard]] std::vector<xinim::pid_t> dependencies(xinim::pid_t pid) const;
+
   private:
     /**
      * @brief Metadata associated with each registered service.

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -133,6 +133,16 @@ target_include_directories(minix_test_service_contract PRIVATE
 )
 add_test(NAME minix_test_service_contract COMMAND minix_test_service_contract)
 
+add_executable(minix_test_service_query
+    test_service_query.cpp
+    ${FASTPATH_SOURCES}
+)
+target_include_directories(minix_test_service_query PRIVATE
+    ${CMAKE_SOURCE_DIR}/kernel
+    ${CMAKE_SOURCE_DIR}/include
+)
+add_test(NAME minix_test_service_query COMMAND minix_test_service_query)
+
 # -----------------------------------------------------------------------------
 # Lattice IPC tests
 # -----------------------------------------------------------------------------

--- a/tests/test_service_query.cpp
+++ b/tests/test_service_query.cpp
@@ -1,0 +1,36 @@
+/**
+ * @file test_service_query.cpp
+ * @brief Unit tests for ServiceManager enumeration helpers.
+ */
+
+#include "../kernel/service.hpp"
+#include <algorithm>
+#include <cassert>
+#include <ranges>
+
+/**
+ * @brief Ensure service enumeration and dependency queries work.
+ */
+int main() {
+    using svc::service_manager;
+
+    service_manager.register_service(1);
+    service_manager.register_service(2, {1});
+    service_manager.register_service(3, {1, 2});
+
+    auto ids = service_manager.list_services();
+    assert(ids.size() == 3);
+    assert(std::ranges::contains(ids, 1));
+    assert(std::ranges::contains(ids, 2));
+    assert(std::ranges::contains(ids, 3));
+
+    auto deps2 = service_manager.dependencies(2);
+    assert(deps2.size() == 1 && deps2[0] == 1);
+
+    auto deps3 = service_manager.dependencies(3);
+    assert(deps3.size() == 2);
+    assert(std::ranges::contains(deps3, 1));
+    assert(std::ranges::contains(deps3, 2));
+
+    return 0;
+}


### PR DESCRIPTION
## Summary
- provide `list_services()` and `dependencies()` in `ServiceManager`
- document usage of the new query functions
- add tests for listing and querying service dependencies

## Testing
- `cmake --build build` *(fails: no type named 'jthread' in namespace 'std')*

------
https://chatgpt.com/codex/tasks/task_e_6851e66dadb0833186c1c74eae956925

## Summary by Sourcery

Implement service enumeration and dependency helper methods in ServiceManager, update documentation, and add corresponding unit tests and build configuration.

New Features:
- Add ServiceManager::list_services to enumerate registered services
- Add ServiceManager::dependencies to retrieve a service's dependency list

Build:
- Add CMake test target for service query tests

Documentation:
- Add documentation for service enumeration and dependency helpers

Tests:
- Add unit tests for service enumeration and dependency query functionality