### PR TITLE
Clean up build artifacts and update status

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -63,3 +63,8 @@ __pycache__/                  # Python byte-code cache
 # ── 8. Local test artifacts ─────────────────────────────────────────────────
 ls_test                       # ad-hoc test binary
 **/ls_test                    # ignore in subdirectories
+
+# Redundant guard lines to ensure build artifacts remain excluded
+build*/
+builds/
+*/CMakeFiles/

--- a/PROJECT_STATUS.md
+++ b/PROJECT_STATUS.md
@@ -19,4 +19,8 @@
 - Verified no build artifacts remain after running CMake in `build/`.
 - Confirmed ignore rules for `build*/`, `builds/`, and `*/CMakeFiles/` already present.
 
-*All cleanup steps ensure that build artifacts are never tracked in Git.*  
+*All cleanup steps ensure that build artifacts are never tracked in Git.*
+
+## 2025-07-31
+- Verified absence of `build*/`, `builds/`, and `*/CMakeFiles/` directories after a full clang-based build.
+- Appended explicit ignore patterns to `.gitignore` as redundant safeguards.

--- a/docs/PROJECT_STATUS.md
+++ b/docs/PROJECT_STATUS.md
@@ -13,9 +13,14 @@ This document tracks repository maintenance and cleanup activities.
 - Ensured no build artifacts are committed by verifying:
   - `find . -name 'build*'` yields no results  
   - `find . -name 'CMakeFiles'` yields no results  
-- Confirmed all build artefacts are cleanly excluded from the repository.  
+- Confirmed all build artefacts are cleanly excluded from the repository.
 ## 2025-07-30
 - Created `tools/header_sanity_check.sh` with robust quoting for include paths.
 - Added explicit `build*/` pattern to `.gitignore` for clarity.
 - Verified absence of build artefacts and recorded cleanup activities.
+
+## 2025-07-31
+- Performed clang-based build to verify toolchain configuration.
+- No `build*/`, `builds/`, or `*/CMakeFiles/` directories remained after cleanup.
+- Added redundant ignore patterns to `.gitignore` as an extra safeguard.
 


### PR DESCRIPTION
## Summary
- enforce extra ignore rules
- document verification of build artifact removal
- add project status entries

## Testing
- `CC=clang-18 CXX=clang++-18 cmake -B build`
- `cmake --build build -j $(nproc)`
- `sphinx-build -b html docs/sphinx docs/sphinx/_build/html` *(fails: cannot find Doxygen XML)*


------
https://chatgpt.com/codex/tasks/task_e_688ab7430db48331afd474afee29b877