### PR TITLE
Remove deprecated register keyword and add Doxygen docs

### DIFF
--- a/fs/open.cpp
+++ b/fs/open.cpp
@@ -32,12 +32,15 @@ PRIVATE char mode_map[] = {R_BIT, W_BIT, R_BIT | W_BIT, 0};
 /*===========================================================================*
  *				do_creat				     *
  *===========================================================================*/
+/**
+ * @brief Handle the CREAT system call.
+ */
 int do_creat() {
     /* Perform the creat(name, mode) system call. */
 
-    register struct inode *rip;
-    register int r;
-    register mask_bits bits;
+    struct inode *rip;
+    int r;
+    mask_bits bits;
     struct filp *fil_ptr;
     int file_d;
     extern struct inode *new_node();
@@ -103,10 +106,13 @@ int do_creat() {
 /*===========================================================================*
  *				do_mknod				     *
  *===========================================================================*/
+/**
+ * @brief Handle the MKNOD system call.
+ */
 int do_mknod() {
     /* Perform the mknod(name, mode, addr) system call. */
 
-    register mask_bits bits;
+    mask_bits bits;
 
     if (!super_user)
         return (ErrorCode::EPERM);                 /* only super_user may make nodes */
@@ -123,6 +129,15 @@ int do_mknod() {
  *				new_node				     *
  *===========================================================================*/
 // Changed to modern C++ signature, PRIVATE becomes static
+/**
+ * @brief Create a fresh inode on disk.
+ *
+ * @param path Path to the new node.
+ * @param bits
+ * Mode bits.
+ * @param z0 Initial zone.
+ * @return Pointer to inode or nullptr.
+ */
 static struct inode *new_node(char *path, uint16_t bits, uint16_t z0) {
     // path is char*
     // bits is mask_bits (uint16_t)
@@ -134,8 +149,8 @@ static struct inode *new_node(char *path, uint16_t bits, uint16_t z0) {
      * 'err_code' contains the appropriate message.
      */
 
-    register struct inode *rlast_dir_ptr, *rip;
-    register int r;
+    struct inode *rlast_dir_ptr, *rip;
+    int r;
     char string[NAME_SIZE]; // NAME_SIZE is std::size_t (was int)
     extern struct inode *alloc_inode(uint16_t,
                                      uint16_t); // Ensure this matches modernized alloc_inode
@@ -193,13 +208,16 @@ static struct inode *new_node(char *path, uint16_t bits, uint16_t z0) {
 /*===========================================================================*
  *				do_open					     *
  *===========================================================================*/
+/**
+ * @brief Handle the OPEN system call.
+ */
 int do_open() {
     /* Perform the open(name, mode) system call. */
 
-    register struct inode *rip;
+    struct inode *rip;
     struct filp *fil_ptr;
-    register int r;
-    register mask_bits bits;
+    int r;
+    mask_bits bits;
     int file_d;
     extern struct inode *eat_path();
 
@@ -260,11 +278,14 @@ int do_open() {
 /*===========================================================================*
  *				do_close				     *
  *===========================================================================*/
+/**
+ * @brief Handle the CLOSE system call.
+ */
 int do_close() {
     /* Perform the close(fd) system call. */
 
-    register struct filp *rfilp;
-    register struct inode *rip;
+    struct filp *rfilp;
+    struct inode *rip;
     int rw;
     int mode_word;
     extern struct filp *get_filp();
@@ -305,11 +326,14 @@ int do_close() {
 /*===========================================================================*
  *				do_lseek				     *
  *===========================================================================*/
+/**
+ * @brief Handle the LSEEK system call.
+ */
 int do_lseek() {
     /* Perform the lseek(ls_fd, offset, whence) system call. */
 
-    register struct filp *rfilp;
-    register file_pos64 pos;
+    struct filp *rfilp;
+    file_pos64 pos;
     extern struct filp *get_filp();
 
     /* Check to see if the file descriptor is valid. */

--- a/fs/read.cpp
+++ b/fs/read.cpp
@@ -42,16 +42,26 @@ PUBLIC int rdwt_err;   /* set to ErrorCode::EIO if disk error occurs */
 /*===========================================================================*
  *				do_read					     *
  *===========================================================================*/
+/**
+ * @brief Perform the READ system call.
+ */
 PUBLIC int do_read() { return (read_write(READING)); }
 
 /*===========================================================================*
  *				read_write				     *
  *===========================================================================*/
+/**
+ * @brief Core routine for reading and writing files.
+ *
+ * @param rw_flag READING or WRITING.
+
+ * * @return Bytes transferred or error code.
+ */
 PUBLIC int read_write(int rw_flag) { // Modernized signature
     /* Perform read(fd, buffer, nbytes) or write(fd, buffer, nbytes) call. */
 
-    register struct inode *rip;
-    register struct filp *f;
+    struct inode *rip;
+    struct filp *f;
     int32_t bytes_left;      // file_pos -> int32_t
     int64_t f_size;          // To match compat_get_size, was file_pos
     std::size_t off, cum_io; // Was unsigned
@@ -211,12 +221,29 @@ PUBLIC int read_write(int rw_flag) { // Modernized signature
  *				rw_chunk				     *
  *===========================================================================*/
 // Modernized signature
+/**
+ * @brief Transfer a partial block between user space and the buffer cache.
+ *
+ * @param rip
+ * Inode representing the file.
+ * @param position Starting byte position.
+ * @param off Offset
+ * within the block.
+ * @param chunk Number of bytes to transfer.
+ * @param rw_flag Direction of
+ * transfer.
+ * @param buff User buffer.
+ * @param seg  Segment for copy.
+ * @param usr  Process
+ * number.
+ * @return ::OK or error code.
+ */
 static int rw_chunk(struct inode *rip, int32_t position, std::size_t off, std::size_t chunk,
                     int rw_flag, char *buff, int seg, int usr) {
     /* Read or write (part of) a block. */
 
-    register struct buf *bp;
-    register int r;
+    struct buf *bp;
+    int r;
     int dir, n, block_spec;
     uint16_t b;   // block_nr -> uint16_t
     uint16_t dev; // dev_nr -> uint16_t
@@ -282,6 +309,14 @@ static int rw_chunk(struct inode *rip, int32_t position, std::size_t off, std::s
  *				read_map				     *
  *===========================================================================*/
 // Modernized signature
+/**
+ * @brief Map a file position to a disk block.
+ *
+ * @param rip Inode pointer.
+ * @param
+ * position Byte offset within the file.
+ * @return Block number or kNoBlock.
+ */
 PUBLIC uint16_t read_map(struct inode *rip,
                          int32_t position) { // block_nr -> uint16_t, file_pos -> int32_t
     /* Given an inode and a position within the corresponding file, locate the
@@ -289,7 +324,7 @@ PUBLIC uint16_t read_map(struct inode *rip,
      * it.
      */
 
-    register struct buf *bp;
+    struct buf *bp;
     uint16_t z;                      // zone_nr -> uint16_t
     uint16_t b;                      // block_nr -> uint16_t
     int32_t excess, zone, block_pos; // Were long, but derived from file_pos (int32_t)
@@ -352,6 +387,20 @@ PUBLIC uint16_t read_map(struct inode *rip,
  *				rw_user					     *
  *===========================================================================*/
 // Modernized signature
+/**
+ * @brief Copy data between user space and the file system.
+ *
+ * @param s Source segment.
+ *
+ * @param u Source process.
+ * @param vir Virtual address.
+ * @param bytes Number of bytes.
+ *
+ * @param buff Buffer pointer.
+ * @param direction TO_USER or FROM_USER.
+ * @return Result of
+ * sys_copy.
+ */
 PUBLIC int rw_user(int s, int u, std::size_t vir, std::size_t bytes, char *buff, int direction) {
     // s, u, direction are int. vir, bytes are std::size_t (vir_bytes). buff is char*.
     /* Transfer a block of data.  Two options exist, depending on 'direction':
@@ -390,10 +439,13 @@ PUBLIC int rw_user(int s, int u, std::size_t vir, std::size_t bytes, char *buff,
 /*===========================================================================*
  *				read_ahead				     *
  *===========================================================================*/
+/**
+ * @brief Prefetch the next block for sequential reads.
+ */
 PUBLIC void read_ahead() { // Modernized signature (was already using ())
     /* Read a block into the cache before it is needed. */
 
-    register struct inode *rip;
+    struct inode *rip;
     struct buf *bp;
     uint16_t b; // block_nr -> uint16_t
     extern struct buf *get_block();

--- a/kernel/dmp.cpp
+++ b/kernel/dmp.cpp
@@ -37,10 +37,13 @@ int vargv;               // Used in set_name, seems to hold a virtual address te
 /*===========================================================================*
  *				DEBUG routines here			     *
  *===========================================================================*/
+/**
+ * @brief Dump the process table for debugging.
+ */
 void p_dmp() noexcept { // K&R -> modern C++, added noexcept
     /* Proc table dump */
 
-    register struct proc *rp;
+    struct proc *rp;
     char *np;
     std::size_t base, limit; // vir_bytes -> std::size_t
     uint64_t first, last;    // Used for physical click addresses
@@ -109,8 +112,11 @@ void p_dmp() noexcept { // K&R -> modern C++, added noexcept
     printf("\n");
 }
 
+/**
+ * @brief Dump process memory mappings.
+ */
 void map_dmp() noexcept { // K&R -> modern C++, added noexcept
-    register struct proc *rp;
+    struct proc *rp;
     std::size_t base_k, size_k; // For K calculations, was vir_bytes
 
     printf("\nPROC   -----TEXT-----  -----DATA-----  ----STACK-----  BASE SIZE\n");
@@ -144,7 +150,9 @@ void map_dmp() noexcept { // K&R -> modern C++, added noexcept
 char *nayme[] = {"PRINTR", "TTY   ", "WINCHE", "FLOPPY", "RAMDSK", "CLOCK ",
                  "SYS   ", "HARDWR", "MM    ", "FS    ", "INIT  "}; // Assuming INIT is at index
                                                                     // NR_TASKS + 0 for user procs
-/* Print process name by index */
+/**
+ * @brief Print a process name given its index.
+ */
 static void prname(int i) noexcept { // Added noexcept
     if (i == ANY + NR_TASKS)
         printf("ANY   ");
@@ -154,7 +162,9 @@ static void prname(int i) noexcept { // Added noexcept
         printf("%4d  ", i - NR_TASKS);
 }
 
-/* Store command name for dumping */
+/**
+ * @brief Store command name for dumping.
+ */
 static void set_name(int proc_nr, char *ptr) noexcept { // Added noexcept
     /* When an EXEC call is done, the kernel is told about the stack pointer.
      * It uses the stack pointer to find the command line, for dumping

--- a/kernel/floppy.cpp
+++ b/kernel/floppy.cpp
@@ -222,9 +222,15 @@ PUBLIC void floppy_task() noexcept { // Added void return, noexcept
 /*===========================================================================*
  *				do_rdwt					     *
  *===========================================================================*/
+/**
+ * @brief Perform a single read or write request.
+ *
+ * @param m_ptr Message describing the
+ * operation.
+ * @return ::OK on success or an error code.
+ */
 static int do_rdwt(message *m_ptr) noexcept { // PRIVATE -> static, modernized signature, noexcept
-    /* Carry out a read or write request from the disk. */
-    register struct floppy *fp;
+    struct floppy *fp;
     int r, drive, errors;
     int64_t block; // Was long, for m_ptr->POSITION (int64_t)
 
@@ -306,6 +312,11 @@ static int do_rdwt(message *m_ptr) noexcept { // PRIVATE -> static, modernized s
 /*===========================================================================*
  *				dma_setup				     *
  *===========================================================================*/
+/**
+ * @brief Program the DMA controller for a transfer.
+ *
+ * @param fp Drive descriptor.
+ */
 static void
 dma_setup(struct floppy *fp) noexcept { // PRIVATE -> static, modernized signature, noexcept
     /* The IBM PC can perform DMA operations by using the DMA chip.  To use it,
@@ -361,6 +372,11 @@ dma_setup(struct floppy *fp) noexcept { // PRIVATE -> static, modernized signatu
 /*===========================================================================*
  *				start_motor				     *
  *===========================================================================*/
+/**
+ * @brief Turn on the floppy drive motor if necessary.
+ *
+ * @param fp Drive descriptor.
+ */
 static void
 start_motor(struct floppy *fp) noexcept { // PRIVATE -> static, modernized signature, noexcept
     /* Control of the floppy disk motors is a big pain.  If a motor is off, you
@@ -398,10 +414,15 @@ start_motor(struct floppy *fp) noexcept { // PRIVATE -> static, modernized signa
 /*===========================================================================*
  *				stop_motor				     *
  *===========================================================================*/
+/**
+ * @brief Callback to stop the floppy drive motor.
+ */
 static void stop_motor() noexcept { // Changed (void) to (), PRIVATE -> static, noexcept
     /* This routine is called by the clock interrupt after several seconds have
-     * elapsed with no floppy disk activity.  It checks to see if any drives are
-     * supposed to be turned off, and if so, turns them off.
+     * elapsed with
+     * no floppy disk activity.  It checks to see if any drives are
+     * supposed to be turned
+     * off, and if so, turns them off.
      */
 
     if ((motor_goal & MOTOR_MASK) != (motor_status & MOTOR_MASK)) {
@@ -413,6 +434,13 @@ static void stop_motor() noexcept { // Changed (void) to (), PRIVATE -> static, 
 /*===========================================================================*
  *				seek					     *
  *===========================================================================*/
+/**
+ * @brief Move the head to the desired cylinder.
+ *
+ * @param fp Drive descriptor.
+ * @return
+ * ::OK on success or an error code.
+ */
 static int seek(struct floppy *fp) noexcept { // PRIVATE -> static, noexcept
     /* Issue a SEEK command on the indicated drive unless the arm is already
      * positioned on the correct cylinder.
@@ -451,6 +479,13 @@ static int seek(struct floppy *fp) noexcept { // PRIVATE -> static, noexcept
 /*===========================================================================*
  *				transfer				     *
  *===========================================================================*/
+/**
+ * @brief Execute a single block data transfer.
+ *
+ * @param fp Drive descriptor.
+ * @return
+ * ::OK on success or an error code.
+ */
 static int transfer(struct floppy *fp) noexcept { // PRIVATE -> static, modernized param, noexcept
     /* The drive is now on the proper cylinder.  Read or write 1 block. */
 
@@ -511,6 +546,13 @@ static int transfer(struct floppy *fp) noexcept { // PRIVATE -> static, moderniz
 /*===========================================================================*
  *				fdc_results				     *
  *===========================================================================*/
+/**
+ * @brief Retrieve result bytes from the floppy controller.
+ *
+ * @param fp Drive descriptor.
+ *
+ * @return ::OK on success or an error code.
+ */
 static int
 fdc_results(struct floppy *fp) noexcept { // PRIVATE -> static, modernized param, noexcept
     /* Extract results from the controller after an operation. */
@@ -547,6 +589,11 @@ fdc_results(struct floppy *fp) noexcept { // PRIVATE -> static, modernized param
 /*===========================================================================*
  *				fdc_out					     *
  *===========================================================================*/
+/**
+ * @brief Output a command byte to the floppy controller.
+ *
+ * @param val Value to send.
+ */
 static void fdc_out(int val) noexcept { // PRIVATE -> static, modernized signature, noexcept
     /* Output a byte to the controller.  This is not entirely trivial, since you
      * can only write to it when it is listening, and it decides when to listen.
@@ -577,6 +624,13 @@ static void fdc_out(int val) noexcept { // PRIVATE -> static, modernized signatu
 /*===========================================================================*
  *				recalibrate				     *
  *===========================================================================*/
+/**
+ * @brief Recalibrate the drive to cylinder zero.
+ *
+ * @param fp Drive descriptor.
+ * @return
+ * ::OK on success or an error code.
+ */
 static int
 recalibrate(struct floppy *fp) noexcept { // PRIVATE -> static, modernized param, noexcept
     /* The floppy disk controller has no way of determining its absolute arm
@@ -617,13 +671,16 @@ recalibrate(struct floppy *fp) noexcept { // PRIVATE -> static, modernized param
 /*===========================================================================*
  *				reset					     *
  *===========================================================================*/
+/**
+ * @brief Reset the floppy controller after an error.
+ */
 static void reset() noexcept { // PRIVATE -> static, modernized signature, noexcept
     /* Issue a reset to the controller.  This is done after any catastrophe,
      * like the controller refusing to respond.
      */
 
     int i, r, status;
-    register struct floppy *fp;
+    struct floppy *fp;
     /* Disable interrupts and strobe reset bit low. */
     need_reset = FALSE;
     lock();
@@ -653,6 +710,13 @@ static void reset() noexcept { // PRIVATE -> static, modernized signature, noexc
 /*===========================================================================*
  *				clock_mess				     *
  *===========================================================================*/
+/**
+ * @brief Schedule a callback with the clock task.
+ *
+ * @param ticks Number of ticks until the
+ * callback.
+ * @param func  Function to call when the time expires.
+ */
 static void clock_mess(int ticks,
                        void (*func)()) noexcept { // PRIVATE -> static, (void)->(), noexcept
     /* Send the clock task a message. */
@@ -667,6 +731,9 @@ static void clock_mess(int ticks,
 /*===========================================================================*
  *				send_mess				     *
  *===========================================================================*/
+/**
+ * @brief Notify the floppy task that the motor has started.
+ */
 static void send_mess() noexcept { // PRIVATE -> static, (void)->(), noexcept
     /* This routine is called when the clock task has timed out on motor startup.*/
 

--- a/mm/break.cpp
+++ b/mm/break.cpp
@@ -52,7 +52,7 @@ PUBLIC int do_brk() {
      * separate I & D space have the SEPARATE bit in mp_flags set.
      */
 
-    register struct mproc *rmp;
+    struct mproc *rmp;
     int r;
     std::size_t v, new_sp;  // vir_bytes -> std::size_t
     std::size_t new_clicks; // vir_clicks -> std::size_t
@@ -91,7 +91,7 @@ PUBLIC int do_brk() {
      * negative, the adjustment of data or stack fails and ErrorCode::ENOMEM is returned.
      */
 
-    register struct mem_map *mem_sp, *mem_dp;
+    struct mem_map *mem_sp, *mem_dp;
     std::size_t sp_click, gap_base, lower, old_clicks; // vir_clicks -> std::size_t
     int changed, r, ft;
     int64_t base_of_stack, delta; // Changed from long for clarity and defined width
@@ -218,7 +218,7 @@ PRIVATE void stack_fault(int proc_nr) {
      * If this is impossible because data segment is in the way, kill the process.
      */
 
-    register struct mproc *rmp;
+    struct mproc *rmp;
     int r;
     std::size_t new_sp; // vir_bytes -> std::size_t
 


### PR DESCRIPTION
## Summary
- remove `register` from several modules
- document functions in kernel, fs and mm with Doxygen comments
- keep code formatted via clang-format

## Testing
- `cmake -B build -S . -DBUILD_SYSTEM=ON`
- `cmake --build build -j $(nproc)` *(fails: `commands/CMakeFiles/minix_cmd_ar.dir/ar.cpp.o`)*

------
https://chatgpt.com/codex/tasks/task_e_685a1ef54570833184e66b325d0759ed