### PR TITLE
docs: summarize utility modernization

### DIFF
--- a/commands/XINIM_UTILITIES_MODERNIZATION_COMPLETE.md
+++ b/commands/XINIM_UTILITIES_MODERNIZATION_COMPLETE.md
@@ -1,19 +1,23 @@
 # XINIM Utilities Modernization Summary
 
 ## Modernized Utilities
-- `cat`
-- `sync`
-- `uniq`
-- `update`
-- `x`
-- Earlier sessions also modernized `ar`, core system tools (`basename` through `passwd`), and `login`.
 
-These tools now employ C++23 features such as RAII, template metaprogramming, and SIMD-aware optimizations.
+- Core text and system tools: `ar`, `basename`–`passwd`, and `login`
+- Recent additions: `cat`, `sync`, `uniq`, `update`, `x`
+- Advanced rewrites:
+  - Print utility (`pr_modern.cpp`)
+  - Sort utility (`sort_modern.cpp`)
+  - TAR archive utility (`tar_modern.cpp`)
+  - MINED text editor suite (`modern_mined_*`)
+
+These implementations embrace C++23 idioms such as RAII, `std::filesystem`, ranges, and SIMD-aware data paths.
 
 ## Remaining Work
-- 27 legacy command utilities still require modernization.
-- Subsequent phases will target filesystem, kernel, and memory-manager components.
+
+- Twenty-seven legacy command utilities remain in their original form.
+- Upcoming phases will also address filesystem, kernel, and memory‑manager components.
 
 ## References
-- Detailed synthesis: `docs/comprehensive_synthesis 2.md`
-- Session report: `docs/session2_final_report 2.md`
+
+- Comprehensive report: `docs/modernization_reports/XINIM_UTILITIES_MODERNIZATION_COMPLETE.md`
+- Detailed session analysis: `docs/session2_final_report.md`


### PR DESCRIPTION
## Summary
- document utilities modernized across XINIM commands
- note remaining legacy utilities and reference detailed modernization report

## Testing
- `cmake -S commands -B build/commands` *(fails: The target name "minix_cmd_mined 2" is reserved or not valid)*

------
https://chatgpt.com/codex/tasks/task_e_68a8135d51c0833187f51d6a5626b909