### PR TITLE
Fix setup script and modernize portions of libc

### DIFF
--- a/include/setjmp.hpp
+++ b/include/setjmp.hpp
@@ -16,15 +16,9 @@
 
 #include <csetjmp>
 
-using jmp_buf = std::jmp_buf; /* expose the standard buffer type */
+using jmp_buf = ::jmp_buf; /* expose the standard buffer type */
 
-/*
- * Delegate to the standard versions.  These are inline so calls are
- * forwarded directly without additional overhead.
- */
-inline int setjmp(jmp_buf env) { return std::setjmp(env); } // std::setjmp is not noexcept
-[[noreturn]] inline void longjmp(jmp_buf env, int val) noexcept {
-    std::longjmp(env, val);
-} // std::longjmp is [[noreturn]]
+extern "C" int setjmp(jmp_buf env);
+extern "C" [[noreturn]] void longjmp(jmp_buf env, int val);
 
 #endif /* SETJMP_H */

--- a/include/stat.hpp
+++ b/include/stat.hpp
@@ -24,3 +24,6 @@ inline constexpr xinim::mode_t S_ISVTX = 01000;   /* save swapped text even afte
 inline constexpr xinim::mode_t S_IREAD = 00400;   /* read permission, owner */
 inline constexpr xinim::mode_t S_IWRITE = 00200;  /* write permission, owner */
 inline constexpr xinim::mode_t S_IEXEC = 00100;   /* execute/search permission, owner */
+
+extern "C" int fstat(int fd, struct stat *buf) noexcept;
+extern "C" int isatty(int fd) noexcept;

--- a/include/xinim/core_types.hpp
+++ b/include/xinim/core_types.hpp
@@ -1,8 +1,8 @@
 #ifndef XINIM_CORE_TYPES_HPP
 #define XINIM_CORE_TYPES_HPP
 
-#include <cstdint> // For fixed-width integer types
 #include <cstddef> // For std::size_t, std::ptrdiff_t
+#include <cstdint> // For fixed-width integer types
 
 namespace xinim {
 
@@ -15,18 +15,19 @@ using phys_bytes_t = phys_addr_t;
 using virt_bytes_t = virt_addr_t;
 
 // Process, User, and Group Identifiers
-using pid_t = std::int32_t;   // Process ID
-using uid_t = std::int32_t;   // User ID (Minix historically used uint16_t, modernizing to int32_t)
-using gid_t = std::int32_t;   // Group ID (Minix historically used uint16_t, modernizing to int32_t)
+using pid_t = std::int32_t; // Process ID
+using uid_t = std::int32_t; // User ID (Minix historically used uint16_t, modernizing to int32_t)
+using gid_t = std::int32_t; // Group ID (Minix historically used uint16_t, modernizing to int32_t)
 
 // Filesystem-related Types
-using dev_t = std::uint32_t;  // Device number
-using ino_t = std::uint64_t;  // Inode number
-using mode_t = std::uint32_t; // File mode (permissions, type)
-using off_t = std::int64_t;   // File offset or size
+using dev_t = std::uint32_t;   // Device number
+using ino_t = std::uint64_t;   // Inode number
+using mode_t = std::uint32_t;  // File mode (permissions, type)
+using nlink_t = std::uint32_t; // Link count
+using off_t = std::int64_t;    // File offset or size
 
 // Time-related Types
-using time_t = std::int64_t;  // Time in seconds (typically since epoch)
+using time_t = std::int64_t; // Time in seconds (typically since epoch)
 
 // Size and Count Types
 using ssize_t = std::ptrdiff_t; // Signed size/count (can represent -1 for errors)
@@ -34,18 +35,19 @@ using ssize_t = std::ptrdiff_t; // Signed size/count (can represent -1 for error
 
 // Hardware-specific types
 namespace hw {
-    // I/O port address type, typically 16-bit on x86
-    using port_t = std::uint16_t;
+// I/O port address type, typically 16-bit on x86
+using port_t = std::uint16_t;
 
-    // DMA address type. This is often physical but can have constraints
-    // (e.g., 24-bit for ISA, 32-bit for older PCI, 64-bit for modern systems).
-    // Using uintptr_t and recommending static_asserts in hardware-specific code.
-    // Alternatively, a fixed size like uint32_t or uint64_t might be chosen
-    // based on dominant hardware targets. For now, uintptr_t is flexible.
-    using dma_addr_t = std::uintptr_t;
+// DMA address type. This is often physical but can have constraints
+// (e.g., 24-bit for ISA, 32-bit for older PCI, 64-bit for modern systems).
+// Using uintptr_t and recommending static_asserts in hardware-specific code.
+// Alternatively, a fixed size like uint32_t or uint64_t might be chosen
+// based on dominant hardware targets. For now, uintptr_t is flexible.
+using dma_addr_t = std::uintptr_t;
 } // namespace hw
 
-// Common XINIM status/error code type (placeholder, might be replaced by std::error_code or similar)
+// Common XINIM status/error code type (placeholder, might be replaced by std::error_code or
+// similar)
 using status_t = int;
 constexpr status_t OK = 0;
 

--- a/kernel/clock.cpp
+++ b/kernel/clock.cpp
@@ -32,6 +32,7 @@
 #include "../h/signal.hpp"
 #include "../h/type.hpp"
 #include "../include/lib.hpp" // for send/receive primitives
+#include "../include/shared/signal_constants.hpp"
 #include "const.hpp"
 #include "glo.hpp"
 #include "proc.hpp"

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -13,6 +13,14 @@ list(REMOVE_ITEM LIB_SRC
     "${CMAKE_CURRENT_LIST_DIR}/getc.cpp"
     "${CMAKE_CURRENT_LIST_DIR}/putc.cpp"
     "${CMAKE_CURRENT_LIST_DIR}/io/src/stdio_compat.cpp"
+    "${CMAKE_CURRENT_LIST_DIR}/regexp.cpp"
+    "${CMAKE_CURRENT_LIST_DIR}/regsub.cpp"
+    "${CMAKE_CURRENT_LIST_DIR}/signal.cpp"
+    "${CMAKE_CURRENT_LIST_DIR}/sleep.cpp"
+    "${CMAKE_CURRENT_LIST_DIR}/sprintf.cpp"
+    "${CMAKE_CURRENT_LIST_DIR}/stb.cpp"
+    "${CMAKE_CURRENT_LIST_DIR}/syslib.cpp"
+    "${CMAKE_CURRENT_LIST_DIR}/ungetc.cpp"
 )
 
 # Define the static library target as minix_libc

--- a/lib/fstat.cpp
+++ b/lib/fstat.cpp
@@ -1,7 +1,8 @@
 #include "../include/lib.hpp" // C++23 header
+#include "../include/stat.hpp"
 
 // Get status information for the open file descriptor 'fd'.
-int fstat(int fd, char *buffer) {
-    int n = callm1(FS, FSTAT, fd, 0, 0, buffer, NIL_PTR, NIL_PTR);
+int fstat(int fd, struct stat *buf) noexcept {
+    int n = callm1(FS, FSTAT, fd, 0, 0, reinterpret_cast<char *>(buf), NIL_PTR, NIL_PTR);
     return n;
 }

--- a/lib/io/src/file_operations.cpp
+++ b/lib/io/src/file_operations.cpp
@@ -1,6 +1,6 @@
-#include "minix/io/file_operations.hpp"
-#include "minix/io/file_stream.hpp"
-#include "minix/io/standard_streams.hpp"
+#include "xinim/io/file_operations.hpp"
+#include "xinim/io/file_stream.hpp"
+#include "xinim/io/standard_streams.hpp"
 
 #include <array>
 #include <cstring>

--- a/lib/io/src/file_stream.cpp
+++ b/lib/io/src/file_stream.cpp
@@ -1,4 +1,4 @@
-#include "minix/io/file_stream.hpp"
+#include "xinim/io/file_stream.hpp"
 
 #include <cerrno>
 #include <cstring>

--- a/lib/io/src/memory_stream.cpp
+++ b/lib/io/src/memory_stream.cpp
@@ -1,4 +1,4 @@
-#include "minix/io/memory_stream.hpp"
+#include "xinim/io/memory_stream.hpp"
 
 #include <cstring>
 

--- a/lib/io/src/standard_streams.cpp
+++ b/lib/io/src/standard_streams.cpp
@@ -1,5 +1,5 @@
-#include "minix/io/standard_streams.hpp"
-#include "minix/io/file_stream.hpp"
+#include "xinim/io/standard_streams.hpp"
+#include "xinim/io/file_stream.hpp"
 
 #include <unistd.h>
 

--- a/lib/io/src/stdio_compat.cpp
+++ b/lib/io/src/stdio_compat.cpp
@@ -1,15 +1,15 @@
+#include "xinim/io/stdio_compat.hpp"
+#include "xinim/io/file_operations.hpp"
+#include "xinim/io/file_stream.hpp"
+#include "xinim/io/standard_streams.hpp"
+#include <cerrno>
 #include <cstdarg>
 #include <cstdio>
-#include <cerrno>
 #include <expected>
 #include <mutex>
 #include <span>
 #include <system_error>
 #include <unordered_map>
-#include "minix/io/file_stream.hpp"
-#include "minix/io/standard_streams.hpp"
-#include "minix/io/file_operations.hpp"
-#include "minix/io/stdio_compat.hpp"
 
 namespace minix::io::compat {
 

--- a/lib/ioctl.cpp
+++ b/lib/ioctl.cpp
@@ -2,13 +2,14 @@
 #include "../include/lib.hpp" // C++23 header
 #include "../include/sgtty.hpp"
 
+// Helper union type encapsulating the possible ioctl argument structures.
+union IoctlArg {
+    sgttyb *argp; ///< Pointer to sgttyb parameters
+    tchars *argt; ///< Pointer to terminal control characters
+};
+
 // Perform an I/O control operation on a terminal device.
-int ioctl(
-    int fd, int request,
-    union {
-        struct sgttyb *argp;
-        struct tchars *argt;
-    } u)
+int ioctl(int fd, int request, IoctlArg u)
 
 {
     int n;

--- a/lib/isatty.cpp
+++ b/lib/isatty.cpp
@@ -1,13 +1,16 @@
-#include "../include/stat.h"
+#include "../include/stat.hpp"
 
-int isatty(fd)
-int fd;
-{
-  struct stat s;
-
-  fstat(fd, &s);
-  if ( (s.st_mode&S_IFMT) == S_IFCHR)
-	return(1);
-  else
-	return(0);
+/**
+ * @brief Determine if a file descriptor refers to a terminal.
+ *
+ * This modern implementation uses a normal function prototype and
+ * leverages the typed \c stat structure defined in \c stat.hpp.
+ *
+ * @param fd File descriptor to query.
+ * @return 1 if the descriptor refers to a character device, otherwise 0.
+ */
+int isatty(int fd) noexcept {
+    struct stat s{};
+    fstat(fd, &s);
+    return ((s.st_mode & S_IFMT) == S_IFCHR) ? 1 : 0;
 }

--- a/lib/itoa.cpp
+++ b/lib/itoa.cpp
@@ -3,31 +3,36 @@
 static int next;
 static char qbuf[8];
 
-char *itoa(n)
-int n;
-{
-  register int r, k;
-  int flag = 0;
+/**
+ * @brief Convert an integer to its decimal string representation.
+ *
+ * @param n The integer
+ * value to convert.
+ * @return Pointer to a static buffer containing the converted string.
+ */
+char *itoa(int n) {
+    int r, k;
+    int flag = 0;
 
-  next = 0;
-  if (n < 0) {
-	qbuf[next++] = '-';
-	n = -n;
-  }
-  if (n == 0) {
-	qbuf[next++] = '0';
-  } else {
-	k = 10000;
-	while (k > 0) {
-		r = n/k;
-		if (flag || r > 0) {
-			qbuf[next++] = '0' + r;
-			flag = 1;
-		}
-		n -= r * k;
-		k = k/10;
-	}
-  }
-  qbuf[next] = 0;
-  return(qbuf);
+    next = 0;
+    if (n < 0) {
+        qbuf[next++] = '-';
+        n = -n;
+    }
+    if (n == 0) {
+        qbuf[next++] = '0';
+    } else {
+        k = 10000;
+        while (k > 0) {
+            r = n / k;
+            if (flag || r > 0) {
+                qbuf[next++] = '0' + r;
+                flag = 1;
+            }
+            n -= r * k;
+            k = k / 10;
+        }
+    }
+    qbuf[next] = 0;
+    return (qbuf);
 }

--- a/lib/malloc.cpp
+++ b/lib/malloc.cpp
@@ -1,80 +1,17 @@
+#include <cstdlib>
 
-#define CLICK_SIZE 16
-// Converted to C++ using alias
-using vir_bytes = unsigned short;
-extern bcopy();
+/**
+ * @file malloc.cpp
+ * @brief Thin wrappers around the C standard library allocation routines.
+ */
 
-#define ALIGN(x, a) (((x) + (a - 1)) & ~(a - 1))
-#define BUSY 1
-#define NEXT(p) (*(char **)(p))
+/// Allocate memory using the system allocator.
+char *malloc(unsigned size) noexcept { return static_cast<char *>(std::malloc(size)); }
 
-extern char *sbrk();
-static char *bottom, *top;
-
-// Extend the heap by at least len bytes
-static int grow(unsigned len) {
-    register char *p;
-
-    p = (char *)ALIGN((vir_bytes)top + sizeof(char *) + len, CLICK_SIZE) - sizeof(char *);
-    if (p < top || brk(p) < 0)
-        return 0;
-    top = p;
-    for (p = bottom; NEXT(p) != 0; p = (char *)(*(vir_bytes *)p & ~BUSY))
-        ;
-    NEXT(p) = top;
-    NEXT(top) = 0;
-    return 1;
+/// Reallocate a memory block using the system allocator.
+char *realloc(char *old, unsigned size) noexcept {
+    return static_cast<char *>(std::realloc(old, size));
 }
 
-// Allocate memory of the given size
-char *malloc(unsigned size) {
-    register char *p, *next, *new;
-    register unsigned len = ALIGN(size, sizeof(char *)) + sizeof(char *);
-
-    if ((p = bottom) == 0) {
-        top = bottom = p = sbrk(sizeof(char *));
-        NEXT(top) = 0;
-    }
-    while ((next = NEXT(p)) != 0)
-        if ((vir_bytes)next & BUSY) /* already in use */
-            p = (char *)((vir_bytes)next & ~BUSY);
-        else {
-            while ((new = NEXT(next)) != 0 && !((vir_bytes) new &BUSY))
-                next = new;
-            if (next - p >= len) {          /* fits */
-                if ((new = p + len) < next) /* too big */
-                    NEXT(new) = next;
-                NEXT(p) = (char *)((vir_bytes) new | BUSY);
-                return p + sizeof(char *);
-            }
-            p = next;
-        }
-    return grow(len) ? malloc(size) : 0;
-}
-
-// Resize previously allocated memory block
-char *realloc(char *old, unsigned size) {
-    register char *p = old - sizeof(char *), *next, *new;
-    register unsigned len = ALIGN(size, sizeof(char *)) + sizeof(char *), n;
-
-    next = (char *)(*(vir_bytes *)p & ~BUSY);
-    n = next - old; /* old size */
-    while ((new = NEXT(next)) != 0 && !((vir_bytes) new &BUSY))
-        next = new;
-    if (next - p >= len) {            /* does it still fit */
-        if ((new = p + len) < next) { /* even too big */
-            NEXT(new) = next;
-            NEXT(p) = (char *)((vir_bytes) new | BUSY);
-        } else
-            NEXT(p) = (char *)((vir_bytes)next | BUSY);
-        return old;
-    }
-    if ((new = malloc(size)) == 0) /* it didn't fit */
-        return 0;
-    bcopy(old, new, n); /* n < size */
-    *(vir_bytes *)p &= ~BUSY;
-    return new;
-}
-
-// Free a previously allocated block
-void free(char *p) { *(vir_bytes *)(p - sizeof(char *)) &= ~BUSY; }
+/// Free a memory block previously allocated with malloc/realloc.
+void free(char *p) noexcept { std::free(p); }

--- a/lib/minix/setjmp.cpp
+++ b/lib/minix/setjmp.cpp
@@ -1,5 +1,5 @@
 #include "../../include/setjmp.hpp"
-#include "../../include/lib.h"
+#include "../../include/lib.hpp"
 #include <csetjmp>
 
 /*
@@ -7,12 +7,12 @@
  * Implementation identical to the generic versions.
  */
 // Alternate location for _setjmp used by certain binaries.
-int _setjmp(jmp_buf env) { return std::setjmp(env); }
+int _setjmp(jmp_buf env) { return setjmp(env); }
 
 // Alternate location for _longjmp used by certain binaries.
 void _longjmp(jmp_buf env, int val) {
     if (val == 0) {
         val = 1;
     }
-    std::longjmp(env, val);
+    longjmp(env, val);
 }

--- a/lib/mktemp.cpp
+++ b/lib/mktemp.cpp
@@ -1,20 +1,26 @@
 /* mktemp - make a name for a temporary file */
+#include <unistd.h>
 
-char *mktemp(template)
-char *template;
-{
-  int pid, k;
-  char *p;
+/**
+ * @brief Generate a simple temporary filename in-place.
+ *
+ * @param templ Template string with trailing XXXXXX to replace.
+ * @return The input pointer for convenience.
+ */
+char *mktemp(char *templ) {
+    int pid;
+    char *p;
 
-  pid = getpid();		/* get process id as semi-unique number */
-  p = template;
-  while (*p++) ;		/* find end of string */
-  p--;				/* backup to last character */
+    pid = getpid(); /* get process id as semi-unique number */
+    p = templ;
+    while (*p++)
+        ; /* find end of string */
+    p--;  /* backup to last character */
 
-  /* Replace XXXXXX at end of template with pid. */
-  while (*--p == 'X') {
-	*p = '0' + (pid % 10);
-	pid = pid/10;
-  }
-  return(template);
+    /* Replace XXXXXX at end of template with pid. */
+    while (*--p == 'X') {
+        *p = '0' + (pid % 10);
+        pid = pid / 10;
+    }
+    return templ;
 }

--- a/lib/perror.cpp
+++ b/lib/perror.cpp
@@ -3,95 +3,53 @@
 #include "../h/error.hpp"
 #include <unistd.h>
 
-/* Global errno provided by the C library. */
 extern int errno;
 
-/* Return the length of a string without relying on strlen(). */
-static int slen(const char *s);
+static int slen(const char *s) {
+    int k = 0;
+    while (*s++)
+        k++;
+    return k;
+}
 
-/* Error message strings corresponding to errno values. */
-/* Table mapping errno values to human readable messages. */
+static const char *error_message[NERROR + 1] = {"Error 0",
+                                                "Not owner",
+                                                "No such file or directory",
+                                                "No such process",
+                                                "Interrupted system call",
+                                                "I/O error",
+                                                "No such device or address",
+                                                "Arg list too long",
+                                                "Exec format error",
+                                                "Bad file number",
+                                                "No children",
+                                                "No more processes",
+                                                "Not enough core",
+                                                "Permission denied",
+                                                "Bad address",
+                                                "Block device required",
+                                                "Mount device busy",
+                                                "File exists",
+                                                "Cross-device link",
+                                                "No such device",
+                                                "Not a directory",
+                                                "Is a directory",
+                                                "Invalid argument",
+                                                "File table overflow",
+                                                "Too many open files",
+                                                "Not a typewriter",
+                                                "Text file busy",
+                                                "File too large",
+                                                "No space left on device",
+                                                "Illegal seek",
+                                                "Read-only file system",
+                                                "Too many links",
+                                                "Broken pipe",
+                                                "Math argument",
+                                                "Result too large"};
 
-const char *error_message[NERROR + 1] = {"Error 0",
-
-                                         "Not owner",
-
-                                         "No such file or directory",
-
-                                         "No such process",
-
-                                         "Interrupted system call",
-
-                                         "I/O error",
-
-                                         "No such device or address",
-
-                                         "Arg list too long",
-
-                                         "Exec format error",
-
-                                         "Bad file number",
-
-                                         "No children",
-
-                                         "No more processes",
-
-                                         "Not enough core",
-
-                                         "Permission denied",
-
-                                         "Bad address",
-
-                                         "Block device required",
-
-                                         "Mount device busy",
-
-                                         "File exists",
-
-                                         "Cross-device link",
-
-                                         "No such device",
-
-                                         "Not a directory",
-
-                                         "Is a directory",
-
-                                         "Invalid argument",
-
-                                         "File table overflow",
-
-                                         "Too many open files",
-
-                                         "Not a typewriter",
-
-                                         "Text file busy",
-
-                                         "File too large",
-
-                                         "No space left on device",
-
-                                         "Illegal seek",
-
-                                         "Read-only file system",
-
-                                         "Too many links",
-
-                                         "Broken pipe",
-
-                                         "Math argument",
-
-                                         "Result too large"
-
-};
-
-/*
- * Print the supplied message followed by the text representation of errno.
- * The output is
- * written directly to file descriptor 2.
- */
 void perror(const char *s) {
     if (errno < 0 || errno > NERROR) {
-        /* errno outside the valid range */
         write(2, "Invalid errno\n", 14);
     } else {
         write(2, s, slen(s));
@@ -99,54 +57,4 @@ void perror(const char *s) {
         write(2, error_message[errno], slen(error_message[errno]));
         write(2, "\n", 1);
     }
-}
-
-/* Simple strlen replacement used by perror. */
-static int slen(const char *s) {
-    int k = 0;
-    while (*s++)
-        k++;
-    return k;
-    "No space left on device", "Illegal seek", "Read-only file system",
-
-        "Too many links",
-
-        "Broken pipe",
-
-        "Math argument",
-
-        "Result too large"
-};
-
-perror(s) char *s;
-if (errno < 0 || errno > NERROR) {
-    write(2, "Invalid errno\n", 14);
-} else {
-    write(2, s, slen(s));
-    write(2, ": ", 2);
-    write(2, error_message[errno], slen(error_message[errno]));
-    write(2, "\n", 1);
-}
-int k = 0;
-while (*s++)
-    k++;
-return (k);
-if (errno < 0 || errno > NERROR) {
-    write(2, "Invalid errno\n", 14);
-} else {
-    write(2, s, slen(s));
-    write(2, ": ", 2);
-    write(2, error_message[errno], slen(error_message[errno]));
-    write(2, "\n", 1);
-}
-}
-
-static int slen(s)
-char *s;
-{
-    int k = 0;
-
-    while (*s++)
-        k++;
-    return (k);
 }

--- a/lib/printk.cpp
+++ b/lib/printk.cpp
@@ -7,6 +7,7 @@
 #define MAXDIGITS 12
 
 #include "../include/shared/number_to_ascii.hpp"
+#include <cstdio>
 
 static int bintoascii(long num, int radix, char a[MAXDIGITS]);
 
@@ -19,7 +20,7 @@ void printk(char *s, int *arglist) {
     valp = (int *)&arglist;
     while (*s != '\0') {
         if (*s != '%') {
-            putc(*s++);
+            std::putchar(*s++);
             continue;
         }
 
@@ -67,31 +68,31 @@ void printk(char *s, int *arglist) {
             break;
         case 'c':
             k = *valp++;
-            putc(k);
+            std::putchar(k);
             s++;
             continue;
         case 's':
             p = (char *)*valp++;
             p1 = p;
             while ((c = *p++) != '\0')
-                putc(c);
+                std::putchar(c);
             s++;
             if ((k = w - (p - p1 - 1)) > 0)
                 while (k--)
-                    putc(' ');
+                    std::putchar(' ');
             continue;
         default:
-            putc('%');
-            putc(*s++);
+            std::putchar('%');
+            std::putchar(*s++);
             continue;
         }
 
         k = bintoascii(l, r, a);
         if ((r = w - k) > 0)
             while (r--)
-                putc(' ');
+                std::putchar(' ');
         for (r = k - 1; r >= 0; r--)
-            putc(a[r]);
+            std::putchar(a[r]);
         s++;
     }
 }

--- a/lib/rindex.cpp
+++ b/lib/rindex.cpp
@@ -1,12 +1,15 @@
-char *rindex(s, c)
-register char *s, c;
-{
-  register char *result;
-
-  result = 0;
-  do
-	if (*s == c)
-		result = s;
-  while (*s++ != 0);
-  return(result);
+/**
+ * @brief Find the last occurrence of a character in a C-string.
+ *
+ * @param s Pointer to the null-terminated string to search.
+ * @param c Character to find.
+ * @return Pointer to the last occurrence or nullptr if not found.
+ */
+char *rindex(char *s, char c) {
+    char *result = nullptr;
+    do {
+        if (*s == c)
+            result = s;
+    } while (*s++ != 0);
+    return result;
 }

--- a/lib/setbuf.cpp
+++ b/lib/setbuf.cpp
@@ -1,9 +1,7 @@
 #include "../include/lib.hpp" // C++23 header
 #include "../include/stdio.hpp"
 
-setbuf(iop, buffer) FILE *iop;
-char *buffer;
-{
+void setbuf(FILE *iop, char *buffer) {
     if (iop->_buf && testflag(iop, IOMYBUF))
         safe_free(iop->_buf);
 

--- a/lib/setjmp.cpp
+++ b/lib/setjmp.cpp
@@ -7,10 +7,7 @@
  * The custom jmp_buf stores a pointer to the real jmp_buf.
  */
 // Portable implementation of _setjmp using the host C library.
-int _setjmp(jmp_buf env) {
-    /* Simply forward to the standard facility. */
-    return std::setjmp(env);
-}
+int _setjmp(jmp_buf env) { return setjmp(env); }
 
 /*
  * Portable implementation of _longjmp using the host C library.
@@ -20,5 +17,5 @@ void _longjmp(jmp_buf env, int val) {
     if (val == 0) {
         val = 1;
     }
-    std::longjmp(env, val);
+    longjmp(env, val);
 }

--- a/lib/strcat.cpp
+++ b/lib/strcat.cpp
@@ -1,15 +1,18 @@
-char *strcat(s1, s2)
-register char *s1, *s2;
-{
-  /* Append s2 to the end of s1. */
+#include <cstring>
 
-  char *original = s1;
-
-  /* Find the end of s1. */
-  while (*s1 != 0) s1++;
-
-  /* Now copy s2 to the end of s1. */
-  while (*s2 != 0) *s1++ = *s2++;
-  *s1 = 0;
-  return(original);
+/**
+ * @brief Append one C-string to another.
+ *
+ * @param s1 Destination buffer containing a null-terminated string.
+ * @param s2 Source string to append.
+ * @return Pointer to the destination buffer.
+ */
+char *strcat(char *s1, const char *s2) {
+    char *original = s1;
+    while (*s1 != 0)
+        s1++;
+    while (*s2 != 0)
+        *s1++ = *s2++;
+    *s1 = 0;
+    return original;
 }

--- a/lib/strncat.cpp
+++ b/lib/strncat.cpp
@@ -1,21 +1,19 @@
-char *strncat(s1, s2, n)
-register char *s1, *s2;
-int n;
-{
-/* Append s2 to the end of s1, but no more than n characters */
+#include <cstring>
 
-  char *original = s1;
-
-  if (n == 0) return(s1);
-
-  /* Find the end of s1. */
-  while (*s1 != 0) s1++;
-
-  /* Now copy s2 to the end of s1. */
-  while (*s2 != 0) {
-	*s1++ = *s2++;
-	if (--n == 0) break;
-  }
-  *s1 = 0;
-  return(original);
+/**
+ * @brief Append at most n characters of one string to another.
+ */
+char *strncat(char *s1, const char *s2, int n) {
+    char *original = s1;
+    if (n == 0)
+        return s1;
+    while (*s1 != 0)
+        s1++;
+    while (*s2 != 0) {
+        *s1++ = *s2++;
+        if (--n == 0)
+            break;
+    }
+    *s1 = 0;
+    return original;
 }

--- a/lib/strncmp.cpp
+++ b/lib/strncmp.cpp
@@ -1,13 +1,16 @@
-int strncmp(s1, s2, n)
-register char *s1, *s2;
-int n;
-{
-/* Compare two strings, but at most n characters. */
+#include <cstring>
 
-  while (1) {
-	if (*s1 != *s2) return(*s1 - *s2);
-	if (*s1 == 0 || --n == 0) return(0);
-	s1++;
-	s2++;
-  }
+/**
+ * @brief Compare two strings up to n characters.
+ */
+int strncmp(const char *s1, const char *s2, int n) {
+    while (n-- > 0) {
+        if (*s1 != *s2)
+            return (*s1 - *s2);
+        if (*s1 == 0)
+            return 0;
+        ++s1;
+        ++s2;
+    }
+    return 0;
 }

--- a/lib/strncpy.cpp
+++ b/lib/strncpy.cpp
@@ -1,15 +1,15 @@
-char *strncpy(s1, s2, n)
-register char *s1, *s2;
-int n;
-{
-/* Copy s2 to s1, but at most n characters. */
+#include <cstring>
 
-  char *original = s1;
-
-  while (*s2 != 0) {
-	*s1++ = *s2++;
-	if (--n == 0) break;
-  }
-  *s1 = 0;
-  return(original);
+/**
+ * @brief Copy at most n characters from one C-string to another.
+ */
+char *strncpy(char *s1, const char *s2, int n) {
+    char *original = s1;
+    while (*s2 != 0) {
+        *s1++ = *s2++;
+        if (--n == 0)
+            break;
+    }
+    *s1 = 0;
+    return original;
 }

--- a/tests/test_memory_stream.cpp
+++ b/tests/test_memory_stream.cpp
@@ -1,6 +1,6 @@
 // Simple MemoryStream unit test
 
-#include "minix/io/memory_stream.hpp"
+#include "xinim/io/memory_stream.hpp"
 
 #include <array>
 #include <cstddef>

--- a/tests/test_stream_foundation.cpp
+++ b/tests/test_stream_foundation.cpp
@@ -1,9 +1,9 @@
 // tests/test_stream_foundation.cpp
 // Minimal Stream architecture verification
 
-#include "minix/io/file_operations.hpp" // open_stream declarations
-#include "minix/io/file_stream.hpp"     // FileStream definition
-#include "minix/io/standard_streams.hpp"
+#include "xinim/io/file_operations.hpp" // open_stream declarations
+#include "xinim/io/file_stream.hpp"     // FileStream definition
+#include "xinim/io/standard_streams.hpp"
 #include <array>
 #include <cassert>
 #include <cstring>

--- a/tools/setup.sh
+++ b/tools/setup.sh
@@ -13,16 +13,19 @@ set -euo pipefail
 sudo apt-get update
 
 # Install build utilities, analysis tools and documentation generators.
+# Prefer clang-11 if available; otherwise fall back to clang-14.
+if ! sudo apt-get install -y --no-install-recommends clang-11 lld-11; then
+    sudo apt-get install -y --no-install-recommends clang-14 lld-14
+fi
+
 sudo apt-get install -y --no-install-recommends \
     build-essential \
     cmake \
     nasm \
-    clang \
     clang-tidy \
     clang-format \
     clang-tools \
     clangd \
-    lld \
     llvm \
     llvm-dev \
     libclang-dev \
@@ -54,7 +57,10 @@ sudo apt-get install -y --no-install-recommends \
     qemu-user \
     tmux \
     cloc \
-    cscope
+    cscope \
+    gcc-x86-64-linux-gnu \
+    g++-x86-64-linux-gnu \
+    binutils-x86-64-linux-gnu
 
 # Ensure ack is installed for convenient searching
 if ! command -v ack >/dev/null 2>&1; then


### PR DESCRIPTION
## Summary
- repair `setup.sh` and add cross-compiler packages
- switch `libc` sources to modern C++
- provide minimal allocation wrappers
- drop legacy sources from the build
- adjust kernel includes

## Testing
- `cmake -B build`
- `cmake --build build` *(fails: dmp.cpp missing printf include)*

------
https://chatgpt.com/codex/tasks/task_e_6858e9ac6b3c8331ab298a44a56d3a64