### PR TITLE
Fix tests build and abort linkage

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -72,7 +72,12 @@ endif()
 # 5. Baseline optimisation flags (native or cross)
 #    x86-64-v1: MMX + SSE + SSE2, widest deployable subset.
 # ─────────────────────────────────────────────────────────────────────────────
-set(BASE_CPU_FLAGS "-march=x86-64-v1 -mtune=generic -msse -mmmx")
+set(BASE_CPU_FLAGS
+    -march=x86-64
+    -mtune=generic
+    -msse
+    -mmmx
+)
 add_compile_options(${BASE_CPU_FLAGS})
 
 # ─────────────────────────────────────────────────────────────────────────────

--- a/crypto/CMakeLists.txt
+++ b/crypto/CMakeLists.txt
@@ -27,7 +27,8 @@ else()
   set(SODIUM_INCLUDE_DIRS ${CMAKE_SOURCE_DIR}/tests)
 endif()
 
-add_library(pqcrypto STATIC kyber.cpp pqcrypto_shared.cpp ${KYBER_IMPL_SOURCES})
+add_library(pqcrypto STATIC kyber.cpp pqcrypto_shared.cpp ${KYBER_IMPL_SOURCES}
+    ${CMAKE_SOURCE_DIR}/lib/abort.cpp)
 
 set_target_properties(pqcrypto PROPERTIES
     CXX_STANDARD 23

--- a/crypto/kyber_impl/randombytes.c
+++ b/crypto/kyber_impl/randombytes.c
@@ -1,3 +1,7 @@
+#ifdef __linux__
+#define _GNU_SOURCE
+#endif
+
 #include "randombytes.h"
 #include "../../include/xinim/abort.h"
 #include <stddef.h>
@@ -11,7 +15,6 @@
 #include <errno.h>
 #include <fcntl.h>
 #ifdef __linux__
-#define _GNU_SOURCE
 #include <sys/syscall.h>
 #include <unistd.h>
 #elif __NetBSD__

--- a/fs/const.hpp
+++ b/fs/const.hpp
@@ -66,4 +66,6 @@ inline constexpr std::size_t PIPE_SIZE =
     static_cast<std::size_t>(NR_DZONE_NUM) * BLOCK_SIZE; /* pipe size in bytes*/
 inline constexpr std::size_t MAX_ZONES = NR_DZONE_NUM + NR_INDIRECTS + NR_INDIRECTS * NR_INDIRECTS;
 /* max # of zones in a file */
+#ifndef __cplusplus
 #define printf printk
+#endif

--- a/include/xinim/abort.h
+++ b/include/xinim/abort.h
@@ -17,7 +17,7 @@
 extern "C" [[noreturn]] void xinim_abort() noexcept;
 inline void xinim_abort() noexcept { std::exit(99); }
 #else
-[[noreturn]] void xinim_abort(void) noexcept;
+_Noreturn void xinim_abort(void);
 #endif
 
 #endif // XINIM_ABORT_H

--- a/kernel/const.hpp
+++ b/kernel/const.hpp
@@ -57,4 +57,6 @@ inline constexpr int PRI_USER = 8;         /* default user process priority */
 inline constexpr int SCHED_QUEUES = NR_SCHED_QUEUES;
 #endif
 
+#ifndef __cplusplus
 #define printf printk /* the kernel really uses printk, not printf */
+#endif

--- a/kernel/net_driver.hpp
+++ b/kernel/net_driver.hpp
@@ -11,7 +11,7 @@
  *   net::init({0, 12000});                               // autodetect node_id
  *   net::add_remote(2, "192.168.1.4", 12000, Protocol::TCP);
  *   net::send(2, payload);                               // sends [local_node|payload]
- *   while (net::recv(pkt)) { /* process pkt */ }
+ *   while (net::recv(pkt)) { // process pkt }
  *   net::shutdown();
  *
  * Thread Safety: All APIs are thread-safe and may be called from multiple threads.
@@ -25,8 +25,8 @@
 #include <span>
 #include <string>
 #include <system_error>
-#include <vector>
 #include <system_error> // for std::errc
+#include <vector>
 
 namespace net {
 
@@ -40,8 +40,8 @@ using node_t = int;
  * they appear as a Packet with src_node and payload.
  */
 struct Packet {
-    node_t                   src_node;  ///< Originating node ID
-    std::vector<std::byte>   payload;   ///< Message payload (excluding prefix)
+    node_t src_node;                ///< Originating node ID
+    std::vector<std::byte> payload; ///< Message payload (excluding prefix)
 };
 
 /**
@@ -70,27 +70,21 @@ enum class Protocol {
  * @param node_id_dir_    Directory for persisting auto-detected node ID
  */
 struct Config {
-    node_t                  node_id;
-    std::uint16_t           port;
-    std::size_t             max_queue_length;
-    OverflowPolicy          overflow;
-    std::filesystem::path   node_id_dir;
+    node_t node_id;
+    std::uint16_t port;
+    std::size_t max_queue_length;
+    OverflowPolicy overflow;
+    std::filesystem::path node_id_dir;
 
-    constexpr Config(node_t                  node_id_        = 0,
-                     std::uint16_t           port_           = 0,
-                     std::size_t             max_len         = 0,
-                     OverflowPolicy          policy          = OverflowPolicy::DropNewest,
-                     std::filesystem::path   node_id_dir_    = {}) noexcept
-      : node_id(node_id_),
-        port(port_),
-        max_queue_length(max_len),
-        overflow(policy),
-        node_id_dir(std::move(node_id_dir_))
-    {}
+    constexpr Config(node_t node_id_ = 0, std::uint16_t port_ = 0, std::size_t max_len = 0,
+                     OverflowPolicy policy = OverflowPolicy::DropNewest,
+                     std::filesystem::path node_id_dir_ = {}) noexcept
+        : node_id(node_id_), port(port_), max_queue_length(max_len), overflow(policy),
+          node_id_dir(std::move(node_id_dir_)) {}
 };
 
 /** Callback type invoked on packet arrival (from background thread). */
-using RecvCallback = std::function<void(const Packet&)>;
+using RecvCallback = std::function<void(const Packet &)>;
 
 /**
  * @brief Initialize the network driver.
@@ -101,7 +95,7 @@ using RecvCallback = std::function<void(const Packet&)>;
  * @param cfg Driver configuration
  * @throws std::system_error on socket/bind/thread failures
  */
-void init(const Config& cfg);
+void init(const Config &cfg);
 
 /**
  * @brief Register a remote peer for sending.
@@ -116,9 +110,7 @@ void init(const Config& cfg);
  * @throws std::invalid_argument on name resolution failure
  * @throws std::system_error on TCP socket/connect failure
  */
-void add_remote(node_t node,
-                const std::string& host,
-                uint16_t port,
+void add_remote(node_t node, const std::string &host, uint16_t port,
                 Protocol proto = Protocol::UDP);
 
 /**
@@ -162,8 +154,7 @@ void shutdown() noexcept;
  * @return std::errc::success on success, or descriptive error code
  * @throws std::system_error on underlying socket failures
  */
-[[nodiscard]] std::errc send(node_t node,
-                             std::span<const std::byte> data);
+[[nodiscard]] std::errc send(node_t node, std::span<const std::byte> data);
 
 /**
  * @brief Dequeue the next received packet, if any.
@@ -171,7 +162,7 @@ void shutdown() noexcept;
  * @param out Packet to populate
  * @return true if a packet was dequeued, false if queue was empty
  */
-[[nodiscard]] bool recv(Packet& out);
+[[nodiscard]] bool recv(Packet &out);
 
 /**
  * @brief Clear all pending packets from the receive queue.

--- a/lib/abort.cpp
+++ b/lib/abort.cpp
@@ -16,6 +16,8 @@
  * traditional abort(3) and is used as the canonical fatal-termination
  * endpoint for the XINIM kernel, tests, and userland.
  */
-_Noreturn void xinim_abort(void) {
-    _Exit(99);  // Fast, async-signal-safe, no flushing or unwinding.
+extern "C" {
+[[noreturn]] void xinim_abort(void) {
+    _Exit(99); // Fast, async-signal-safe, no flushing or unwinding.
+}
 }

--- a/mm/const.hpp
+++ b/mm/const.hpp
@@ -21,4 +21,6 @@ inline constexpr std::size_t MAX_PAGES = 1048576;
 inline constexpr std::size_t HDR_SIZE = 32;
 inline constexpr phys_clicks NO_MEM = 0; /* returned by alloc_mem() when mem is up */
 
+#ifndef __cplusplus
 #define printf printk
+#endif


### PR DESCRIPTION
## Summary
- compile pqcrypto with abort helper to satisfy randombytes
- wrap kernel printf macros for C-only inclusion
- update net driver comments to remove invalid nested block
- correct abort helper attribute
- refresh service manager serialization test

## Testing
- `bash tools/setup.sh` *(partial success: libfuzzer-dev unavailable)*
- `cmake -B build -DENABLE_UNIT_TESTS=ON`
- `cmake --build build -j$(nproc)`
- `ctest --test-dir build` *(several tests aborted)*
- `make -f test_makefile` *(failed: No rule to make target 'main.cpp')*

------
https://chatgpt.com/codex/tasks/task_e_685f29dab26c83319919510d1798fe94