### PR TITLE
Use xinim_abort wrapper

### DIFF
--- a/commands/legacy_backup/mined1_legacy_backup.cpp
+++ b/commands/legacy_backup/mined1_legacy_backup.cpp
@@ -411,6 +411,7 @@
  *  ========================================================================  */
 
 #include "../include/lib.hpp" // C++23 header
+#include "../include/xinim/abort.h"
 #include "mined.hpp"
 #include "sgtty.hpp"
 #include "signal.hpp"
@@ -1046,7 +1047,7 @@ abort_mined() {
     putchar('\n');
     flush();
 #ifdef UNIX
-    abort();
+    xinim_abort();
 #else
     exit(1);
 #endif UNIX
@@ -1123,7 +1124,7 @@ panic(message) register char *message;
     raw_mode(OFF);
 
 #ifdef UNIX
-    abort();
+    xinim_abort();
 #else
     exit(1);
 #endif UNIX

--- a/crypto/kyber_impl/randombytes.c
+++ b/crypto/kyber_impl/randombytes.c
@@ -1,18 +1,19 @@
+#include "randombytes.h"
+#include "../../include/xinim/abort.h"
 #include <stddef.h>
 #include <stdint.h>
 #include <stdlib.h>
-#include "randombytes.h"
 
 #ifdef _WIN32
-#include <windows.h>
 #include <wincrypt.h>
+#include <windows.h>
 #else
-#include <fcntl.h>
 #include <errno.h>
+#include <fcntl.h>
 #ifdef __linux__
 #define _GNU_SOURCE
-#include <unistd.h>
 #include <sys/syscall.h>
+#include <unistd.h>
 #elif __NetBSD__
 #include <sys/random.h>
 #else
@@ -22,76 +23,76 @@
 
 #ifdef _WIN32
 void randombytes(uint8_t *out, size_t outlen) {
-  HCRYPTPROV ctx;
-  size_t len;
+    HCRYPTPROV ctx;
+    size_t len;
 
-  if(!CryptAcquireContext(&ctx, NULL, NULL, PROV_RSA_FULL, CRYPT_VERIFYCONTEXT))
-    abort();
+    if (!CryptAcquireContext(&ctx, NULL, NULL, PROV_RSA_FULL, CRYPT_VERIFYCONTEXT))
+        xinim_abort();
 
-  while(outlen > 0) {
-    len = (outlen > 1048576) ? 1048576 : outlen;
-    if(!CryptGenRandom(ctx, len, (BYTE *)out))
-      abort();
+    while (outlen > 0) {
+        len = (outlen > 1048576) ? 1048576 : outlen;
+        if (!CryptGenRandom(ctx, len, (BYTE *)out))
+            xinim_abort();
 
-    out += len;
-    outlen -= len;
-  }
+        out += len;
+        outlen -= len;
+    }
 
-  if(!CryptReleaseContext(ctx, 0))
-    abort();
+    if (!CryptReleaseContext(ctx, 0))
+        xinim_abort();
 }
 #elif defined(__linux__) && defined(SYS_getrandom)
 void randombytes(uint8_t *out, size_t outlen) {
-  ssize_t ret;
+    ssize_t ret;
 
-  while(outlen > 0) {
-    ret = syscall(SYS_getrandom, out, outlen, 0);
-    if(ret == -1 && errno == EINTR)
-      continue;
-    else if(ret == -1)
-      abort();
+    while (outlen > 0) {
+        ret = syscall(SYS_getrandom, out, outlen, 0);
+        if (ret == -1 && errno == EINTR)
+            continue;
+        else if (ret == -1)
+            xinim_abort();
 
-    out += ret;
-    outlen -= ret;
-  }
+        out += ret;
+        outlen -= ret;
+    }
 }
 #elif defined(__NetBSD__)
 void randombytes(uint8_t *out, size_t outlen) {
-  ssize_t ret;
+    ssize_t ret;
 
-  while(outlen > 0) {
-    ret = getrandom(out, outlen, 0);
-    if(ret == -1 && errno == EINTR)
-      continue;
-    else if(ret == -1)
-      abort();
+    while (outlen > 0) {
+        ret = getrandom(out, outlen, 0);
+        if (ret == -1 && errno == EINTR)
+            continue;
+        else if (ret == -1)
+            xinim_abort();
 
-    out += ret;
-    outlen -= ret;
-  }
+        out += ret;
+        outlen -= ret;
+    }
 }
 #else
 void randombytes(uint8_t *out, size_t outlen) {
-  static int fd = -1;
-  ssize_t ret;
+    static int fd = -1;
+    ssize_t ret;
 
-  while(fd == -1) {
-    fd = open("/dev/urandom", O_RDONLY);
-    if(fd == -1 && errno == EINTR)
-      continue;
-    else if(fd == -1)
-      abort();
-  }
+    while (fd == -1) {
+        fd = open("/dev/urandom", O_RDONLY);
+        if (fd == -1 && errno == EINTR)
+            continue;
+        else if (fd == -1)
+            xinim_abort();
+    }
 
-  while(outlen > 0) {
-    ret = read(fd, out, outlen);
-    if(ret == -1 && errno == EINTR)
-      continue;
-    else if(ret == -1)
-      abort();
+    while (outlen > 0) {
+        ret = read(fd, out, outlen);
+        if (ret == -1 && errno == EINTR)
+            continue;
+        else if (ret == -1)
+            xinim_abort();
 
-    out += ret;
-    outlen -= ret;
-  }
+        out += ret;
+        outlen -= ret;
+    }
 }
 #endif

--- a/include/xinim/abort.h
+++ b/include/xinim/abort.h
@@ -1,0 +1,23 @@
+/**
+ * @file abort.h
+ * @brief Cross-language wrapper for program termination.
+ */
+#ifndef XINIM_ABORT_H
+#define XINIM_ABORT_H
+
+#ifdef __cplusplus
+#include <cstdlib>
+/**
+ * @brief Terminate the process without invoking signal handlers.
+ *
+ * The function exits the application with status code 99 and never
+ * returns. It is provided both as a C linkage declaration and an
+ * inline C++ helper.
+ */
+extern "C" [[noreturn]] void xinim_abort() noexcept;
+inline void xinim_abort() noexcept { std::exit(99); }
+#else
+[[noreturn]] void xinim_abort(void) noexcept;
+#endif
+
+#endif // XINIM_ABORT_H

--- a/lib/abort.cpp
+++ b/lib/abort.cpp
@@ -1,14 +1,8 @@
 /**
  * @file abort.cpp
- * @brief Minimal stub for the C @c abort function.
+ * @brief Implementation of the xinim_abort wrapper.
  */
 
-#include <stdlib.h>
+#include "../include/xinim/abort.h"
 
-/**
- * @brief Terminate the program abnormally.
- *
- * Simply exits with status code 99 to indicate failure. In a full
- * implementation this would raise SIGABRT and generate a core dump.
- */
-[[noreturn]] void abort() { exit(99); }
+extern "C" [[noreturn]] void xinim_abort() noexcept { std::exit(99); }


### PR DESCRIPTION
## Summary
- add `xinim_abort` termination wrapper
- use `xinim_abort()` instead of `abort()`

## Testing
- `clang++ -std=c++23 -O2 -pipe -Wall -Wextra -Wpedantic -march=native tests/t10a.cpp -o tests/t10a && ./tests/t10a && echo "test ok"`


------
https://chatgpt.com/codex/tasks/task_e_685a1ef42eb08331a95b491d0faf032e