### PR TITLE
Enable generic x86‑64 tuning

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -67,8 +67,12 @@ if(CROSS_COMPILE_X86_64)
   set(CMAKE_AR "${CROSS_PREFIX}ar")
   set(CMAKE_RANLIB "${CROSS_PREFIX}ranlib")
   set(CMAKE_LINKER "${CROSS_PREFIX}ld")
-  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -m64")
+  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -m64 -march=x86-64-v1 -mtune=generic")
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -m64 -march=x86-64-v1 -mtune=generic")
 endif()
+
+# Default tuning for native builds
+add_compile_options(-march=x86-64-v1 -mtune=generic)
 
 # Options for wini driver selection
 option(DRIVER_AT "Use AT wini driver" OFF)

--- a/commands/CMakeLists_mined.txt
+++ b/commands/CMakeLists_mined.txt
@@ -52,7 +52,7 @@ endif()
 
 # Compiler flags
 set(CMAKE_CXX_FLAGS_DEBUG "-g -O0 -DDEBUG -fsanitize=address -fsanitize=undefined")
-set(CMAKE_CXX_FLAGS_RELEASE "-O3 -DNDEBUG -march=native")
+set(CMAKE_CXX_FLAGS_RELEASE "-O3 -DNDEBUG -march=x86-64-v1 -mtune=generic")
 set(CMAKE_CXX_FLAGS_RELWITHDEBINFO "-O2 -g -DNDEBUG")
 
 # Enable SIMD optimizations

--- a/commands/make.cpp
+++ b/commands/make.cpp
@@ -928,8 +928,8 @@ public:
         // Initialize default macros
         macro_processor_.define_macro("CC", "clang++");
         macro_processor_.define_macro("CXX", "clang++");
-        macro_processor_.define_macro("CFLAGS", "-std=c++23 -O3 -march=native");
-        macro_processor_.define_macro("CXXFLAGS", "-std=c++23 -O3 -march=native");
+        macro_processor_.define_macro("CFLAGS", "-std=c++23 -O3 -march=x86-64-v1 -mtune=generic");
+        macro_processor_.define_macro("CXXFLAGS", "-std=c++23 -O3 -march=x86-64-v1 -mtune=generic");
         macro_processor_.define_macro("AS", "as");
         macro_processor_.define_macro("AFLAGS", "");
         

--- a/common/math/Makefile
+++ b/common/math/Makefile
@@ -1,8 +1,9 @@
 # Makefile for math libraries (Quaternion, Octonion, Sedenion)
 
-CXX := g++
+CXX := clang++
 # Use C++23 standard, enable warnings, optimization, and position-independent code for library
-CXXFLAGS := -std=c++23 -Wall -Wextra -pedantic -O2 -fPIC -I.
+CXXFLAGS := -std=c++23 -Wall -Wextra -pedantic -O2 -fPIC -I. \
+    -march=x86-64-v1 -mtune=generic
 AR := ar
 ARFLAGS := rcs
 

--- a/lib/Makefile
+++ b/lib/Makefile
@@ -1,7 +1,7 @@
 # Default to clang for building the library
 CC ?= clang
 AR ?= ar
-CFLAGS ?= -O2
+CFLAGS ?= -O2 -march=x86-64-v1 -mtune=generic
 # Object files derived only from C sources.
 OBJS := $(patsubst %.cpp,%.o,$(wildcard *.cpp))
 

--- a/lib/simd/CMakeLists.txt
+++ b/lib/simd/CMakeLists.txt
@@ -35,8 +35,8 @@ target_compile_features(${SIMD_MATH_LIB} PUBLIC cxx_std_23)
 if(CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang")
     target_compile_options(${SIMD_MATH_LIB} PRIVATE
         -O3
-        -march=native
-        -mtune=native
+        -march=x86-64-v1
+        -mtune=generic
         -ffast-math
         -funroll-loops
         -fomit-frame-pointer

--- a/test_makefile
+++ b/test_makefile
@@ -1,6 +1,7 @@
 # Test Makefile for modern make system
 CC=clang++
-CXXFLAGS=-std=c++23 -O2 -pipe -Wall -Wextra -Wpedantic -march=native
+CXXFLAGS=-std=c++23 -O2 -pipe -Wall -Wextra -Wpedantic \
+    -march=x86-64-v1 -mtune=generic
 TARGET=test_program
 SOURCES=main.cpp utils.cpp
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -8,7 +8,7 @@ set(CMAKE_CXX_EXTENSIONS OFF)
 
 # Recommended build flags
 set(CMAKE_CXX_FLAGS_DEBUG "-g3 -O0 -fsanitize=address,undefined")
-set(CMAKE_CXX_FLAGS_RELEASE "-O3 -DNDEBUG -flto -march=native")
+set(CMAKE_CXX_FLAGS_RELEASE "-O3 -DNDEBUG -flto -march=x86-64-v1 -mtune=generic")
 set(CMAKE_CXX_FLAGS_RELWITHDEBINFO "-O2 -g -DNDEBUG")
 add_compile_options(-Wall -Wextra -Wpedantic)
 

--- a/tools/Makefile
+++ b/tools/Makefile
@@ -3,7 +3,8 @@
 
 # Compiler configuration
 CXX := clang++
-CXXFLAGS := -std=c++23 -Wall -Wextra -Wpedantic -Werror -O2
+CXXFLAGS := -std=c++23 -Wall -Wextra -Wpedantic -Werror -O2 \
+    -march=x86-64-v1 -mtune=generic
 CXXFLAGS += -Wno-unused-parameter -Wno-missing-field-initializers
 
 # Debug configuration

--- a/tools/minix/Makefile
+++ b/tools/minix/Makefile
@@ -5,6 +5,7 @@ INC ?= ../include
 LIB ?= ../lib/lib.a
 LDFLAGS ?=
 CFLAGS ?= -F
+CFLAGS += -march=x86-64-v1 -mtune=generic
 CFLAGS += -I$(INC)
 
 all:


### PR DESCRIPTION
## Summary
- use generic x86-64 optimisation flags in the build
- tune SIMD math library flags
- make clang the default for common Makefiles
- update test makefiles and default flags
- propagate the options into the unit test build

## Testing
- `cmake -B build -S .`

------
https://chatgpt.com/codex/tasks/task_e_685a1f172da08331ac20a35e2286bc9d