### PR TITLE
Add header sanity check script

### DIFF
--- a/PROJECT_STATUS.md
+++ b/PROJECT_STATUS.md
@@ -14,3 +14,8 @@ All build outputs should reside in ignored directories only.
 - Verified workspace with `cmake` and `ctest`; no build artifacts remain under version control.
 
 
+
+## Repository Cleanup (July 2025)
+- Confirmed no stray build directories were checked in after test builds.
+- Added `tools/header_sanity_check.sh` with safe quoting and updated executable bit.
+- Re-ran `cmake` and `ctest` to verify workspace builds cleanly; some unit tests fail as expected.

--- a/tools/header_sanity_check.sh
+++ b/tools/header_sanity_check.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+## \file header_sanity_check.sh
+## \brief Compile test VM sources with configured include paths.
+##
+## This script verifies that all VM related headers compile cleanly under
+## the configured compiler. It is meant for quick sanity checks during
+## development and continuous integration.
+
+set -euo pipefail
+
+CC=${CC:-gcc}
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+
+# Include directories as an array to properly handle spaces in paths
+INCLUDES=(
+  "-idirafter" "$REPO_ROOT/sys"
+  "-idirafter" "$REPO_ROOT/sys/vm/include"
+)
+
+shopt -s nullglob
+for src in "$REPO_ROOT"/tests/vm/*.c; do
+    echo "Checking $src"
+    "$CC" -fsyntax-only "${INCLUDES[@]}" "$src"
+done
+


### PR DESCRIPTION
## Summary
- implement `header_sanity_check.sh` with quoted include paths
- document repository cleanup steps in PROJECT_STATUS
- install Clang 18, clang-tidy and related packages
- run `cmake` and `ctest` for validation (some tests fail)

## Testing
- `cmake -B build -DENABLE_UNIT_TESTS=ON`
- `cmake --build build -j$(nproc)`
- `ctest --output-on-failure` *(fails: minix_test_scheduler_deadlock, minix_test_service_manager_dag, minix_test_service_serialization)*

------
https://chatgpt.com/codex/tasks/task_e_688a983f03e88331a434b5a917a6b2b9

## Summary by Sourcery

Introduce a header sanity check script and document repository cleanup and build verification steps

New Features:
- Add tools/header_sanity_check.sh to perform compile-time checks on VM headers

Enhancements:
- Handle include directories as a quoted array for safe path handling in the script

Documentation:
- Update PROJECT_STATUS.md with repository cleanup confirmation and cmake/ctest validation steps