### PR TITLE
Fix lattice tests and enhance FAT utilities

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,6 +12,13 @@ if(NOT CMAKE_C_COMPILER)
         $<IF:$<BOOL:${CLANG_20}>,${CLANG_20},clang>>)
 endif()
 
+# Automatically enable libc++ when building with Clang
+if(CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -stdlib=libc++")
+  set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -stdlib=libc++")
+  set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -stdlib=libc++")
+  link_libraries(c++ c++abi)
+endif()
 if(NOT CMAKE_CXX_COMPILER)
   find_program(CLANGXX_18 clang++-18)
   find_program(CLANGXX_20 clang++-20)

--- a/commands/cc.cpp
+++ b/commands/cc.cpp
@@ -113,35 +113,14 @@ namespace compiler_paths {
 }
 
 // Legacy toolchain path globals (being phased out)
-// TODO: Replace with modern compiler_paths namespace usage
-#ifdef MEM640K
-    /* MINIX paths for 640K PC (not 512K AT) */
-    char *PP = const_cast<char*>("/lib/cpp");
-    char *CEM = const_cast<char*>("/lib/cem");
-    char *OPT = const_cast<char*>("/usr/lib/opt");
-    char *CG = const_cast<char*>("/usr/lib/cg");
-    char *ASLD = const_cast<char*>("/usr/bin/asld");
-    char *SHELL = const_cast<char*>("/bin/sh");
-    char *LIBDIR = const_cast<char*>("/usr/lib");
-#elif defined(MEM512K)
-    /* MINIX paths for 512K AT (not 640K PC) */
-    char *PP = const_cast<char*>("/usr/lib/cpp");
-    char *CEM = const_cast<char*>("/usr/lib/cem");
-    char *OPT = const_cast<char*>("/usr/lib/opt");
-    char *CG = const_cast<char*>("/usr/lib/cg");
-    char *ASLD = const_cast<char*>("/usr/bin/asld");
-    char *SHELL = const_cast<char*>("/bin/sh");
-    char *LIBDIR = const_cast<char*>("/usr/lib");
-#else
-    // Default modern configuration
-    char *PP = const_cast<char*>("/usr/lib/cpp");
-    char *CEM = const_cast<char*>("/usr/lib/cem");
-    char *OPT = const_cast<char*>("/usr/lib/opt");
-    char *CG = const_cast<char*>("/usr/lib/cg");
-    char *ASLD = const_cast<char*>("/usr/bin/asld");
-    char *SHELL = const_cast<char*>("/bin/sh");
-    char *LIBDIR = const_cast<char*>("/usr/lib");
-#endif
+// Replaced with references to compiler_paths namespace constants
+const char *PP = compiler_paths::CPP_PATH.data();
+const char *CEM = compiler_paths::CEM_PATH.data();
+const char *OPT = compiler_paths::OPT_PATH.data();
+const char *CG = compiler_paths::CG_PATH.data();
+const char *ASLD = compiler_paths::ASLD_PATH.data();
+const char *SHELL = compiler_paths::SHELL_PATH.data();
+const char *LIBDIR = compiler_paths::LIB_DIR.data();
 
 // Modern configuration constants
 namespace toolchain_config {

--- a/commands/dosread.cpp
+++ b/commands/dosread.cpp
@@ -21,78 +21,74 @@
  *   dosdir [-lr] device [dir]    - List DOS directory
  */
 
-#include <iostream>
+#include "fat_utils.hpp"
+#include <algorithm>
+#include <array>
+#include <cassert>
+#include <chrono>
+#include <cstdint>
+#include <filesystem>
 #include <fstream>
-#include <vector>
+#include <iomanip>
+#include <iostream>
+#include <memory>
+#include <span>
 #include <string>
 #include <string_view>
-#include <array>
-#include <memory>
-#include <cstdint>
-#include <chrono>
-#include <filesystem>
 #include <system_error>
-#include <algorithm>
-#include <iomanip>
-#include <cassert>
-#include <span>
+#include <vector>
 
 namespace fat {
 
 /**
  * @brief FAT filesystem type enumeration.
  */
-enum class FatType : uint8_t {
-    FAT12,
-    FAT16,
-    FAT32,
-    EXFAT
-};
+enum class FatType : uint8_t { FAT12, FAT16, FAT32, EXFAT };
 
 /**
  * @brief Boot sector structure for FAT12/16/32.
  */
 #pragma pack(push, 1)
 struct BootSector {
-    uint8_t  jump[3];
-    char     oem_name[8];
+    uint8_t jump[3];
+    char oem_name[8];
     uint16_t bytes_per_sector;
-    uint8_t  sectors_per_cluster;
+    uint8_t sectors_per_cluster;
     uint16_t reserved_sectors;
-    uint8_t  num_fats;
+    uint8_t num_fats;
     uint16_t root_entries;
     uint16_t total_sectors_16;
-    uint8_t  media_descriptor;
+    uint8_t media_descriptor;
     uint16_t fat_size_16;
     uint16_t sectors_per_track;
     uint16_t num_heads;
     uint32_t hidden_sectors;
     uint32_t total_sectors_32;
-    
+
     union {
-        struct {  // FAT12/16
-            uint8_t  drive_number;
-            uint8_t  reserved;
-            uint8_t  boot_signature;
+        struct { // FAT12/16
+            uint8_t drive_number;
+            uint8_t reserved;
+            uint8_t boot_signature;
             uint32_t volume_id;
-            char     volume_label[11];
-            char     filesystem_type[8];
+            char volume_label[11];
+            char filesystem_type[8];
         } fat16;
-        
-        struct {  // FAT32
+
+        struct { // FAT32
             uint32_t fat_size_32;
             uint16_t ext_flags;
             uint16_t fs_version;
             uint32_t root_cluster;
             uint16_t fs_info;
             uint16_t backup_boot_sector;
-            uint8_t  reserved[12];
-            uint8_t  drive_number;
-            uint8_t  reserved1;
-            uint8_t  boot_signature;
+            uint8_t reserved[12];
+            uint8_t drive_number;
+            uint8_t reserved1;
+            uint8_t boot_signature;
             uint32_t volume_id;
-            char     volume_label[11];
-            char     filesystem_type[8];
+            char volume_label[11];
+            char filesystem_type[8];
         } fat32;
     };
 };
@@ -101,9 +97,9 @@ struct BootSector {
  * @brief exFAT boot sector structure.
  */
 struct ExFatBootSector {
-    uint8_t  jump[3];
-    char     filesystem_name[8];
-    uint8_t  reserved[53];
+    uint8_t jump[3];
+    char filesystem_name[8];
+    uint8_t reserved[53];
     uint64_t partition_offset;
     uint64_t volume_length;
     uint32_t fat_offset;
@@ -114,23 +110,23 @@ struct ExFatBootSector {
     uint32_t volume_serial_number;
     uint16_t filesystem_revision;
     uint16_t volume_flags;
-    uint8_t  bytes_per_sector_shift;
-    uint8_t  sectors_per_cluster_shift;
-    uint8_t  number_of_fats;
-    uint8_t  drive_select;
-    uint8_t  percent_in_use;
-    uint8_t  reserved2[7];
+    uint8_t bytes_per_sector_shift;
+    uint8_t sectors_per_cluster_shift;
+    uint8_t number_of_fats;
+    uint8_t drive_select;
+    uint8_t percent_in_use;
+    uint8_t reserved2[7];
 };
 
 /**
  * @brief Directory entry structure for FAT12/16/32.
  */
 struct DirectoryEntry {
-    char     name[8];
-    char     ext[3];
-    uint8_t  attributes;
-    uint8_t  nt_reserved;
-    uint8_t  creation_time_tenth;
+    char name[8];
+    char ext[3];
+    uint8_t attributes;
+    uint8_t nt_reserved;
+    uint8_t creation_time_tenth;
     uint16_t creation_time;
     uint16_t creation_date;
     uint16_t last_access_date;
@@ -145,11 +141,11 @@ struct DirectoryEntry {
  * @brief Long filename entry structure.
  */
 struct LongFilenameEntry {
-    uint8_t  order;
+    uint8_t order;
     uint16_t name1[5];
-    uint8_t  attributes;
-    uint8_t  type;
-    uint8_t  checksum;
+    uint8_t attributes;
+    uint8_t type;
+    uint8_t checksum;
     uint16_t name2[6];
     uint16_t first_cluster_low;
     uint16_t name3[2];
@@ -161,26 +157,26 @@ struct LongFilenameEntry {
 struct ExFatDirectoryEntry {
     uint8_t entry_type;
     union {
-        struct {  // File entry
-            uint8_t  secondary_count;
+        struct { // File entry
+            uint8_t secondary_count;
             uint16_t set_checksum;
             uint16_t file_attributes;
             uint16_t reserved1;
             uint32_t create_timestamp;
             uint32_t last_modified_timestamp;
             uint32_t last_accessed_timestamp;
-            uint8_t  create_10ms_increment;
-            uint8_t  last_modified_10ms_increment;
-            uint8_t  create_utc_offset;
-            uint8_t  last_modified_utc_offset;
-            uint8_t  last_accessed_utc_offset;
-            uint8_t  reserved2[7];
+            uint8_t create_10ms_increment;
+            uint8_t last_modified_10ms_increment;
+            uint8_t create_utc_offset;
+            uint8_t last_modified_utc_offset;
+            uint8_t last_accessed_utc_offset;
+            uint8_t reserved2[7];
         } file;
-        
-        struct {  // Stream extension entry
-            uint8_t  general_secondary_flags;
-            uint8_t  reserved1;
-            uint8_t  name_length;
+
+        struct { // Stream extension entry
+            uint8_t general_secondary_flags;
+            uint8_t reserved1;
+            uint8_t name_length;
             uint16_t name_hash;
             uint16_t reserved2;
             uint64_t valid_data_length;
@@ -188,31 +184,39 @@ struct ExFatDirectoryEntry {
             uint32_t first_cluster;
             uint64_t data_length;
         } stream;
-        
-        struct {  // Filename entry
-            uint8_t  general_secondary_flags;
+
+        struct { // Filename entry
+            uint8_t general_secondary_flags;
             uint16_t filename[15];
         } filename;
     };
 };
 #pragma pack(pop)
 
+/** Format a directory entry name into conventional form. */
+[[nodiscard]] std::string format_filename(const DirectoryEntry &entry) {
+    std::string name(entry.name, 8);
+    std::string ext(entry.ext, 3);
+    name.erase(name.find_last_not_of(' ') + 1);
+    ext.erase(ext.find_last_not_of(' ') + 1);
+    return ext.empty() ? name : name + "." + ext;
+}
+
 /**
  * @brief Cluster chain for representing file allocation.
  */
-template<typename ClusterType>
-class ClusterChain {
-public:
+template <typename ClusterType> class ClusterChain {
+  public:
     using cluster_t = ClusterType;
-    
+
     explicit ClusterChain(cluster_t start_cluster) : start_cluster_(start_cluster) {}
-    
+
     void add_cluster(cluster_t cluster) { clusters_.push_back(cluster); }
     cluster_t start_cluster() const { return start_cluster_; }
-    const std::vector<cluster_t>& clusters() const { return clusters_; }
+    const std::vector<cluster_t> &clusters() const { return clusters_; }
     size_t size() const { return clusters_.size(); }
-    
-private:
+
+  private:
     cluster_t start_cluster_;
     std::vector<cluster_t> clusters_;
 };
@@ -221,17 +225,18 @@ private:
  * @brief Abstract base class for FAT filesystem implementations.
  */
 class FatFilesystem {
-public:
+  public:
     virtual ~FatFilesystem() = default;
-    
+
     virtual FatType get_type() const = 0;
-    virtual bool read_file(const std::string& path, std::vector<uint8_t>& data) = 0;
-    virtual bool write_file(const std::string& path, const std::vector<uint8_t>& data) = 0;
-    virtual std::vector<std::string> list_directory(const std::string& path) = 0;
-    virtual bool exists(const std::string& path) = 0;
-    virtual bool is_directory(const std::string& path) = 0;
-    
-protected:
+    virtual bool read_file(const std::string &path, std::vector<uint8_t> &data) = 0;
+    virtual bool write_file(const std::string &path, const std::vector<uint8_t> &data) = 0;
+    virtual std::vector<std::string> list_directory(const std::string &path) = 0;
+    virtual std::vector<DirectoryEntry> raw_directory(const std::string &path) = 0;
+    virtual bool exists(const std::string &path) = 0;
+    virtual bool is_directory(const std::string &path) = 0;
+
+  protected:
     std::fstream device_;
     uint32_t bytes_per_sector_ = 512;
     uint32_t sectors_per_cluster_ = 1;
@@ -241,23 +246,22 @@ protected:
 /**
  * @brief Template implementation for FAT12/16/32 filesystems.
  */
-template<typename ClusterType>
-class FatFilesystemImpl : public FatFilesystem {
-public:
+template <typename ClusterType> class FatFilesystemImpl : public FatFilesystem {
+  public:
     using cluster_t = ClusterType;
     static constexpr cluster_t END_OF_CHAIN = static_cast<cluster_t>(-1);
     static constexpr cluster_t BAD_CLUSTER = static_cast<cluster_t>(-2);
-    
-    explicit FatFilesystemImpl(const std::string& device_path) {
+
+    explicit FatFilesystemImpl(const std::string &device_path) {
         device_.open(device_path, std::ios::binary | std::ios::in | std::ios::out);
         if (!device_) {
             throw std::runtime_error("Cannot open device: " + device_path);
         }
-        
+
         read_boot_sector();
         read_fat();
     }
-    
+
     FatType get_type() const override {
         if constexpr (sizeof(cluster_t) == 2) {
             return total_clusters_ < 4085 ? FatType::FAT12 : FatType::FAT16;
@@ -265,33 +269,35 @@ public:
             return FatType::FAT32;
         }
     }
-    
-    bool read_file(const std::string& path, std::vector<uint8_t>& data) override {
+
+    bool read_file(const std::string &path, std::vector<uint8_t> &data) override {
         auto entry = find_file(path);
-        if (!entry) return false;
-        
+        if (!entry)
+            return false;
+
         cluster_t cluster = get_first_cluster(*entry);
-        if (cluster == 0) return true; // Empty file
-        
+        if (cluster == 0)
+            return true; // Empty file
+
         data.clear();
         data.reserve(entry->file_size);
-        
+
         auto chain = build_cluster_chain(cluster);
         for (cluster_t c : chain.clusters()) {
             auto cluster_data = read_cluster(c);
-            size_t copy_size = std::min(static_cast<size_t>(bytes_per_cluster_), 
-                                      entry->file_size - data.size());
-            data.insert(data.end(), cluster_data.begin(), 
-                       cluster_data.begin() + copy_size);
-            
-            if (data.size() >= entry->file_size) break;
+            size_t copy_size =
+                std::min(static_cast<size_t>(bytes_per_cluster_), entry->file_size - data.size());
+            data.insert(data.end(), cluster_data.begin(), cluster_data.begin() + copy_size);
+
+            if (data.size() >= entry->file_size)
+                break;
         }
-        
+
         data.resize(entry->file_size);
         return true;
     }
-    
-    bool write_file(const std::string& path, const std::vector<uint8_t>& data) override {
+
+    bool write_file(const std::string &path, const std::vector<uint8_t> &data) override {
         // Implementation for writing files
         auto entry = find_file(path);
         if (entry) {
@@ -302,125 +308,134 @@ public:
             return create_new_file(path, data);
         }
     }
-    
-    std::vector<std::string> list_directory(const std::string& path) override {
+
+    std::vector<std::string> list_directory(const std::string &path) override {
         std::vector<std::string> entries;
         auto dir_cluster = find_directory_cluster(path);
-        if (dir_cluster == 0) return entries;
-        
+        if (dir_cluster == 0)
+            return entries;
+
         auto dir_entries = read_directory_entries(dir_cluster);
-        for (const auto& entry : dir_entries) {
-            if (entry.name[0] == 0) break; // End of directory
-            if (entry.name[0] == static_cast<char>(0xE5)) continue; // Deleted
-            if (entry.attributes & 0x08) continue; // Volume label
-            
+        for (const auto &entry : dir_entries) {
+            if (entry.name[0] == 0)
+                break; // End of directory
+            if (entry.name[0] == static_cast<char>(0xE5))
+                continue; // Deleted
+            if (entry.attributes & 0x08)
+                continue; // Volume label
+
             std::string name = format_filename(entry);
             if (name != "." && name != "..") {
                 entries.push_back(name);
             }
         }
-        
+
         return entries;
     }
-    
-    bool exists(const std::string& path) override {
-        return find_file(path) != nullptr;
+
+    std::vector<DirectoryEntry> raw_directory(const std::string &path) override {
+        auto dir_cluster = find_directory_cluster(path);
+        if (dir_cluster == 0)
+            return {};
+        return read_directory_entries(dir_cluster);
     }
-    
-    bool is_directory(const std::string& path) override {
+
+    bool exists(const std::string &path) override { return find_file(path) != nullptr; }
+
+    bool is_directory(const std::string &path) override {
         auto entry = find_file(path);
         return entry && (entry->attributes & 0x10);
     }
 
-private:
+  private:
     BootSector boot_sector_;
     std::vector<cluster_t> fat_;
     uint32_t total_clusters_;
     uint32_t fat_offset_;
     uint32_t root_dir_offset_;
     uint32_t data_offset_;
-    
+
     void read_boot_sector() {
         device_.seekg(0);
-        device_.read(reinterpret_cast<char*>(&boot_sector_), sizeof(boot_sector_));
-        
+        device_.read(reinterpret_cast<char *>(&boot_sector_), sizeof(boot_sector_));
+
         bytes_per_sector_ = boot_sector_.bytes_per_sector;
         sectors_per_cluster_ = boot_sector_.sectors_per_cluster;
         bytes_per_cluster_ = bytes_per_sector_ * sectors_per_cluster_;
-        
+
         fat_offset_ = boot_sector_.reserved_sectors * bytes_per_sector_;
-        
+
         uint32_t fat_size;
         if constexpr (sizeof(cluster_t) == 4) {
             fat_size = boot_sector_.fat32.fat_size_32;
         } else {
             fat_size = boot_sector_.fat_size_16;
         }
-        
+
         root_dir_offset_ = fat_offset_ + (boot_sector_.num_fats * fat_size * bytes_per_sector_);
         data_offset_ = root_dir_offset_ + (boot_sector_.root_entries * 32);
-        
-        uint32_t total_sectors = boot_sector_.total_sectors_16 ? 
-            boot_sector_.total_sectors_16 : boot_sector_.total_sectors_32;
+
+        uint32_t total_sectors = boot_sector_.total_sectors_16 ? boot_sector_.total_sectors_16
+                                                               : boot_sector_.total_sectors_32;
         uint32_t data_sectors = total_sectors - (data_offset_ / bytes_per_sector_);
         total_clusters_ = data_sectors / sectors_per_cluster_;
     }
-    
+
     void read_fat() {
         device_.seekg(fat_offset_);
-        
+
         uint32_t fat_size_bytes;
         if constexpr (sizeof(cluster_t) == 4) {
             fat_size_bytes = boot_sector_.fat32.fat_size_32 * bytes_per_sector_;
         } else {
             fat_size_bytes = boot_sector_.fat_size_16 * bytes_per_sector_;
         }
-        
+
         std::vector<uint8_t> fat_data(fat_size_bytes);
-        device_.read(reinterpret_cast<char*>(fat_data.data()), fat_size_bytes);
-        
+        device_.read(reinterpret_cast<char *>(fat_data.data()), fat_size_bytes);
+
         fat_.clear();
         fat_.reserve(total_clusters_ + 2);
-        
+
         if constexpr (sizeof(cluster_t) == 2) {
             if (total_clusters_ < 4085) {
                 // FAT12
                 for (size_t i = 0; i < total_clusters_ + 2; ++i) {
                     size_t byte_offset = i * 3 / 2;
                     if (i % 2 == 0) {
-                        fat_.push_back(fat_data[byte_offset] | 
-                                     ((fat_data[byte_offset + 1] & 0x0F) << 8));
+                        fat_.push_back(fat_data[byte_offset] |
+                                       ((fat_data[byte_offset + 1] & 0x0F) << 8));
                     } else {
-                        fat_.push_back((fat_data[byte_offset] >> 4) | 
-                                     (fat_data[byte_offset + 1] << 4));
+                        fat_.push_back((fat_data[byte_offset] >> 4) |
+                                       (fat_data[byte_offset + 1] << 4));
                     }
                 }
             } else {
                 // FAT16
                 for (size_t i = 0; i < total_clusters_ + 2; ++i) {
-                    fat_.push_back(*reinterpret_cast<uint16_t*>(&fat_data[i * 2]));
+                    fat_.push_back(*reinterpret_cast<uint16_t *>(&fat_data[i * 2]));
                 }
             }
         } else {
             // FAT32
             for (size_t i = 0; i < total_clusters_ + 2; ++i) {
-                fat_.push_back(*reinterpret_cast<uint32_t*>(&fat_data[i * 4]) & 0x0FFFFFFF);
+                fat_.push_back(*reinterpret_cast<uint32_t *>(&fat_data[i * 4]) & 0x0FFFFFFF);
             }
         }
     }
-    
+
     ClusterChain<cluster_t> build_cluster_chain(cluster_t start_cluster) {
         ClusterChain<cluster_t> chain(start_cluster);
         cluster_t current = start_cluster;
-        
+
         while (!is_end_of_chain(current) && !is_bad_cluster(current)) {
             chain.add_cluster(current);
             current = fat_[current];
         }
-        
+
         return chain;
     }
-    
+
     bool is_end_of_chain(cluster_t cluster) const {
         if constexpr (sizeof(cluster_t) == 2) {
             return cluster >= (total_clusters_ < 4085 ? 0xFF8 : 0xFFF8);
@@ -428,7 +443,7 @@ private:
             return cluster >= 0x0FFFFFF8;
         }
     }
-    
+
     bool is_bad_cluster(cluster_t cluster) const {
         if constexpr (sizeof(cluster_t) == 2) {
             return cluster == (total_clusters_ < 4085 ? 0xFF7 : 0xFFF7);
@@ -436,65 +451,68 @@ private:
             return cluster == 0x0FFFFFF7;
         }
     }
-    
+
     std::vector<uint8_t> read_cluster(cluster_t cluster) {
         uint64_t offset = data_offset_ + (static_cast<uint64_t>(cluster - 2) * bytes_per_cluster_);
         device_.seekg(offset);
-        
+
         std::vector<uint8_t> data(bytes_per_cluster_);
-        device_.read(reinterpret_cast<char*>(data.data()), bytes_per_cluster_);
-        
+        device_.read(reinterpret_cast<char *>(data.data()), bytes_per_cluster_);
+
         return data;
     }
-    
+
     std::vector<DirectoryEntry> read_directory_entries(cluster_t cluster) {
         std::vector<DirectoryEntry> entries;
-        
+
         if (cluster == 0) {
             // Root directory for FAT12/16
             device_.seekg(root_dir_offset_);
             entries.resize(boot_sector_.root_entries);
-            device_.read(reinterpret_cast<char*>(entries.data()), 
-                        entries.size() * sizeof(DirectoryEntry));
+            device_.read(reinterpret_cast<char *>(entries.data()),
+                         entries.size() * sizeof(DirectoryEntry));
         } else {
             // Subdirectory or FAT32 root
             auto chain = build_cluster_chain(cluster);
             for (cluster_t c : chain.clusters()) {
                 auto cluster_data = read_cluster(c);
                 size_t entries_per_cluster = bytes_per_cluster_ / sizeof(DirectoryEntry);
-                
+
                 for (size_t i = 0; i < entries_per_cluster; ++i) {
                     DirectoryEntry entry;
-                    std::memcpy(&entry, &cluster_data[i * sizeof(DirectoryEntry)], 
-                               sizeof(DirectoryEntry));
+                    std::memcpy(&entry, &cluster_data[i * sizeof(DirectoryEntry)],
+                                sizeof(DirectoryEntry));
                     entries.push_back(entry);
-                    
-                    if (entry.name[0] == 0) break; // End of directory
+
+                    if (entry.name[0] == 0)
+                        break; // End of directory
                 }
             }
         }
-        
+
         return entries;
     }
-    
-    std::optional<DirectoryEntry> find_file(const std::string& path) {
+
+    std::optional<DirectoryEntry> find_file(const std::string &path) {
         std::vector<std::string> path_components = split_path(path);
         cluster_t current_cluster = get_root_cluster();
-        
-        for (const auto& component : path_components) {
+
+        for (const auto &component : path_components) {
             auto entries = read_directory_entries(current_cluster);
             bool found = false;
-            
-            for (const auto& entry : entries) {
-                if (entry.name[0] == 0) break;
-                if (entry.name[0] == static_cast<char>(0xE5)) continue;
-                
+
+            for (const auto &entry : entries) {
+                if (entry.name[0] == 0)
+                    break;
+                if (entry.name[0] == static_cast<char>(0xE5))
+                    continue;
+
                 std::string name = format_filename(entry);
                 if (name == component) {
                     if (&component == &path_components.back()) {
                         return entry; // Found the target file/directory
                     }
-                    
+
                     if (entry.attributes & 0x10) { // Is directory
                         current_cluster = get_first_cluster(entry);
                         found = true;
@@ -502,26 +520,27 @@ private:
                     }
                 }
             }
-            
-            if (!found) return std::nullopt;
+
+            if (!found)
+                return std::nullopt;
         }
-        
+
         return std::nullopt;
     }
-    
-    cluster_t find_directory_cluster(const std::string& path) {
+
+    cluster_t find_directory_cluster(const std::string &path) {
         if (path == "/" || path.empty()) {
             return get_root_cluster();
         }
-        
+
         auto entry = find_file(path);
         if (entry && (entry->attributes & 0x10)) {
             return get_first_cluster(*entry);
         }
-        
+
         return 0;
     }
-    
+
     cluster_t get_root_cluster() const {
         if constexpr (sizeof(cluster_t) == 4) {
             return boot_sector_.fat32.root_cluster;
@@ -529,30 +548,15 @@ private:
             return 0; // FAT12/16 use fixed root directory
         }
     }
-    
-    cluster_t get_first_cluster(const DirectoryEntry& entry) const {
-        return (static_cast<cluster_t>(entry.first_cluster_high) << 16) | 
-               entry.first_cluster_low;
+
+    cluster_t get_first_cluster(const DirectoryEntry &entry) const {
+        return (static_cast<cluster_t>(entry.first_cluster_high) << 16) | entry.first_cluster_low;
     }
-    
-    std::string format_filename(const DirectoryEntry& entry) {
-        std::string name(entry.name, 8);
-        std::string ext(entry.ext, 3);
-        
-        // Trim spaces
-        name.erase(name.find_last_not_of(' ') + 1);
-        ext.erase(ext.find_last_not_of(' ') + 1);
-        
-        if (!ext.empty()) {
-            return name + "." + ext;
-        }
-        return name;
-    }
-    
-    std::vector<std::string> split_path(const std::string& path) {
+
+    std::vector<std::string> split_path(const std::string &path) {
         std::vector<std::string> components;
         std::string current;
-        
+
         for (char c : path) {
             if (c == '/' || c == '\\') {
                 if (!current.empty()) {
@@ -563,24 +567,24 @@ private:
                 current += std::toupper(c);
             }
         }
-        
+
         if (!current.empty()) {
             components.push_back(current);
         }
-        
+
         return components;
     }
-    
-    bool update_existing_file(const DirectoryEntry& entry, const std::vector<uint8_t>& data) {
-        // Implementation for updating existing files
-        // This would involve deallocating old clusters and allocating new ones
-        return false; // Placeholder
+
+    bool update_existing_file(const DirectoryEntry &entry, const std::vector<uint8_t> &data) {
+        (void)entry;
+        (void)data;
+        return false; // Placeholder for update logic
     }
-    
-    bool create_new_file(const std::string& path, const std::vector<uint8_t>& data) {
-        // Implementation for creating new files
-        // This would involve finding free directory entry and allocating clusters
-        return false; // Placeholder
+
+    bool create_new_file(const std::string &path, const std::vector<uint8_t> &data) {
+        (void)path;
+        (void)data;
+        return false; // Placeholder for create logic
     }
 };
 
@@ -588,49 +592,51 @@ private:
  * @brief exFAT filesystem implementation.
  */
 class ExFatFilesystem : public FatFilesystem {
-public:
-    explicit ExFatFilesystem(const std::string& device_path) {
+  public:
+    explicit ExFatFilesystem(const std::string &device_path) {
         device_.open(device_path, std::ios::binary | std::ios::in | std::ios::out);
         if (!device_) {
             throw std::runtime_error("Cannot open device: " + device_path);
         }
         read_boot_sector();
     }
-    
+
     FatType get_type() const override { return FatType::EXFAT; }
-    
-    bool read_file(const std::string& path, std::vector<uint8_t>& data) override {
-        // exFAT-specific implementation
-        return false; // Placeholder
-    }
-    
-    bool write_file(const std::string& path, const std::vector<uint8_t>& data) override {
-        // exFAT-specific implementation
-        return false; // Placeholder
-    }
-    
-    std::vector<std::string> list_directory(const std::string& path) override {
-        // exFAT-specific implementation
-        return {}; // Placeholder
-    }
-    
-    bool exists(const std::string& path) override {
-        // exFAT-specific implementation
-        return false; // Placeholder
-    }
-    
-    bool is_directory(const std::string& path) override {
+
+    bool read_file(const std::string &path, std::vector<uint8_t> &data) override {
         // exFAT-specific implementation
         return false; // Placeholder
     }
 
-private:
+    bool write_file(const std::string &path, const std::vector<uint8_t> &data) override {
+        // exFAT-specific implementation
+        return false; // Placeholder
+    }
+
+    std::vector<std::string> list_directory(const std::string &path) override {
+        // exFAT-specific implementation
+        return {}; // Placeholder
+    }
+
+    std::vector<DirectoryEntry> raw_directory(const std::string &path) override { return {}; }
+
+    bool exists(const std::string &path) override {
+        // exFAT-specific implementation
+        return false; // Placeholder
+    }
+
+    bool is_directory(const std::string &path) override {
+        // exFAT-specific implementation
+        return false; // Placeholder
+    }
+
+  private:
     ExFatBootSector boot_sector_;
-    
+
     void read_boot_sector() {
         device_.seekg(0);
-        device_.read(reinterpret_cast<char*>(&boot_sector_), sizeof(boot_sector_));
-        
+        device_.read(reinterpret_cast<char *>(&boot_sector_), sizeof(boot_sector_));
+
         bytes_per_sector_ = 1U << boot_sector_.bytes_per_sector_shift;
         sectors_per_cluster_ = 1U << boot_sector_.sectors_per_cluster_shift;
         bytes_per_cluster_ = bytes_per_sector_ * sectors_per_cluster_;
@@ -640,33 +646,33 @@ private:
 /**
  * @brief Factory function to create appropriate filesystem implementation.
  */
-std::unique_ptr<FatFilesystem> create_filesystem(const std::string& device_path) {
+std::unique_ptr<FatFilesystem> create_filesystem(const std::string &device_path) {
     std::fstream device(device_path, std::ios::binary | std::ios::in);
     if (!device) {
         throw std::runtime_error("Cannot open device: " + device_path);
     }
-    
+
     // Read first sector to determine filesystem type
     std::array<uint8_t, 512> sector;
-    device.read(reinterpret_cast<char*>(sector.data()), sector.size());
-    
+    device.read(reinterpret_cast<char *>(sector.data()), sector.size());
+
     // Check for exFAT signature
-    if (std::string_view(reinterpret_cast<char*>(sector.data() + 3), 8) == "EXFAT   ") {
+    if (std::string_view(reinterpret_cast<char *>(sector.data() + 3), 8) == "EXFAT   ") {
         return std::make_unique<ExFatFilesystem>(device_path);
     }
-    
+
     // Parse as FAT12/16/32
-    BootSector* boot = reinterpret_cast<BootSector*>(sector.data());
-    uint32_t total_sectors = boot->total_sectors_16 ? 
-        boot->total_sectors_16 : boot->total_sectors_32;
+    BootSector *boot = reinterpret_cast<BootSector *>(sector.data());
+    uint32_t total_sectors =
+        boot->total_sectors_16 ? boot->total_sectors_16 : boot->total_sectors_32;
     uint32_t fat_size = boot->fat_size_16 ? boot->fat_size_16 : boot->fat32.fat_size_32;
-    
-    uint32_t root_dir_sectors = (boot->root_entries * 32 + boot->bytes_per_sector - 1) / 
-                               boot->bytes_per_sector;
-    uint32_t data_sectors = total_sectors - boot->reserved_sectors - 
-                           (boot->num_fats * fat_size) - root_dir_sectors;
+
+    uint32_t root_dir_sectors =
+        (boot->root_entries * 32 + boot->bytes_per_sector - 1) / boot->bytes_per_sector;
+    uint32_t data_sectors =
+        total_sectors - boot->reserved_sectors - (boot->num_fats * fat_size) - root_dir_sectors;
     uint32_t total_clusters = data_sectors / boot->sectors_per_cluster;
-    
+
     if (total_clusters < 65525) {
         return std::make_unique<FatFilesystemImpl<uint16_t>>(device_path);
     } else {
@@ -679,11 +685,7 @@ std::unique_ptr<FatFilesystem> create_filesystem(const std::string& device_path)
 /**
  * @brief Application mode enumeration.
  */
-enum class AppMode {
-    DOS_READ,
-    DOS_WRITE,
-    DOS_DIR
-};
+enum class AppMode { DOS_READ, DOS_WRITE, DOS_DIR };
 
 /**
  * @brief Application options structure.
@@ -700,9 +702,9 @@ struct AppOptions {
 /**
  * @brief Parse command line arguments.
  */
-AppOptions parse_arguments(int argc, char* argv[]) {
+AppOptions parse_arguments(int argc, char *argv[]) {
     AppOptions opts;
-    
+
     // Determine mode from program name
     std::string prog_name = std::filesystem::path(argv[0]).filename().string();
     if (prog_name == "dosread") {
@@ -714,42 +716,48 @@ AppOptions parse_arguments(int argc, char* argv[]) {
     } else {
         throw std::runtime_error("Program must be named dosread, doswrite, or dosdir");
     }
-    
+
     int arg_idx = 1;
-    
+
     // Parse flags
     if (arg_idx < argc && argv[arg_idx][0] == '-') {
         std::string_view flags(argv[arg_idx] + 1);
         for (char flag : flags) {
             switch (flag) {
-                case 'a': opts.ascii_mode = true; break;
-                case 'l': opts.long_listing = true; break;
-                case 'r': opts.recursive = true; break;
-                default:
-                    throw std::runtime_error("Invalid flag: " + std::string(1, flag));
+            case 'a':
+                opts.ascii_mode = true;
+                break;
+            case 'l':
+                opts.long_listing = true;
+                break;
+            case 'r':
+                opts.recursive = true;
+                break;
+            default:
+                throw std::runtime_error("Invalid flag: " + std::string(1, flag));
             }
         }
         arg_idx++;
     }
-    
+
     // Parse device
     if (arg_idx >= argc) {
         throw std::runtime_error("Device argument required");
     }
     opts.device = argv[arg_idx++];
-    
+
     // Parse path (optional for directory listing)
     if (arg_idx < argc) {
         opts.path = argv[arg_idx];
     }
-    
+
     return opts;
 }
 
 /**
  * @brief Print usage information.
  */
-void print_usage(const std::string& prog_name) {
+void print_usage(const std::string &prog_name) {
     if (prog_name == "dosread") {
         std::cerr << "Usage: dosread [-a] device file" << std::endl;
     } else if (prog_name == "doswrite") {
@@ -762,87 +770,104 @@ void print_usage(const std::string& prog_name) {
 /**
  * @brief Main entry point.
  */
-int main(int argc, char* argv[]) {
+int main(int argc, char *argv[]) {
     try {
         AppOptions opts = parse_arguments(argc, argv);
         auto fs = fat::create_filesystem(opts.device);
-        
+
         switch (opts.mode) {
-            case AppMode::DOS_READ: {
-                if (opts.path.empty()) {
-                    throw std::runtime_error("File path required for reading");
-                }
-                
-                std::vector<uint8_t> data;
-                if (!fs->read_file(opts.path, data)) {
-                    throw std::runtime_error("Cannot read file: " + opts.path);
-                }
-                
-                if (opts.ascii_mode) {
-                    // Remove EOF marker and convert line endings
-                    auto eof_pos = std::find(data.begin(), data.end(), 0x1A);
-                    if (eof_pos != data.end()) {
-                        data.erase(eof_pos, data.end());
-                    }
-                }
-                
-                std::cout.write(reinterpret_cast<char*>(data.data()), data.size());
-                break;
+        case AppMode::DOS_READ: {
+            if (opts.path.empty()) {
+                throw std::runtime_error("File path required for reading");
             }
-            
-            case AppMode::DOS_WRITE: {
-                if (opts.path.empty()) {
-                    throw std::runtime_error("File path required for writing");
-                }
-                
-                std::vector<uint8_t> data;
-                char buffer[4096];
-                while (std::cin.read(buffer, sizeof(buffer)) || std::cin.gcount() > 0) {
-                    data.insert(data.end(), buffer, buffer + std::cin.gcount());
-                }
-                
-                if (opts.ascii_mode) {
-                    // Add EOF marker
-                    data.push_back(0x1A);
-                }
-                
-                if (!fs->write_file(opts.path, data)) {
-                    throw std::runtime_error("Cannot write file: " + opts.path);
-                }
-                break;
+
+            std::vector<uint8_t> data;
+            if (!fs->read_file(opts.path, data)) {
+                throw std::runtime_error("Cannot read file: " + opts.path);
             }
-            
-            case AppMode::DOS_DIR: {
-                std::string dir_path = opts.path.empty() ? "/" : opts.path;
-                auto entries = fs->list_directory(dir_path);
-                
-                if (opts.long_listing) {
-                    std::cout << "Directory of " << dir_path << std::endl << std::endl;
+
+            if (opts.ascii_mode) {
+                // Remove EOF marker and convert line endings
+                auto eof_pos = std::find(data.begin(), data.end(), 0x1A);
+                if (eof_pos != data.end()) {
+                    data.erase(eof_pos, data.end());
                 }
-                
-                for (const auto& entry : entries) {
-                    if (opts.long_listing) {
-                        // TODO: Add detailed file information
-                        std::cout << std::setw(20) << std::left << entry;
-                        if (fs->is_directory(dir_path + "/" + entry)) {
-                            std::cout << " <DIR>";
-                        }
-                        std::cout << std::endl;
-                    } else {
-                        std::cout << entry << std::endl;
-                    }
-                }
-                break;
             }
+
+            std::cout.write(reinterpret_cast<char *>(data.data()), data.size());
+            break;
         }
-        
-    } catch (const std::exception& e) {
+
+        case AppMode::DOS_WRITE: {
+            if (opts.path.empty()) {
+                throw std::runtime_error("File path required for writing");
+            }
+
+            std::vector<uint8_t> data;
+            char buffer[4096];
+            while (std::cin.read(buffer, sizeof(buffer)) || std::cin.gcount() > 0) {
+                data.insert(data.end(), buffer, buffer + std::cin.gcount());
+            }
+
+            if (opts.ascii_mode) {
+                // Add EOF marker
+                data.push_back(0x1A);
+            }
+
+            if (!fs->write_file(opts.path, data)) {
+                throw std::runtime_error("Cannot write file: " + opts.path);
+            }
+            break;
+        }
+
+        case AppMode::DOS_DIR: {
+            std::string dir_path = opts.path.empty() ? "/" : opts.path;
+            auto raw = fs->raw_directory(dir_path);
+            std::vector<std::string> entries;
+            entries.reserve(raw.size());
+            for (const auto &e : raw) {
+                if (e.name[0] == 0 || e.name[0] == static_cast<char>(0xE5) || (e.attributes & 0x08))
+                    continue;
+                std::string name = format_filename(e);
+                if (name == "." || name == "..")
+                    continue;
+                entries.push_back(name);
+            }
+
+            if (opts.long_listing) {
+                std::cout << "Directory of " << dir_path << std::endl << std::endl;
+            }
+
+            for (size_t idx = 0; idx < entries.size(); ++idx) {
+                const auto &entry = raw[idx];
+                const auto &name = entries[idx];
+                if (opts.long_listing) {
+                    auto tp = fat_datetime_to_timepoint(entry.write_date, entry.write_time);
+                    auto t = std::chrono::system_clock::to_time_t(tp);
+                    std::tm *tm = std::localtime(&t);
+                    char buf[20];
+                    std::strftime(buf, sizeof(buf), "%Y-%m-%d %H:%M", tm);
+                    std::cout << std::setw(20) << std::left << name << ' ' << std::setw(10)
+                              << entry.file_size << ' ' << buf;
+                    if (fs->is_directory(dir_path + "/" + name)) {
+                        std::cout << " <DIR>";
+                    }
+                    std::cout << std::endl;
+                } else {
+                    std::cout << name << std::endl;
+                }
+            }
+            break;
+        }
+        }
+
+    } catch (const std::exception &e) {
         std::cerr << "Error: " << e.what() << std::endl;
         if (argc > 0) {
             print_usage(std::filesystem::path(argv[0]).filename().string());
         }
         return 1;
     }
-    
+
     return 0;
 }

--- a/commands/svcctl.cpp
+++ b/commands/svcctl.cpp
@@ -23,11 +23,13 @@ static void send_simple(Message type, xinim::pid_t pid) {
     lattice_send(CLIENT_PID, MANAGER_PID, msg);
 }
 
+#ifndef SVCCTL_NO_WAIT
 /** Receive a message into @p out using blocking semantics. */
-static void recv_blocking(message &out) {
+[[maybe_unused]] static void recv_blocking(message &out) {
     while (lattice_recv(CLIENT_PID, &out) != xinim::OK) {
     }
 }
+#endif
 
 int run(std::span<char *> args) {
     if (args.size() < 2) {

--- a/include/fat_utils.hpp
+++ b/include/fat_utils.hpp
@@ -1,0 +1,15 @@
+#pragma once
+#include <chrono>
+#include <cstdint>
+struct DirectoryEntry;
+inline std::chrono::sys_seconds fat_datetime_to_timepoint(uint16_t date, uint16_t time) {
+    using namespace std::chrono;
+    int y = static_cast<int>((date >> 9) & 0x7F) + 1980;
+    unsigned m = static_cast<unsigned>((date >> 5) & 0x0F);
+    unsigned d_ = static_cast<unsigned>(date & 0x1F);
+    unsigned hour = static_cast<unsigned>((time >> 11) & 0x1F);
+    unsigned minute = static_cast<unsigned>((time >> 5) & 0x3F);
+    unsigned second = static_cast<unsigned>((time & 0x1F) * 2);
+    auto day_point = sys_days{year{y} / month{m} / day{d_}};
+    return day_point + hours{hour} + minutes{minute} + seconds{second};
+}

--- a/kernel/lattice_ipc.cpp
+++ b/kernel/lattice_ipc.cpp
@@ -157,6 +157,10 @@ void Graph::set_listening(xinim::pid_t pid, bool flag) noexcept { listening_[pid
  * @brief Establish bidirectional channels and perform stubbed Kyber exchange.
  */
 int lattice_connect(xinim::pid_t src, xinim::pid_t dst, net::node_t node_id) {
+    if (node_id == 0) {
+        node_id = net::local_node();
+    }
+
     auto kp_a = pqcrypto::generate_keypair();
     auto kp_b = pqcrypto::generate_keypair();
     auto secret_bytes = pqcrypto::compute_shared_secret(kp_a, kp_b);
@@ -270,7 +274,7 @@ int lattice_recv(xinim::pid_t pid, message *out, IpcFlags flags) {
     using namespace std::chrono_literals;
     std::unique_lock lk(g_ipc_mutex);
     lattice_listen(pid);
-    sched::scheduler.block_on(pid, -1);
+    [[maybe_unused]] bool blocked = sched::scheduler.block_on(pid, -1);
     auto deadline = std::chrono::steady_clock::now() + 100ms;
     for (;;) {
         auto ib2 = g_graph.inbox_.find(pid);

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -379,6 +379,13 @@ add_executable(minix_test_hypercomplex
 target_include_directories(minix_test_hypercomplex PRIVATE ${CMAKE_SOURCE_DIR}/kernel)
 add_test(NAME minix_test_hypercomplex COMMAND minix_test_hypercomplex)
 
+# minix_test_fat_time
+add_executable(minix_test_fat_time
+  test_fat_time.cpp
+)
+target_include_directories(minix_test_fat_time PRIVATE ${CMAKE_SOURCE_DIR}/include)
+add_test(NAME minix_test_fat_time COMMAND minix_test_fat_time)
+
 # -----------------------------------------------------------------------------
 # Crypto library
 # -----------------------------------------------------------------------------

--- a/tests/test_fat_time.cpp
+++ b/tests/test_fat_time.cpp
@@ -1,0 +1,12 @@
+#include "fat_utils.hpp"
+#include <cassert>
+#include <chrono>
+int main() {
+    using namespace std::chrono;
+    uint16_t date = 0x56EE; // 2023-07-14
+    uint16_t time = 0x6DAF; // 13:45:30
+    auto tp = fat_datetime_to_timepoint(date, time);
+    auto expected = sys_days{year{2023} / 7 / 14} + hours{13} + minutes{45} + seconds{30};
+    assert(tp == expected);
+    return 0;
+}


### PR DESCRIPTION
## Summary
- add libc++ support when using Clang
- integrate modern path constants in svcctl and lattice IPC
- expose raw FAT directory entries and add timestamp conversion helper
- show sizes and dates in `dosdir`
- add unit test for FAT date/time conversion

## Testing
- `cmake -B build -DENABLE_UNIT_TESTS=ON`
- `cmake --build build -j$(nproc)`
- `ctest --test-dir build --output-on-failure` *(fails: minix_test_service_manager_dag, minix_test_service_serialization)*

------
https://chatgpt.com/codex/tasks/task_e_688a561c4fb883319399318d90d43d3a