### PR TITLE
Add cleaning script and new root README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,23 @@
+# XINIM
+
+XINIM is a modern C++23 reimagining of MINIX 1. The project builds with CMake or traditional Makefiles on both x86-64 and arm64 hosts.
+
+## Building
+
+```bash
+cmake -B build
+cmake --build build
+```
+
+Refer to `docs/BUILDING.md` for detailed options such as cross-compilation and driver selection.
+
+## Cleaning the Workspace
+
+Use the provided helper to remove all build artifacts:
+
+```bash
+./tools/clean.sh
+```
+
+This script deletes the `build/` directory produced by CMake as well as `tools/build`, ensuring that subsequent builds start from a pristine state.
+

--- a/tools/clean.sh
+++ b/tools/clean.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+## \file clean.sh
+## \brief Remove build artifacts and generated binaries.
+##
+## This script deletes the main build directory produced by CMake and
+## any compiled tools placed under tools/build. Run it from the repository
+## root to reset the workspace.
+
+set -euo pipefail
+
+remove_dir() {
+    local dir="$1"
+    if [[ -d "$dir" ]]; then
+        rm -rf "$dir"
+        echo "Removed $dir"
+    fi
+}
+
+main() {
+    remove_dir "build"
+    remove_dir "tools/build"
+}
+
+main "$@"


### PR DESCRIPTION
## Summary
- add a helper script `tools/clean.sh` to remove the build directory and built tool binaries
- document the new cleanup helper in a root README

## Testing
- `cmake -B build`
- `bash tools/clean.sh`

------
https://chatgpt.com/codex/tasks/task_e_685a1f0160d88331a2635e338697156d