### PR TITLE
Add build cleanup notes and update ignores

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,8 @@
 # ── 1. Build & tool-chain artefacts ──────────────────────────────────────────
 **/build/                     # any “build” dir (out-of-source CMake, Meson…)
 build/                        # top-level build tree
+build*/                       # build variants like build_debug/
+builds/                       # aggregated build artifacts
 bin/                          # root-level binaries
 */bin/                        # per-module bin/
 
@@ -25,6 +27,7 @@ bin/                          # root-level binaries
 
 # ── 3. CMake generated files ────────────────────────────────────────────────
 CMakeFiles/
+*/CMakeFiles/
 CMakeCache.txt
 cmake_install.cmake           # install script generator
 

--- a/PROJECT_STATUS.md
+++ b/PROJECT_STATUS.md
@@ -1,0 +1,9 @@
+# Project Status
+
+## Repository Cleanup (September 2025)
+
+- Removed residual build directories (none were tracked).
+- Added ignore patterns for `build*/`, `builds/`, and `*/CMakeFiles/` to `.gitignore`.
+- Verified workspace with `cmake` and `ctest`; no build artifacts remain under version control.
+
+


### PR DESCRIPTION
## Summary
- exclude build variants and CMake files from version control
- document repository cleanup actions

## Testing
- `cmake -B build`
- `cmake --build build`
- `ctest --test-dir build`

------
https://chatgpt.com/codex/tasks/task_e_688a8e701a6c8331a50a977ea038fc5f

## Summary by Sourcery

Document repository cleanup actions and update .gitignore to exclude build artifacts.

Enhancements:
- Add ignore patterns for build directories (build*/ and builds/) and CMakeFiles directories in .gitignore

Documentation:
- Add PROJECT_STATUS.md with notes on repository cleanup and verification steps