### PR TITLE
chore: add clang-format pre-commit hook

### DIFF
--- a/docs/BUILDING.md
+++ b/docs/BUILDING.md
@@ -152,7 +152,19 @@ database.
 
 ---
 
-## 11 · Generating Documentation
+## 11 · Git Hooks
+
+Install the provided pre-commit hook to automatically format staged C and C++ sources:
+
+```sh
+ln -s ../../hooks/pre-commit .git/hooks/pre-commit
+```
+
+The hook runs `clang-format -i` on each staged file and re-adds the result to the commit.
+
+---
+
+## 12 · Generating Documentation
 
 API reference and architecture manuals combine **Doxygen** with **Sphinx**
 using the **Breathe** extension. The mapping in `docs/sphinx/conf.py` is:

--- a/hooks/pre-commit
+++ b/hooks/pre-commit
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+# Git pre-commit hook that formats staged C/C++ sources with clang-format.
+# It rewrites the staged files in place and re-adds them to the index.
+set -euo pipefail
+
+files=$(git diff --cached --name-only --diff-filter=ACMR | grep -E '\.(c|cc|cpp|cxx|h|hh|hpp|hxx)$') || true
+
+if [[ -n "$files" ]]; then
+  echo "Formatting staged C/C++ files with clang-format"
+  for file in $files; do
+    clang-format -i "$file"
+    git add "$file"
+  done
+fi
+
+exit 0


### PR DESCRIPTION
## Summary
- add git hook that auto-formats staged C/C++ sources with `clang-format`
- document hook installation in build guide

## Testing
- `clang++ -std=c++23 -O2 -pipe -Wall -Wextra -Wpedantic -march=x86-64 tests/t10a.cpp -o tests/t10a && ./tests/t10a`
- `./tests/t10a && echo "test program ran"`


------
https://chatgpt.com/codex/tasks/task_e_6892eb4deb1483318bb2f3d27c221a2c