### PR TITLE
Implement sort merge and add tests

### DIFF
--- a/commands/sort.cpp
+++ b/commands/sort.cpp
@@ -4,7 +4,7 @@
  * @author XINIM Project (Modernized from Michiel Huisjes original)
  * @version 2.0
  * @date 2025
- * 
+ *
  * Complete modernization using C++23 paradigms:
  * - RAII memory management with smart containers
  * - Type-safe enums and strong typing
@@ -30,6 +30,7 @@
 #include <locale>
 #include <memory>
 #include <optional>
+#include <queue>
 #include <ranges>
 #include <regex>
 #include <span>
@@ -46,52 +47,54 @@ namespace xinim::sort_utility {
 // =============================================================================
 
 /// Result type for operations that can fail
-template<typename T>
-using Result = std::expected<T, std::string>;
+template <typename T> using Result = std::expected<T, std::string>;
 
 /// Strong type for field numbers (0-based)
 struct FieldNumber {
     std::size_t value{0};
-    
+
     constexpr explicit FieldNumber(std::size_t field = 0) noexcept : value{field} {}
-    constexpr auto operator<=>(const FieldNumber&) const = default;
-    constexpr FieldNumber& operator++() noexcept { ++value; return *this; }
-    constexpr FieldNumber operator++(int) noexcept { auto tmp = *this; ++value; return tmp; }
+    constexpr auto operator<=>(const FieldNumber &) const = default;
+    constexpr FieldNumber &operator++() noexcept {
+        ++value;
+        return *this;
+    }
+    constexpr FieldNumber operator++(int) noexcept {
+        auto tmp = *this;
+        ++value;
+        return tmp;
+    }
 };
 
 /// Strong type for character offsets within fields
 struct FieldOffset {
     std::size_t value{0};
-    
+
     constexpr explicit FieldOffset(std::size_t offset = 0) noexcept : value{offset} {}
-    constexpr auto operator<=>(const FieldOffset&) const = default;
+    constexpr auto operator<=>(const FieldOffset &) const = default;
 };
 
 /// Modern sort flags with type safety
 enum class SortFlag : std::uint16_t {
-    None           = 0x0000,
-    FoldCase       = 0x0001,  // -f: Fold upper case to lower
-    Numeric        = 0x0002,  // -n: Sort numeric values
-    IgnoreBlanks   = 0x0004,  // -b: Skip leading blanks
-    IgnoreNonASCII = 0x0008,  // -i: Ignore non-ASCII chars
-    Reverse        = 0x0010,  // -r: Reverse sort order
-    Dictionary     = 0x0020,  // -d: Dictionary order only
-    Unique         = 0x0040,  // -u: Unique lines only
-    CheckOrder     = 0x0080,  // -c: Check if sorted
-    Merge          = 0x0100,  // -m: Merge sorted files
+    None = 0x0000,
+    FoldCase = 0x0001,       // -f: Fold upper case to lower
+    Numeric = 0x0002,        // -n: Sort numeric values
+    IgnoreBlanks = 0x0004,   // -b: Skip leading blanks
+    IgnoreNonASCII = 0x0008, // -i: Ignore non-ASCII chars
+    Reverse = 0x0010,        // -r: Reverse sort order
+    Dictionary = 0x0020,     // -d: Dictionary order only
+    Unique = 0x0040,         // -u: Unique lines only
+    CheckOrder = 0x0080,     // -c: Check if sorted
+    Merge = 0x0100,          // -m: Merge sorted files
 };
 
 /// Bitwise operations for sort flags
 constexpr SortFlag operator|(SortFlag lhs, SortFlag rhs) noexcept {
-    return static_cast<SortFlag>(
-        static_cast<std::uint16_t>(lhs) | static_cast<std::uint16_t>(rhs)
-    );
+    return static_cast<SortFlag>(static_cast<std::uint16_t>(lhs) | static_cast<std::uint16_t>(rhs));
 }
 
 constexpr SortFlag operator&(SortFlag lhs, SortFlag rhs) noexcept {
-    return static_cast<SortFlag>(
-        static_cast<std::uint16_t>(lhs) & static_cast<std::uint16_t>(rhs)
-    );
+    return static_cast<SortFlag>(static_cast<std::uint16_t>(lhs) & static_cast<std::uint16_t>(rhs));
 }
 
 constexpr bool has_flag(SortFlag flags, SortFlag flag) noexcept {
@@ -105,11 +108,11 @@ struct FieldSpec {
     std::optional<FieldNumber> end_field;
     std::optional<FieldOffset> end_offset;
     SortFlag flags{SortFlag::None};
-    
+
     constexpr FieldSpec() = default;
-    
-    constexpr FieldSpec(FieldNumber start_f, FieldOffset start_o = FieldOffset{0}, 
-                       SortFlag field_flags = SortFlag::None) noexcept
+
+    constexpr FieldSpec(FieldNumber start_f, FieldOffset start_o = FieldOffset{0},
+                        SortFlag field_flags = SortFlag::None) noexcept
         : start_field{start_f}, start_offset{start_o}, flags{field_flags} {}
 };
 
@@ -121,14 +124,10 @@ struct SortConfig {
     std::filesystem::path output_file;
     std::vector<std::filesystem::path> input_files;
     bool use_stdin{false};
-    
-    [[nodiscard]] bool is_valid() const noexcept {
-        return !input_files.empty() || use_stdin;
-    }
-    
-    [[nodiscard]] bool has_custom_fields() const noexcept {
-        return !fields.empty();
-    }
+
+    [[nodiscard]] bool is_valid() const noexcept { return !input_files.empty() || use_stdin; }
+
+    [[nodiscard]] bool has_custom_fields() const noexcept { return !fields.empty(); }
 };
 
 // =============================================================================
@@ -137,19 +136,19 @@ struct SortConfig {
 
 /// RAII container for line management
 class LineContainer {
-private:
+  private:
     std::vector<std::string> lines_;
     std::unordered_set<std::string> unique_lines_;
     bool enforce_unique_{false};
-    
-public:
+
+  public:
     explicit LineContainer(bool unique_only = false) : enforce_unique_{unique_only} {
         if (unique_only) {
             unique_lines_.reserve(1000); // Initial capacity
         }
         lines_.reserve(1000);
     }
-    
+
     /// Add a line to the container
     bool add_line(std::string line) {
         if (enforce_unique_) {
@@ -158,26 +157,20 @@ public:
                 return false; // Duplicate line
             }
         }
-        
+
         lines_.emplace_back(std::move(line));
         return true;
     }
-    
+
     /// Get all lines
-    [[nodiscard]] auto lines() const noexcept -> const std::vector<std::string>& {
-        return lines_;
-    }
-    
+    [[nodiscard]] auto lines() const noexcept -> const std::vector<std::string> & { return lines_; }
+
     /// Get mutable lines for sorting
-    [[nodiscard]] auto mutable_lines() noexcept -> std::vector<std::string>& {
-        return lines_;
-    }
-    
+    [[nodiscard]] auto mutable_lines() noexcept -> std::vector<std::string> & { return lines_; }
+
     /// Get line count
-    [[nodiscard]] auto size() const noexcept -> std::size_t {
-        return lines_.size();
-    }
-    
+    [[nodiscard]] auto size() const noexcept -> std::size_t { return lines_.size(); }
+
     /// Clear all lines
     void clear() noexcept {
         lines_.clear();
@@ -190,7 +183,7 @@ public:
 // =============================================================================
 
 /// Concept for field extractors
-template<typename T>
+template <typename T>
 concept FieldExtractor = requires(T extractor, std::string_view line, FieldSpec spec) {
     { extractor.extract_field(line, spec) } -> std::convertible_to<std::string_view>;
 };
@@ -238,7 +231,7 @@ class ModernFieldExtractor {
                         return {};
                     }
                 }
-                if (spec.end_offset && i == spec.end_field.value &&
+                if (spec.end_offset && i == spec.end_field->value &&
                     spec.end_offset->value < field.size()) {
                     field = field.substr(0, spec.end_offset->value);
                 }
@@ -263,19 +256,19 @@ class ModernFieldExtractor {
     /// Split line into fields using separator
     void split_fields(std::string_view line) {
         field_cache_.clear();
-        
+
         if (separator_ == '\t') {
             // Default whitespace splitting
-            auto fields = line | std::views::split(' ') | 
-                         std::views::filter([](auto&& field) { return !field.empty(); });
-            
-            for (auto&& field : fields) {
+            auto fields = line | std::views::split(' ') |
+                          std::views::filter([](auto &&field) { return !field.empty(); });
+
+            for (auto &&field : fields) {
                 field_cache_.emplace_back(std::string_view{field.begin(), field.end()});
             }
         } else {
             // Custom separator splitting
             auto fields = line | std::views::split(separator_);
-            for (auto&& field : fields) {
+            for (auto &&field : fields) {
                 field_cache_.emplace_back(std::string_view{field.begin(), field.end()});
             }
         }
@@ -288,21 +281,22 @@ class ModernFieldExtractor {
 
 /// Modern comparison engine using function objects
 class ComparisonEngine {
-private:
+  private:
     SortConfig config_;
     ModernFieldExtractor extractor_;
-    
-public:
-    explicit ComparisonEngine(const SortConfig& config) 
+
+  public:
+    explicit ComparisonEngine(const SortConfig &config)
         : config_{config}, extractor_{config.field_separator} {}
-    
+
     /// Create comparison function for sorting
-    [[nodiscard]] auto create_comparator() -> std::function<bool(const std::string&, const std::string&)> {
-        return [this](const std::string& lhs, const std::string& rhs) -> bool {
+    [[nodiscard]] auto create_comparator()
+        -> std::function<bool(const std::string &, const std::string &)> {
+        return [this](const std::string &lhs, const std::string &rhs) -> bool {
             return compare_lines(lhs, rhs) < 0;
         };
     }
-    
+
     /// Compare two lines according to configuration
     [[nodiscard]] auto compare_lines(std::string_view lhs, std::string_view rhs) -> int {
         if (config_.has_custom_fields()) {
@@ -311,14 +305,14 @@ public:
             return compare_whole_lines(lhs, rhs);
         }
     }
-    
-private:
+
+  private:
     /// Compare using field specifications
     [[nodiscard]] auto compare_with_fields(std::string_view lhs, std::string_view rhs) -> int {
-        for (const auto& field_spec : config_.fields) {
+        for (const auto &field_spec : config_.fields) {
             auto lhs_field = extractor_.extract_field(lhs, field_spec);
             auto rhs_field = extractor_.extract_field(rhs, field_spec);
-            
+
             auto result = compare_field_values(lhs_field, rhs_field, field_spec.flags);
             if (result != 0) {
                 return has_flag(field_spec.flags, SortFlag::Reverse) ? -result : result;
@@ -326,19 +320,20 @@ private:
         }
         return 0;
     }
-    
+
     /// Compare whole lines
     [[nodiscard]] auto compare_whole_lines(std::string_view lhs, std::string_view rhs) -> int {
         auto result = compare_field_values(lhs, rhs, config_.global_flags);
         return has_flag(config_.global_flags, SortFlag::Reverse) ? -result : result;
     }
-    
+
     /// Compare field values with specific flags
-    [[nodiscard]] auto compare_field_values(std::string_view lhs, std::string_view rhs, SortFlag flags) -> int {
+    [[nodiscard]] auto compare_field_values(std::string_view lhs, std::string_view rhs,
+                                            SortFlag flags) -> int {
         // Apply preprocessing based on flags
         auto processed_lhs = preprocess_field(lhs, flags);
         auto processed_rhs = preprocess_field(rhs, flags);
-        
+
         if (has_flag(flags, SortFlag::Numeric)) {
             return compare_numeric(processed_lhs, processed_rhs);
         } else if (has_flag(flags, SortFlag::Dictionary)) {
@@ -347,11 +342,11 @@ private:
             return processed_lhs.compare(processed_rhs);
         }
     }
-    
+
     /// Preprocess field based on flags
     [[nodiscard]] auto preprocess_field(std::string_view field, SortFlag flags) -> std::string {
         std::string result{field};
-        
+
         if (has_flag(flags, SortFlag::IgnoreBlanks)) {
             // Remove leading whitespace
             auto start = result.find_first_not_of(" \t");
@@ -359,62 +354,65 @@ private:
                 result = result.substr(start);
             }
         }
-        
+
         if (has_flag(flags, SortFlag::FoldCase)) {
             std::transform(result.begin(), result.end(), result.begin(),
-                          [](unsigned char c) { return std::tolower(c); });
+                           [](unsigned char c) { return std::tolower(c); });
         }
-        
+
         if (has_flag(flags, SortFlag::IgnoreNonASCII)) {
-            std::erase_if(result, [](unsigned char c) { 
-                return c < 32 || c > 126; 
-            });
+            std::erase_if(result, [](unsigned char c) { return c < 32 || c > 126; });
         }
-        
+
         return result;
     }
-    
+
     /// Compare numeric fields
     [[nodiscard]] auto compare_numeric(std::string_view lhs, std::string_view rhs) -> int {
         try {
             auto lhs_num = std::stod(std::string{lhs});
             auto rhs_num = std::stod(std::string{rhs});
-            
-            if (lhs_num < rhs_num) return -1;
-            if (lhs_num > rhs_num) return 1;
+
+            if (lhs_num < rhs_num)
+                return -1;
+            if (lhs_num > rhs_num)
+                return 1;
             return 0;
-        } catch (const std::exception&) {
+        } catch (const std::exception &) {
             // Fall back to string comparison if not numeric
             return lhs.compare(rhs);
         }
     }
-    
+
     /// Compare in dictionary order
     [[nodiscard]] auto compare_dictionary(std::string_view lhs, std::string_view rhs) -> int {
-        auto is_dict_char = [](char c) {
-            return std::isalnum(c) || c == ',' || c == '.';
-        };
-        
+        auto is_dict_char = [](char c) { return std::isalnum(c) || c == ',' || c == '.'; };
+
         auto lhs_it = lhs.begin();
         auto rhs_it = rhs.begin();
-        
+
         while (lhs_it != lhs.end() && rhs_it != rhs.end()) {
             // Skip non-dictionary characters
-            while (lhs_it != lhs.end() && !is_dict_char(*lhs_it)) ++lhs_it;
-            while (rhs_it != rhs.end() && !is_dict_char(*rhs_it)) ++rhs_it;
-            
-            if (lhs_it == lhs.end() && rhs_it == rhs.end()) return 0;
-            if (lhs_it == lhs.end()) return -1;
-            if (rhs_it == rhs.end()) return 1;
-            
+            while (lhs_it != lhs.end() && !is_dict_char(*lhs_it))
+                ++lhs_it;
+            while (rhs_it != rhs.end() && !is_dict_char(*rhs_it))
+                ++rhs_it;
+
+            if (lhs_it == lhs.end() && rhs_it == rhs.end())
+                return 0;
+            if (lhs_it == lhs.end())
+                return -1;
+            if (rhs_it == rhs.end())
+                return 1;
+
             if (*lhs_it != *rhs_it) {
                 return (*lhs_it < *rhs_it) ? -1 : 1;
             }
-            
+
             ++lhs_it;
             ++rhs_it;
         }
-        
+
         return 0;
     }
 };
@@ -425,16 +423,15 @@ private:
 
 /// Modern file reader with RAII
 class ModernFileReader {
-private:
+  private:
     std::unique_ptr<std::istream> stream_;
-    std::istream* raw_stream_ptr_{nullptr};
+    std::istream *raw_stream_ptr_{nullptr};
     std::filesystem::path file_path_;
     bool owns_stream_{false};
-    
-public:
+
+  public:
     /// Constructor for file-based input
-    explicit ModernFileReader(const std::filesystem::path& path) 
-        : file_path_{path} {
+    explicit ModernFileReader(const std::filesystem::path &path) : file_path_{path} {
         auto file_stream = std::make_unique<std::ifstream>(path);
         if (!file_stream->is_open()) {
             throw std::runtime_error(std::format("Cannot open file: {}", path.string()));
@@ -442,49 +439,48 @@ public:
         stream_ = std::move(file_stream);
         owns_stream_ = true;
     }
-    
+
     /// Constructor for standard input
-    explicit ModernFileReader(std::istream& input_stream) 
+    explicit ModernFileReader(std::istream &input_stream)
         : raw_stream_ptr_{&input_stream}, owns_stream_{false} {}
-    
+
     /// Read all lines into container
-    auto read_lines(LineContainer& container) -> Result<void> {
+    auto read_lines(LineContainer &container) -> Result<void> {
         try {
             std::string line;
-            auto* active_stream = owns_stream_ ? stream_.get() : raw_stream_ptr_;
-            
+            auto *active_stream = owns_stream_ ? stream_.get() : raw_stream_ptr_;
+
             while (std::getline(*active_stream, line)) {
                 container.add_line(std::move(line));
             }
-            
+
             if (active_stream->bad()) {
                 return std::unexpected("I/O error while reading file");
             }
-            
+
             return {};
-        } catch (const std::exception& e) {
+        } catch (const std::exception &e) {
             return std::unexpected(std::format("Error reading file: {}", e.what()));
         }
     }
-    
+
     /// Get file path
-    [[nodiscard]] auto file_path() const noexcept -> const std::filesystem::path& {
+    [[nodiscard]] auto file_path() const noexcept -> const std::filesystem::path & {
         return file_path_;
     }
 };
 
 /// Modern file writer with RAII
 class ModernFileWriter {
-private:
+  private:
     std::unique_ptr<std::ostream> stream_;
-    std::ostream* raw_stream_ptr_{nullptr};
+    std::ostream *raw_stream_ptr_{nullptr};
     std::filesystem::path file_path_;
     bool owns_stream_{false};
-    
-public:
+
+  public:
     /// Constructor for file-based output
-    explicit ModernFileWriter(const std::filesystem::path& path) 
-        : file_path_{path} {
+    explicit ModernFileWriter(const std::filesystem::path &path) : file_path_{path} {
         auto file_stream = std::make_unique<std::ofstream>(path);
         if (!file_stream->is_open()) {
             throw std::runtime_error(std::format("Cannot create file: {}", path.string()));
@@ -492,28 +488,28 @@ public:
         stream_ = std::move(file_stream);
         owns_stream_ = true;
     }
-    
+
     /// Constructor for standard output
-    explicit ModernFileWriter(std::ostream& output_stream) 
+    explicit ModernFileWriter(std::ostream &output_stream)
         : raw_stream_ptr_{&output_stream}, owns_stream_{false} {}
-    
+
     /// Write all lines from container
-    auto write_lines(const LineContainer& container) -> Result<void> {
+    auto write_lines(const LineContainer &container) -> Result<void> {
         try {
-            auto* active_stream = owns_stream_ ? stream_.get() : raw_stream_ptr_;
-            
-            for (const auto& line : container.lines()) {
+            auto *active_stream = owns_stream_ ? stream_.get() : raw_stream_ptr_;
+
+            for (const auto &line : container.lines()) {
                 *active_stream << line << '\n';
             }
-            
+
             active_stream->flush();
-            
+
             if (active_stream->bad()) {
                 return std::unexpected("I/O error while writing file");
             }
-            
+
             return {};
-        } catch (const std::exception& e) {
+        } catch (const std::exception &e) {
             return std::unexpected(std::format("Error writing file: {}", e.what()));
         }
     }
@@ -525,18 +521,18 @@ public:
 
 /// Modern command line parser
 class CommandLineParser {
-private:
-    std::span<char*> args_;
+  private:
+    std::span<char *> args_;
     SortConfig config_;
-    
-public:
-    explicit CommandLineParser(std::span<char*> arguments) : args_{arguments} {}
-    
+
+  public:
+    explicit CommandLineParser(std::span<char *> arguments) : args_{arguments} {}
+
     /// Parse all command line arguments
     [[nodiscard]] auto parse() -> Result<SortConfig> {
         for (std::size_t i = 1; i < args_.size(); ++i) {
             std::string_view arg{args_[i]};
-            
+
             if (arg.starts_with('+')) {
                 // Field start specification
                 auto field_result = parse_field_start(arg.substr(1));
@@ -544,7 +540,7 @@ public:
                     return std::unexpected(field_result.error());
                 }
                 config_.fields.push_back(*field_result);
-                
+
             } else if (arg.starts_with('-') && arg.size() > 1) {
                 if (std::isdigit(arg[1])) {
                     // Field end specification
@@ -553,7 +549,7 @@ public:
                         return std::unexpected(field_result.error());
                     }
                     if (!config_.fields.empty()) {
-                        auto& last_field = config_.fields.back();
+                        auto &last_field = config_.fields.back();
                         last_field.end_field = field_result->start_field;
                         last_field.end_offset = field_result->start_offset;
                     }
@@ -565,89 +561,108 @@ public:
                     }
                     i = *option_result; // Update index if option consumed additional arguments
                 }
-                
+
             } else {
                 // Input file
                 config_.input_files.emplace_back(arg);
             }
         }
-        
+
         // Configure derived settings
         if (config_.input_files.empty()) {
             config_.use_stdin = true;
         }
-        
+
         // Validate configuration
         if (!config_.is_valid()) {
             return std::unexpected("Invalid configuration parameters");
         }
-        
+
         return config_;
     }
-    
-private:
+
+  private:
     /// Parse field start specification (+field.offset)
     [[nodiscard]] auto parse_field_start(std::string_view spec) -> Result<FieldSpec> {
         auto dot_pos = spec.find('.');
         auto field_str = spec.substr(0, dot_pos);
-        
+
         try {
             auto field_num = std::stoul(std::string{field_str});
             FieldSpec field_spec{FieldNumber{field_num}};
-            
+
             if (dot_pos != std::string_view::npos) {
                 auto offset_str = spec.substr(dot_pos + 1);
                 auto offset_num = std::stoul(std::string{offset_str});
                 field_spec.start_offset = FieldOffset{offset_num};
             }
-            
+
             return field_spec;
-        } catch (const std::exception& e) {
+        } catch (const std::exception &e) {
             return std::unexpected(std::format("Invalid field specification: {}", e.what()));
         }
     }
-    
+
     /// Parse field end specification
     [[nodiscard]] auto parse_field_end(std::string_view spec) -> Result<FieldSpec> {
         return parse_field_start(spec); // Same format
     }
-    
+
     /// Parse option flags
-    [[nodiscard]] auto parse_options(std::string_view arg, std::size_t& index) -> Result<std::size_t> {
+    [[nodiscard]] auto parse_options(std::string_view arg, std::size_t &index)
+        -> Result<std::size_t> {
         for (std::size_t j = 1; j < arg.size(); ++j) {
             switch (arg[j]) {
-                case 'f': config_.global_flags = config_.global_flags | SortFlag::FoldCase; break;
-                case 'n': config_.global_flags = config_.global_flags | SortFlag::Numeric; break;
-                case 'b': config_.global_flags = config_.global_flags | SortFlag::IgnoreBlanks; break;
-                case 'i': config_.global_flags = config_.global_flags | SortFlag::IgnoreNonASCII; break;
-                case 'r': config_.global_flags = config_.global_flags | SortFlag::Reverse; break;
-                case 'd': config_.global_flags = config_.global_flags | SortFlag::Dictionary; break;
-                case 'u': config_.global_flags = config_.global_flags | SortFlag::Unique; break;
-                case 'c': config_.global_flags = config_.global_flags | SortFlag::CheckOrder; break;
-                case 'm': config_.global_flags = config_.global_flags | SortFlag::Merge; break;
-                
-                case 'o':
-                    if (++index >= args_.size()) {
-                        return std::unexpected("Option -o requires an argument");
-                    }
-                    config_.output_file = args_[index];
+            case 'f':
+                config_.global_flags = config_.global_flags | SortFlag::FoldCase;
+                break;
+            case 'n':
+                config_.global_flags = config_.global_flags | SortFlag::Numeric;
+                break;
+            case 'b':
+                config_.global_flags = config_.global_flags | SortFlag::IgnoreBlanks;
+                break;
+            case 'i':
+                config_.global_flags = config_.global_flags | SortFlag::IgnoreNonASCII;
+                break;
+            case 'r':
+                config_.global_flags = config_.global_flags | SortFlag::Reverse;
+                break;
+            case 'd':
+                config_.global_flags = config_.global_flags | SortFlag::Dictionary;
+                break;
+            case 'u':
+                config_.global_flags = config_.global_flags | SortFlag::Unique;
+                break;
+            case 'c':
+                config_.global_flags = config_.global_flags | SortFlag::CheckOrder;
+                break;
+            case 'm':
+                config_.global_flags = config_.global_flags | SortFlag::Merge;
+                break;
+
+            case 'o':
+                if (++index >= args_.size()) {
+                    return std::unexpected("Option -o requires an argument");
+                }
+                config_.output_file = args_[index];
+                return index;
+
+            case 't':
+                if (j + 1 < arg.size()) {
+                    config_.field_separator = arg[j + 1];
                     return index;
-                    
-                case 't':
-                    if (j + 1 < arg.size()) {
-                        config_.field_separator = arg[j + 1];
-                        return index;
-                    } else if (++index < args_.size()) {
-                        config_.field_separator = args_[index][0];
-                        return index;
-                    }
-                    return std::unexpected("Option -t requires a separator character");
-                    
-                default:
-                    return std::unexpected(std::format("Unknown option: -{}", arg[j]));
+                } else if (++index < args_.size()) {
+                    config_.field_separator = args_[index][0];
+                    return index;
+                }
+                return std::unexpected("Option -t requires a separator character");
+
+            default:
+                return std::unexpected(std::format("Unknown option: -{}", arg[j]));
             }
         }
-        
+
         return index;
     }
 };
@@ -658,57 +673,149 @@ private:
 
 /// Modern sort engine
 class ModernSortEngine {
-private:
+  private:
     SortConfig config_;
     ComparisonEngine comparator_;
-    
-public:
-    explicit ModernSortEngine(const SortConfig& config) 
-        : config_{config}, comparator_{config} {}
-    
+
+  public:
+    explicit ModernSortEngine(const SortConfig &config) : config_{config}, comparator_{config} {}
+
     /// Sort lines in container
-    auto sort_lines(LineContainer& container) -> Result<void> {
+    auto sort_lines(LineContainer &container) -> Result<void> {
         try {
             if (has_flag(config_.global_flags, SortFlag::CheckOrder)) {
                 return check_order(container);
             } else if (has_flag(config_.global_flags, SortFlag::Merge)) {
-                return merge_files();
+                return merge_files(container);
             } else {
                 return perform_sort(container);
             }
-        } catch (const std::exception& e) {
+        } catch (const std::exception &e) {
             return std::unexpected(std::format("Sort error: {}", e.what()));
         }
     }
-    
-private:
+
+  private:
     /// Perform the actual sorting
-    auto perform_sort(LineContainer& container) -> Result<void> {
-        auto& lines = container.mutable_lines();
+    auto perform_sort(LineContainer &container) -> Result<void> {
+        auto &lines = container.mutable_lines();
         auto comparator = comparator_.create_comparator();
-        
+
         // Use C++23 ranges algorithms for sorting
         std::ranges::sort(lines, comparator);
-        
+
         return {};
     }
-    
+
     /// Check if lines are already sorted
-    auto check_order(const LineContainer& container) -> Result<void> {
-        const auto& lines = container.lines();
+    auto check_order(const LineContainer &container) -> Result<void> {
+        const auto &lines = container.lines();
         auto comparator = comparator_.create_comparator();
-        
+
         if (!std::ranges::is_sorted(lines, comparator)) {
             return std::unexpected("File is not sorted");
         }
-        
+
         return {};
     }
-    
-    /// Merge multiple sorted files
-    auto merge_files() -> Result<void> {
-        // TODO: Implement merge functionality for multiple files
-        return std::unexpected("Merge functionality not yet implemented");
+
+    /// Merge multiple sorted input streams into the container.
+    ///
+    /// This performs a classic \em k-way merge using a min-heap. Each input
+    /// file (and optionally standard input) is assumed to be individually
+    /// sorted according to the configuration flags. The resulting merged
+    /// sequence is appended to \p container while respecting the unique line
+    /// option if enabled.
+    auto merge_files(LineContainer &container) -> Result<void> {
+        struct InputSource {
+            std::unique_ptr<std::ifstream> file_stream{}; ///< owned file stream
+            std::istream *stream{nullptr};                ///< active stream
+            std::filesystem::path path{};                 ///< file path for errors
+            std::string line{};                           ///< current line buffer
+        };
+
+        std::vector<InputSource> sources;
+
+        // Helper lambda to push a source into the heap when it has a line.
+        auto load_first_line = [](InputSource &src) -> bool {
+            return static_cast<bool>(std::getline(*src.stream, src.line));
+        };
+
+        // Open all file inputs
+        for (const auto &file_path : config_.input_files) {
+            try {
+                InputSource src;
+                src.file_stream = std::make_unique<std::ifstream>(file_path);
+                if (!src.file_stream->is_open()) {
+                    std::cerr << std::format("Warning: Cannot open {}\n", file_path.string());
+                    continue;
+                }
+                src.stream = src.file_stream.get();
+                src.path = file_path;
+                if (load_first_line(src)) {
+                    sources.emplace_back(std::move(src));
+                } else if (src.stream->bad()) {
+                    return std::unexpected(
+                        std::format("I/O error while reading {}", file_path.string()));
+                }
+            } catch (const std::exception &e) {
+                std::cerr << std::format("Warning: Cannot open {}: {}\n", file_path.string(),
+                                         e.what());
+                continue;
+            }
+        }
+
+        // Include standard input if requested
+        if (config_.use_stdin) {
+            InputSource src;
+            src.stream = &std::cin;
+            src.path = "<stdin>";
+            if (load_first_line(src)) {
+                sources.emplace_back(std::move(src));
+            } else if (src.stream->bad()) {
+                return std::unexpected("I/O error while reading standard input");
+            }
+        }
+
+        if (sources.empty()) {
+            return std::unexpected("No input sources available for merge");
+        }
+
+        // Priority queue for k-way merge (min-heap)
+        auto less = comparator_.create_comparator();
+
+        struct HeapItem {
+            std::size_t index; ///< Index into sources vector
+        };
+
+        auto heap_comp = [&](const HeapItem &a, const HeapItem &b) {
+            return less(sources[b.index].line, sources[a.index].line);
+        };
+
+        std::priority_queue<HeapItem, std::vector<HeapItem>, decltype(heap_comp)> heap(heap_comp);
+
+        for (std::size_t i = 0; i < sources.size(); ++i) {
+            if (!sources[i].line.empty()) {
+                heap.push({i});
+            }
+        }
+
+        while (!heap.empty()) {
+            auto [idx] = heap.top();
+            heap.pop();
+
+            auto &src = sources[idx];
+            container.add_line(std::move(src.line));
+
+            if (std::getline(*src.stream, src.line)) {
+                heap.push({idx});
+            } else if (src.stream->bad()) {
+                return std::unexpected(
+                    std::format("I/O error while reading {}", src.path.string()));
+            }
+        }
+
+        return {};
     }
 };
 
@@ -718,72 +825,73 @@ private:
 
 /// Main sort utility application
 class SortUtilityApp {
-private:
+  private:
     SortConfig config_;
     ModernSortEngine engine_;
-    
-public:
-    explicit SortUtilityApp(const SortConfig& config) 
-        : config_{config}, engine_{config} {}
-    
+
+  public:
+    explicit SortUtilityApp(const SortConfig &config) : config_{config}, engine_{config} {}
+
     /// Run the sort utility
     [[nodiscard]] auto run() -> Result<void> {
         try {
             LineContainer container{has_flag(config_.global_flags, SortFlag::Unique)};
-            
-            // Read input
-            auto read_result = read_input(container);
-            if (!read_result) {
-                return std::unexpected(read_result.error());
+
+            // Read input unless we are in merge mode (merge handles its own I/O)
+            if (!has_flag(config_.global_flags, SortFlag::Merge)) {
+                auto read_result = read_input(container);
+                if (!read_result) {
+                    return std::unexpected(read_result.error());
+                }
             }
-            
-            // Sort lines
+
+            // Sort or merge lines
             auto sort_result = engine_.sort_lines(container);
             if (!sort_result) {
                 return std::unexpected(sort_result.error());
             }
-            
+
             // Write output
             auto write_result = write_output(container);
             if (!write_result) {
                 return std::unexpected(write_result.error());
             }
-            
+
             return {};
-        } catch (const std::exception& e) {
+        } catch (const std::exception &e) {
             return std::unexpected(std::format("Runtime error: {}", e.what()));
         }
     }
-    
-private:
+
+  private:
     /// Read input from files or stdin
-    auto read_input(LineContainer& container) -> Result<void> {
+    auto read_input(LineContainer &container) -> Result<void> {
         if (config_.use_stdin) {
             ModernFileReader reader{std::cin};
             return reader.read_lines(container);
         } else {
-            for (const auto& file_path : config_.input_files) {
+            for (const auto &file_path : config_.input_files) {
                 try {
                     ModernFileReader reader{file_path};
                     auto result = reader.read_lines(container);
                     if (!result) {
-                        std::cerr << std::format("Warning: Cannot read {}: {}\n", 
-                                                file_path.string(), result.error());
+                        std::cerr << std::format("Warning: Cannot read {}: {}\n",
+                                                 file_path.string(), result.error());
                         continue; // Continue with other files
                     }
-                } catch (const std::exception& e) {
-                    std::cerr << std::format("Warning: Cannot open {}: {}\n", 
-                                           file_path.string(), e.what());
+                } catch (const std::exception &e) {
+                    std::cerr << std::format("Warning: Cannot open {}: {}\n", file_path.string(),
+                                             e.what());
                     continue;
                 }
             }
         }
-        
+
         return {};
     }
-    
+
     /// Write output to file or stdout
-    auto write_output(const LineContainer& container) -> Result<void> {
+    auto write_output(const LineContainer &container) -> Result<void> {
         if (config_.output_file.empty()) {
             ModernFileWriter writer{std::cout};
             return writer.write_lines(container);
@@ -830,43 +938,43 @@ Examples:
 
 Modern C++23 implementation with Unicode support and memory safety.
 )",
-        program_name, program_name, program_name, program_name, 
-        program_name, program_name, program_name
-    );
+                             program_name, program_name, program_name, program_name, program_name,
+                             program_name, program_name);
 }
 
 } // namespace xinim::sort_utility
 
+#ifndef SORT_UTILITY_NO_MAIN
 // =============================================================================
 // Modern Main Function
 // =============================================================================
 
-auto main(int argc, char* argv[]) -> int {
+auto main(int argc, char *argv[]) -> int {
     using namespace xinim::sort_utility;
-    
+
     try {
         // Parse command line arguments
         CommandLineParser parser{std::span{argv, static_cast<std::size_t>(argc)}};
         auto config_result = parser.parse();
-        
+
         if (!config_result) {
             std::cerr << std::format("Error: {}\n", config_result.error());
             show_usage(argv[0]);
             return 1;
         }
-        
+
         // Create and run the application
         SortUtilityApp app{*config_result};
         auto result = app.run();
-        
+
         if (!result) {
             std::cerr << std::format("Error: {}\n", result.error());
             return 1;
         }
-        
+
         return 0;
-        
-    } catch (const std::exception& e) {
+
+    } catch (const std::exception &e) {
         std::cerr << std::format("Fatal error: {}\n", e.what());
         return 1;
     } catch (...) {
@@ -874,3 +982,4 @@ auto main(int argc, char* argv[]) -> int {
         return 1;
     }
 }
+#endif // SORT_UTILITY_NO_MAIN

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -739,6 +739,17 @@ target_link_libraries(minix_test_net_driver_autodetect PRIVATE Threads::Threads)
 add_test(NAME minix_test_net_driver_autodetect COMMAND minix_test_net_driver_autodetect)
 
 # -----------------------------------------------------------------------------
+# minix_test_sort_merge
+# -----------------------------------------------------------------------------
+add_executable(minix_test_sort_merge
+  test_sort_merge.cpp
+)
+target_include_directories(minix_test_sort_merge PUBLIC
+  ${CMAKE_SOURCE_DIR}/commands
+)
+add_test(NAME minix_test_sort_merge COMMAND minix_test_sort_merge)
+
+# -----------------------------------------------------------------------------
 # Crypto subdirectory
 # -----------------------------------------------------------------------------
 add_subdirectory(crypto)

--- a/tests/test_sort_merge.cpp
+++ b/tests/test_sort_merge.cpp
@@ -1,0 +1,53 @@
+#include <cassert>
+#include <filesystem>
+#include <fstream>
+#include <vector>
+
+#include "../commands/sort.cpp"
+
+/**
+ * @file test_sort_merge.cpp
+ * @brief Unit test for the merge functionality of the modern sort utility.
+ */
+using namespace xinim::sort_utility;
+
+/// Helper to create a temporary file with given lines.
+static auto create_temp_file(const std::filesystem::path &path,
+                             const std::vector<std::string> &lines) -> void {
+    std::ofstream out{path};
+    for (const auto &line : lines) {
+        out << line << '\n';
+    }
+}
+
+int main() {
+    const auto file1 = std::filesystem::path{"merge_input1.txt"};
+    const auto file2 = std::filesystem::path{"merge_input2.txt"};
+    const auto outfile = std::filesystem::path{"merge_output.txt"};
+
+    create_temp_file(file1, {"apple", "banana"});
+    create_temp_file(file2, {"apricot", "blueberry"});
+
+    SortConfig cfg;
+    cfg.global_flags = SortFlag::Merge;
+    cfg.input_files = {file1, file2};
+    cfg.output_file = outfile;
+
+    SortUtilityApp app{cfg};
+    auto res = app.run();
+    assert(res && "merge operation failed");
+
+    std::ifstream in{outfile};
+    std::vector<std::string> merged;
+    std::string line;
+    while (std::getline(in, line)) {
+        merged.push_back(line);
+    }
+
+    assert((merged == std::vector<std::string>{"apple", "apricot", "banana", "blueberry"}));
+
+    std::filesystem::remove(file1);
+    std::filesystem::remove(file2);
+    std::filesystem::remove(outfile);
+    return 0;
+}


### PR DESCRIPTION
## Summary
- implement k-way merge for multiple sorted inputs using a priority queue
- bypass initial reading phase in merge mode for efficiency
- add regression test covering merge behavior

## Testing
- `cmake -S tests -B build/tests` *(fails: add_test given test NAME "minix_test_memory_stream" which already exists)*
- `g++ -std=c++23 -DSORT_UTILITY_NO_MAIN tests/test_sort_merge.cpp -o tests/test_sort_merge`
- `./tests/test_sort_merge`

------
https://chatgpt.com/codex/tasks/task_e_6892eb7a0bfc8331b5fcbf4d30c64dc9