### PR TITLE
Integrate libsodium via pkg-config

### DIFF
--- a/crypto/CMakeLists.txt
+++ b/crypto/CMakeLists.txt
@@ -14,18 +14,17 @@ set(KYBER_IMPL_SOURCES
 
 find_package(OpenSSL REQUIRED)
 find_package(PkgConfig REQUIRED)
-pkg_check_modules(LIBSODIUM libsodium)
+pkg_check_modules(SODIUM libsodium)
 
-if(LIBSODIUM_FOUND)
-  set(SODIUM_LIB ${LIBSODIUM_LIBRARIES})
-  set(SODIUM_INCLUDE ${LIBSODIUM_INCLUDE_DIRS})
+if(SODIUM_FOUND)
+  # libsodium detected via pkg-config; use provided variables
 else()
   message(WARNING "libsodium not found; building with local stubs")
   add_library(sodium_stub STATIC ${CMAKE_SOURCE_DIR}/tests/sodium_stub.cpp)
   list(REMOVE_ITEM KYBER_IMPL_SOURCES kyber_impl/randombytes.c)
   list(APPEND KYBER_IMPL_SOURCES ${CMAKE_SOURCE_DIR}/tests/randombytes_stub.c)
-  set(SODIUM_LIB sodium_stub)
-  set(SODIUM_INCLUDE ${CMAKE_SOURCE_DIR}/tests)
+  set(SODIUM_LIBRARIES sodium_stub)
+  set(SODIUM_INCLUDE_DIRS ${CMAKE_SOURCE_DIR}/tests)
 endif()
 
 add_library(pqcrypto STATIC kyber.cpp pqcrypto_shared.cpp ${KYBER_IMPL_SOURCES})
@@ -43,5 +42,5 @@ target_include_directories(pqcrypto PUBLIC
     ${CMAKE_CURRENT_SOURCE_DIR}
     ${CMAKE_CURRENT_SOURCE_DIR}/kyber_impl)
 
-target_link_libraries(pqcrypto PUBLIC OpenSSL::Crypto ${SODIUM_LIB})
-target_include_directories(pqcrypto PRIVATE ${SODIUM_INCLUDE})
+target_link_libraries(pqcrypto PUBLIC OpenSSL::Crypto ${SODIUM_LIBRARIES})
+target_include_directories(pqcrypto PRIVATE ${SODIUM_INCLUDE_DIRS})

--- a/docs/BUILDING.md
+++ b/docs/BUILDING.md
@@ -19,6 +19,7 @@ simplicity on modern **arm64** and **x86-64** machines using **C++23**.
 * **Assemblers** – NASM ≥ 2.14 *or* YASM ≥ 1.3.
 * **CMake** ≥ 3.5 if you prefer that build system.
 * **Make** / POSIX shell for the traditional Makefiles.
+* **libsodium** – development headers for the crypto subsystem (`libsodium-dev`).
 
 All packages can be installed automatically:
 


### PR DESCRIPTION
## Summary
- detect libsodium with PkgConfig in `crypto/CMakeLists.txt`
- link `pqcrypto` with `${SODIUM_LIBRARIES}` and add `${SODIUM_INCLUDE_DIRS}`
- document libsodium build dependency in `docs/BUILDING.md`

## Testing
- `cmake -B build`
- `cmake --build build`

------
https://chatgpt.com/codex/tasks/task_e_685a1eff41e08331a6760434676d4f63