### PR TITLE
Set clang-18 as default compiler

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,36 +1,28 @@
 cmake_minimum_required(VERSION 3.5)
 project(minix1 CXX C)
 
-# Default to clang-18 when no explicit compiler is configured.
-# Fall back to clang-20 if available and finally to the generic clang
-# wrapper.
+# ------------------------------------------------------------------------------
+# Compiler configuration
+# ------------------------------------------------------------------------------
+
+# Require Clang 18 when no explicit compiler is provided.  Fail early if the
+# tool chain is missing so users know to run tools/setup.sh first.
 if(NOT CMAKE_C_COMPILER)
   find_program(CLANG_18 clang-18)
-  if(CLANG_18)
-    set(CMAKE_C_COMPILER ${CLANG_18})
-  else()
-    find_program(CLANG_20 clang-20)
-    if(CLANG_20)
-      set(CMAKE_C_COMPILER ${CLANG_20})
-    else()
-      set(CMAKE_C_COMPILER clang)
-    endif()
+  if(NOT CLANG_18)
+    message(FATAL_ERROR "clang-18 is required but was not found. Run tools/setup.sh")
   endif()
+  set(CMAKE_C_COMPILER ${CLANG_18})
 endif()
 
 if(NOT CMAKE_CXX_COMPILER)
   find_program(CLANGXX_18 clang++-18)
-  if(CLANGXX_18)
-    set(CMAKE_CXX_COMPILER ${CLANGXX_18})
-  else()
-    find_program(CLANGXX_20 clang++-20)
-    if(CLANGXX_20)
-      set(CMAKE_CXX_COMPILER ${CLANGXX_20})
-    else()
-      set(CMAKE_CXX_COMPILER clang++)
-    endif()
+  if(NOT CLANGXX_18)
+    message(FATAL_ERROR "clang++-18 is required but was not found. Run tools/setup.sh")
   endif()
+  set(CMAKE_CXX_COMPILER ${CLANGXX_18})
 endif()
+
 
 # Enforce a strict C++23 environment across the project
 set(CMAKE_C_STANDARD 17)
@@ -39,6 +31,17 @@ set(CMAKE_C_EXTENSIONS OFF)
 set(CMAKE_CXX_STANDARD 23)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
+
+# Global optimisation flags tuned for modern x86-64 CPUs.  These are applied to
+# every target built in this project, including the kernel, libraries and tools.
+add_compile_options(
+  -march=x86-64-v1
+  -msse2
+  -msse3
+  -mssse3
+  -msse4.1
+  -msse4.2
+)
 
 # Add global include directories
 include_directories(h)
@@ -61,9 +64,9 @@ if(CROSS_COMPILE_X86_64)
   endif()
   set(CMAKE_SYSTEM_NAME Generic)
   set(CMAKE_SYSTEM_PROCESSOR x86_64)
-  # Use clang for cross compilation as well
-  set(CMAKE_C_COMPILER "${CROSS_PREFIX}clang")
-  set(CMAKE_CXX_COMPILER "${CROSS_PREFIX}clang++")
+  # Use clang-18 for cross compilation as well
+  set(CMAKE_C_COMPILER "${CROSS_PREFIX}clang-18")
+  set(CMAKE_CXX_COMPILER "${CROSS_PREFIX}clang++-18")
   set(CMAKE_AR "${CROSS_PREFIX}ar")
   set(CMAKE_RANLIB "${CROSS_PREFIX}ranlib")
   set(CMAKE_LINKER "${CROSS_PREFIX}ld")

--- a/common/math/Makefile
+++ b/common/math/Makefile
@@ -1,8 +1,10 @@
 # Makefile for math libraries (Quaternion, Octonion, Sedenion)
 
-CXX := g++
+# Use clang++-18 to build the algebra libraries
+CXX := clang++-18
 # Use C++23 standard, enable warnings, optimization, and position-independent code for library
-CXXFLAGS := -std=c++23 -Wall -Wextra -pedantic -O2 -fPIC -I.
+CXXFLAGS := -std=c++23 -Wall -Wextra -pedantic -O2 -fPIC -I. \
+    -march=x86-64-v1 -msse2 -msse3 -mssse3 -msse4.1 -msse4.2
 AR := ar
 ARFLAGS := rcs
 

--- a/kernel/Makefile
+++ b/kernel/Makefile
@@ -1,14 +1,13 @@
 #The kernel directory contains PC / XT and AT wini driver sources.Set the
 # `WINI_DRIVER` variable to `pc` or `at` when invoking `make` to select the
 #correct driver.If not specified the PC / XT driver is used.
-#Use clang to compile the kernel
-CC ? = clang CFLAGS
-           ? = -O INC
-                   ? =../ include LIB
-                          ? =../ lib / lib.a LDFLAGS
-                                 ? = CFLAGS += -I$(INC) h =
-                                       ../
-                                       h l =../ lib
+# Use clang-18 to compile the kernel
+CC ?= clang-18
+CFLAGS ?= -O
+INC ?= ../include
+LIB ?= ../lib/lib.a
+LDFLAGS ?=
+CFLAGS += -I$(INC) -march=x86-64-v1 -msse2 -msse3 -mssse3 -msse4.1 -msse4.2
 
 #Determine which driver source file to use
                                                         WINI_DRIVER

--- a/lib/Makefile
+++ b/lib/Makefile
@@ -1,7 +1,7 @@
-# Default to clang for building the library
-CC ?= clang
+# Default to clang-18 for building the library
+CC ?= clang-18
 AR ?= ar
-CFLAGS ?= -O2
+CFLAGS ?= -O2 -march=x86-64-v1 -msse2 -msse3 -mssse3 -msse4.1 -msse4.2
 # Object files derived only from C sources.
 OBJS := $(patsubst %.cpp,%.o,$(wildcard *.cpp))
 

--- a/test_makefile
+++ b/test_makefile
@@ -1,6 +1,7 @@
 # Test Makefile for modern make system
-CC=clang++
-CXXFLAGS=-std=c++23 -O2 -pipe -Wall -Wextra -Wpedantic -march=native
+CC=clang++-18
+CXXFLAGS=-std=c++23 -O2 -pipe -Wall -Wextra -Wpedantic \
+    -march=x86-64-v1 -msse2 -msse3 -mssse3 -msse4.1 -msse4.2
 TARGET=test_program
 SOURCES=main.cpp utils.cpp
 

--- a/tools/Makefile
+++ b/tools/Makefile
@@ -2,8 +2,9 @@
 # Modern C++23 implementation with comprehensive build options
 
 # Compiler configuration
-CXX := clang++
-CXXFLAGS := -std=c++23 -Wall -Wextra -Wpedantic -Werror -O2
+CXX := clang++-18
+CXXFLAGS := -std=c++23 -Wall -Wextra -Wpedantic -Werror -O2 \
+    -march=x86-64-v1 -msse2 -msse3 -mssse3 -msse4.1 -msse4.2
 CXXFLAGS += -Wno-unused-parameter -Wno-missing-field-initializers
 
 # Debug configuration

--- a/tools/minix/Makefile
+++ b/tools/minix/Makefile
@@ -1,11 +1,11 @@
-# Use clang for the legacy tooling
-CC ?= clang
+# Use clang-18 for the legacy tooling
+CC ?= clang-18
 l=../lib
 INC ?= ../include
 LIB ?= ../lib/lib.a
 LDFLAGS ?=
 CFLAGS ?= -F
-CFLAGS += -I$(INC)
+CFLAGS += -I$(INC) -march=x86-64-v1 -msse2 -msse3 -mssse3 -msse4.1 -msse4.2
 
 all:
 	make init

--- a/tools/setup.sh
+++ b/tools/setup.sh
@@ -2,7 +2,7 @@
 # ===========================================================================
 #  setup.sh — Dependency bootstrap for the Minix-1 C++23 revival
 # ---------------------------------------------------------------------------
-#  * Installs Clang/LLVM tool-chain (prefers 18, falls back to 20, then distro)
+#  * Installs the Clang/LLVM 18 tool-chain (required)
 #  * Pulls in analysis and doc tools (clang-tidy, cppcheck, doxygen, Sphinx…)
 #  * Works on Ubuntu ≥ 22.04; warns but continues on partial failures
 # ===========================================================================
@@ -24,14 +24,10 @@ if ! sudo apt-get update; then
 fi
 
 # ─────────────────────── clang / LLVM stack ─────────────────────────
+# clang-18 is mandatory for building the project.  Abort if installation fails.
 if ! opt_install clang-18 lld-18 lldb-18; then
-  # Try the official LLVM script for clang-20
-  if curl -fsSL https://apt.llvm.org/llvm.sh | sudo bash -s -- 20; then
-    opt_install clang-20 lld-20 lldb-20
-  else
-    # Fall back to distro default
-    opt_install clang lld lldb
-  fi
+  echo "setup.sh: error: clang-18 toolchain required" >&2
+  exit 1
 fi
 
 # ───────────────────── core build / analysis pkgs ───────────────────


### PR DESCRIPTION
## Summary
- require clang-18 for all builds and add tuned x86-64 flags in `CMakeLists.txt`
- update Makefiles to default to clang-18 with the same optimization flags
- enforce clang-18 installation in `tools/setup.sh`

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_685a1ef5f1c4833197b851cbf845226e