### PR TITLE
Fix .gitignore CMake install pattern

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,7 +13,7 @@ bin/
 # Ignore CMake generated files
 CMakeFiles/
 CMakeCache.txt
-cmake_install.cppmake
+cmake_install.cmake
 
 # Ignore other temporary files
 *.log


### PR DESCRIPTION
## Summary
- fix typo in `.gitignore` for CMake install script

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_685a1f065f408331bd106c9544fc4357