### PR TITLE
Refine abort header and _GNU_SOURCE guard

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -72,7 +72,12 @@ endif()
 # 5. Baseline optimisation flags (native or cross)
 #    x86-64-v1: MMX + SSE + SSE2, widest deployable subset.
 # ─────────────────────────────────────────────────────────────────────────────
-set(BASE_CPU_FLAGS "-march=x86-64-v1 -mtune=generic -msse -mmmx")
+set(BASE_CPU_FLAGS
+    "-march=x86-64"
+    "-mtune=generic"
+    "-msse"
+    "-mmmx"
+)
 add_compile_options(${BASE_CPU_FLAGS})
 
 # ─────────────────────────────────────────────────────────────────────────────

--- a/crypto/kyber_impl/randombytes.c
+++ b/crypto/kyber_impl/randombytes.c
@@ -1,3 +1,8 @@
+#ifdef __linux__
+#ifndef _GNU_SOURCE
+#define _GNU_SOURCE
+#endif
+#endif
 #include "randombytes.h"
 #include "../../include/xinim/abort.h"
 #include <stddef.h>
@@ -11,7 +16,6 @@
 #include <errno.h>
 #include <fcntl.h>
 #ifdef __linux__
-#define _GNU_SOURCE
 #include <sys/syscall.h>
 #include <unistd.h>
 #elif __NetBSD__

--- a/include/xinim/abort.h
+++ b/include/xinim/abort.h
@@ -14,10 +14,10 @@
  * returns. It is provided both as a C linkage declaration and an
  * inline C++ helper.
  */
-extern "C" [[noreturn]] void xinim_abort() noexcept;
-inline void xinim_abort() noexcept { std::exit(99); }
+extern "C" _Noreturn void xinim_abort(void) noexcept;
+inline _Noreturn void xinim_abort(void) noexcept { std::exit(99); }
 #else
-[[noreturn]] void xinim_abort(void) noexcept;
+_Noreturn void xinim_abort(void);
 #endif
 
 #endif // XINIM_ABORT_H


### PR DESCRIPTION
## Summary
- guard `_GNU_SOURCE` in randombytes for portable clang builds
- mark inline abort helper as `_Noreturn` for compilers
- keep baseline CPU flags using recognized `x86-64`

## Testing
- `cmake -B build -DCMAKE_C_COMPILER=clang-18 -DCMAKE_CXX_COMPILER=clang++-18`
- `cmake --build build -j$(nproc)`
- `ctest --test-dir build` *(no tests found)*

------
https://chatgpt.com/codex/tasks/task_e_685f2765e0408331b98d5c037d826f0c