### PR TITLE
Implement header sanity script and ignore cleanup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@
 **/build*/                    # catch “build”, “build_debug” etc.
 build/                        # top-level build tree
 builds/                       # alternate plural naming
+build*/                       # other top-level build dirs
 */CMakeFiles/                 # per-dir CMake state
 bin/                          # root-level binaries
 */bin/                        # per-module bin/

--- a/docs/PROJECT_STATUS.md
+++ b/docs/PROJECT_STATUS.md
@@ -14,3 +14,8 @@ This document tracks repository maintenance and cleanup activities.
   - `find . -name 'build*'` yields no results  
   - `find . -name 'CMakeFiles'` yields no results  
 - Confirmed all build artefacts are cleanly excluded from the repository.  
+## 2025-07-30
+- Created `tools/header_sanity_check.sh` with robust quoting for include paths.
+- Added explicit `build*/` pattern to `.gitignore` for clarity.
+- Verified absence of build artefacts and recorded cleanup activities.
+

--- a/tools/header_sanity_check.sh
+++ b/tools/header_sanity_check.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+# ===========================================================================
+#  header_sanity_check.sh — verify VM test headers compile cleanly
+# ---------------------------------------------------------------------------
+#  Iterates over tests/vm/*.c and ensures they compile with strict warnings
+#  enabled. Paths containing spaces are correctly handled.
+# ===========================================================================
+
+set -euo pipefail
+
+CC=${CC:-gcc}
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+
+# Include directories as an array to avoid word-splitting issues
+INCLUDE_DIRS=("$REPO_ROOT/sys" "$REPO_ROOT/sys/vm/include")
+
+# Build compiler arguments
+INC_ARGS=()
+for inc in "${INCLUDE_DIRS[@]}"; do
+    INC_ARGS+=( -idirafter "$inc" )
+done
+
+for src in "$REPO_ROOT"/tests/vm/*.c; do
+    [ -e "$src" ] || continue
+    echo "Checking $src"
+    "$CC" -Wall -Wextra -Werror -std=c17 -fsyntax-only "${INC_ARGS[@]}" "$src"
+done
+


### PR DESCRIPTION
## Summary
- add `header_sanity_check.sh` script with safe quoting
- expand ignore patterns for build folders
- log cleanup actions in `docs/PROJECT_STATUS.md`

## Testing
- `tools/setup.sh`
- `cmake -B build`
- `cmake --build build`
- `ctest --test-dir build`

------
https://chatgpt.com/codex/tasks/task_e_688a983f03e88331a434b5a917a6b2b9