### PR TITLE
Update build documentation for LLVM 18 setup

### DIFF
--- a/docs/BUILDING.md
+++ b/docs/BUILDING.md
@@ -14,8 +14,7 @@ simplicity on modern **arm64** and **x86-64** machines using **C++23**.
 
 ## 1 · Prerequisites
 
-* **C++23 tool-chain** – Clang 18 ✚ LLVM 18 (lld, lldb) is recommended; GCC 13+
-  also works.
+* **C++23 tool-chain** – Clang 18 ✚ LLVM 18 (lld, lldb) is recommended; GCC 13+ also works.
 * **Assemblers** – NASM ≥ 2.14 *or* YASM ≥ 1.3.
 * **CMake** ≥ 3.5 if you prefer that build system.
 * **Make** / POSIX shell for the traditional Makefiles.
@@ -23,7 +22,7 @@ simplicity on modern **arm64** and **x86-64** machines using **C++23**.
 All packages can be installed automatically:
 
 ```sh
-tools/setup.sh            # installs clang/lld/lldb, nasm, cmake …
+tools/setup.sh            # installs clang-18, lld-18, lldb-18, nasm, cmake …
 clang++ --version         # check detected version
 ````
 
@@ -90,13 +89,13 @@ setting `BUILD_MODE=<mode>` when using `make`, or the equivalent CMake
 | Mode        | Purpose                        | Representative flags                   |
 | ----------- | ------------------------------ | -------------------------------------- |
 | **debug**   | Heavy diagnostics + sanitizers | `-g3 -O0 -fsanitize=address,undefined` |
-| **release** | Maximum performance / size     | `-O3 -DNDEBUG -flto -march=native`     |
+| **release** | Maximum performance / size     | `-O3 -DNDEBUG -flto -march=x86-64-v1`     |
 | **profile** | gprof / perf instrumentation   | `-O2 -g -pg`                           |
 
 Typical ad-hoc compilation during development:
 
 ```sh
-clang++ -std=c++23 -O2 -pipe -Wall -Wextra -Wpedantic -march=native \
+clang++ -std=c++23 -O2 -pipe -Wall -Wextra -Wpedantic -march=x86-64-v1 \
         example.cpp -o example
 ```
 
@@ -115,7 +114,7 @@ make -C test f=t10a LIB=       # skips lib.a linkage
 Or compile directly:
 
 ```sh
-clang++ -std=c++23 -O2 -pipe -Wall -Wextra -Wpedantic -march=native \
+clang++ -std=c++23 -O2 -pipe -Wall -Wextra -Wpedantic -march=x86-64-v1 \
         tests/t10a.cpp -o tests/t10a
 ./tests/t10a && echo "✓ tool-chain OK"
 ```
@@ -163,6 +162,20 @@ tools/run_cppcheck.sh
 ```
 
 Outputs land in `build/reports/` (XML / JSON) along with a `cscope` DB.
+
+---
+
+## 11 · Documentation Generation
+
+Build the API documentation via **Doxygen** and **Sphinx** using the
+**Breathe** extension:
+
+```sh
+doxygen Doxyfile
+sphinx-build -b html docs/sphinx docs/sphinx/html
+```
+
+HTML output appears in `docs/sphinx/html`.
 
 ---
 

--- a/docs/README_renamed.md
+++ b/docs/README_renamed.md
@@ -63,8 +63,9 @@ users.
 ### Prerequisites
 
  - **Compiler**: GCC 13+ or Clang 18+ with the full LLVM 18 suite including lld and lldb (MSVC 19.36+ supported)
-- **Build System**: Make (GNU Make recommended)
-- **Optional**: Doxygen for documentation, Valgrind for debugging
+ - **Setup**: Run `tools/setup.sh` to install clang-18, lld-18, lldb-18, and related packages
+ - **Build System**: Make (GNU Make recommended)
+ - **Optional**: Doxygen for documentation, Valgrind for debugging
 
 ### Quick Start
 
@@ -72,6 +73,9 @@ users.
 # Clone the repository
 git clone <repository-url>
 cd XINIM
+
+# Install dependencies (LLVM 18, lld, etc.)
+tools/setup.sh
 
 # Build debug version (default)
 make
@@ -88,7 +92,7 @@ sudo make install
 | Mode | Description | Flags |
 |------|-------------|-------|
 | `debug` | Development build with sanitizers | `-g3 -O0 -fsanitize=address,undefined` |
-| `release` | Optimized production build | `-O3 -DNDEBUG -flto -march=native` |
+| `release` | Optimized production build | `-O3 -DNDEBUG -flto -march=x86-64-v1` |
 | `profile` | Profiling build | `-O2 -g -pg` |
 
 ### Make vs CMake
@@ -277,6 +281,8 @@ make gdb
 5. **Safety**: Use sanitizers during development
 
 ## Documentation
+
+Documentation is produced through a **Sphinx** + **Breathe** workflow driven by **Doxygen**.
 
 Generate comprehensive API documentation:
 


### PR DESCRIPTION
## Summary
- document `tools/setup.sh` usage for installing Clang 18 suite
- use `-march=x86-64-v1` in build examples
- outline Doxygen + Sphinx (Breathe) documentation workflow

## Testing
- `bash tools/setup.sh >/tmp/setup.log`


------
https://chatgpt.com/codex/tasks/task_e_685a1f18533c8331b93ffb5e9deb5a6f