### PR TITLE
Add header sanity check script

### DIFF
--- a/PROJECT_STATUS.md
+++ b/PROJECT_STATUS.md
@@ -14,3 +14,10 @@ All build outputs should reside in ignored directories only.
 - Verified workspace with `cmake` and `ctest`; no build artifacts remain under version control.
 
 
+
+## Repository Cleanup (Aug 2025 - header sanity script)
+
+- Created `tools/header_sanity_check.sh` with safe include handling.
+- Verified no build artifacts remain after running CMake in `build/`.
+- Confirmed ignore rules for `build*/`, `builds/`, and `*/CMakeFiles/` already present.
+

--- a/tools/header_sanity_check.sh
+++ b/tools/header_sanity_check.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+## \file header_sanity_check.sh
+## \brief Ensure VM test sources compile with provided headers only.
+##
+## This script compiles each C source file in tests/vm with strict include
+## paths to verify headers do not leak undeclared dependencies.
+
+set -euo pipefail
+CC=${CC:-gcc}
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+
+# Include directories as an array to handle spaces correctly
+INCLUDE_PATHS=(
+    "$REPO_ROOT/sys"
+    "$REPO_ROOT/sys/vm/include"
+)
+
+for src in "$REPO_ROOT"/tests/vm/*.c; do
+    [ -e "$src" ] || continue
+    echo "Checking $src"
+    "$CC" -fsyntax-only "${INCLUDE_PATHS[@]/#/-idirafter }" "$src"
+    echo "OK"
+done


### PR DESCRIPTION
## Summary
- add a shell script to verify VM test headers compile in isolation
- document repository cleanup and new script in PROJECT_STATUS

## Testing
- `cmake -S . -B build`
- `cmake --build build`
- `bash tools/header_sanity_check.sh`


------
https://chatgpt.com/codex/tasks/task_e_688a983f03e88331a434b5a917a6b2b9