### PR TITLE
docs: add paging API doxygen

### DIFF
--- a/docs/PROJECT_STATUS.md
+++ b/docs/PROJECT_STATUS.md
@@ -24,3 +24,7 @@ This document tracks repository maintenance and cleanup activities.
 - No `build*/`, `builds/`, or `*/CMakeFiles/` directories remained after cleanup.
 - Added redundant ignore patterns to `.gitignore` as an extra safeguard.
 
+## 2025-08-06
+- Expanded Doxygen coverage for paging interfaces and miscellaneous file-system routines.
+- Generated API reference with Doxygen and attempted Sphinx build (errors remain in legacy `.rst` files).
+

--- a/include/paging.hpp
+++ b/include/paging.hpp
@@ -4,6 +4,11 @@
   ARM and x86/x86_64 hardware using C++23.
 >>>*/
 
+/**
+ * @file
+ * @brief Generic 4-level paging structures and kernel interfaces.
+ */
+
 #ifndef PAGING_H
 #define PAGING_H
 
@@ -13,47 +18,84 @@
 
 /* Generic 4-level paging structures for 48-bit virtual addresses. */
 
-// Size in bytes of a single 4 KiB page.
+/** Size in bytes of a single 4 KiB page. */
 inline constexpr std::size_t PAGE_SIZE_4K = 4096;
 
-// Number of entries in each level of the page table hierarchy.
+/** Number of entries in each level of the page table hierarchy. */
 inline constexpr std::size_t PT_ENTRIES = 512;
 
-/* Page table entry flags */
-// Page table entry flags encoded as bit values.
+/**
+ * @brief Page table entry flags encoded as bit values.
+ */
 enum PT_Flag : unsigned long {
-    PT_PRESENT = 0x001,  // entry is valid
-    PT_WRITABLE = 0x002, // memory region is writable
-    PT_USER = 0x004      // accessible from user mode
+    PT_PRESENT = 0x001,  ///< Entry is valid.
+    PT_WRITABLE = 0x002, ///< Memory region is writable.
+    PT_USER = 0x004      ///< Accessible from user mode.
 };
 
 using phys_addr64 = u64_t;
 using virt_addr64 = u64_t;
 
+/**
+ * @brief Single page table entry mapping a page to a physical address.
+ */
 struct pt_entry {
-    phys_addr64 addr;
-    unsigned long flags;
+    phys_addr64 addr;   ///< Physical address referenced by the entry.
+    unsigned long flags; ///< Attribute bits from ::PT_Flag.
 };
 
+/**
+ * @brief Page table containing ::PT_ENTRIES entries.
+ */
 struct page_table {
-    struct pt_entry entries[PT_ENTRIES];
+    pt_entry entries[PT_ENTRIES]; ///< Array of page table entries.
 };
 
+/**
+ * @brief Page directory referencing lower level tables.
+ */
 struct page_directory {
-    struct page_table *tables[PT_ENTRIES];
+    page_table *tables[PT_ENTRIES]; ///< Pointers to page tables.
 };
 
+/**
+ * @brief Directory-pointer level aggregating page directories.
+ */
 struct page_dir_ptr {
-    struct page_directory *dirs[PT_ENTRIES];
+    page_directory *dirs[PT_ENTRIES]; ///< Pointers to page directories.
 };
 
+/**
+ * @brief Top-level page map for 4-level paging.
+ */
 struct pml4 {
-    struct page_dir_ptr *ptrs[PT_ENTRIES];
+    page_dir_ptr *ptrs[PT_ENTRIES]; ///< Pointers to directory pointers.
 };
 
 /* Kernel interfaces */
+
+/**
+ * @brief Initialize kernel paging structures.
+ */
 void paging_init(void);
+
+/**
+ * @brief Allocate virtual kernel address space.
+ *
+ * @param bytes Number of bytes to allocate.
+ * @param flags Allocation attributes.
+ * @return Pointer to the allocated virtual region.
+ */
 void *alloc_virtual(u64_t bytes, int flags);
+
+/**
+ * @brief Record a mapping from virtual to physical address.
+ *
+ * @param va Virtual address to map.
+ * @param pa Physical address to associate.
+ * @param flags Mapping attributes.
+ * @return ::OK on success or an error code.
+ */
 int map_page(virt_addr64 va, phys_addr64 pa, int flags);
 
 #endif /* PAGING_H */


### PR DESCRIPTION
## Summary
- document paging interface constants, tables, and kernel hooks with Doxygen
- record documentation coverage and Doxygen build attempt

## Testing
- `apt-get install -y doxygen graphviz`
- `python3 -m pip install sphinx breathe`
- `doxygen docs/Doxyfile`
- `sphinx-build -b html docs/sphinx docs/sphinx/_build/html` *(fails: Title level inconsistent)*

------
https://chatgpt.com/codex/tasks/task_e_6892eb7e98e483319da69f71349558f8