### PR TITLE
refactor(fs): replace macros with constexpr and add tests

### DIFF
--- a/fs/compat.cpp
+++ b/fs/compat.cpp
@@ -1,57 +1,54 @@
-/* Translation helpers for compatibility with the original Minix FS.
- * These helpers store 64-bit file sizes and extent tables while
- * maintaining the legacy 32-bit structures.
+/**
+ * @brief Translation helpers for compatibility with the original Minix FS.
+ *
+ * These helpers store 64-bit file sizes and extent tables while maintaining
+ * the legacy 32-bit structures.
  */
 
-#include "compat.hpp"
 #include "../h/const.hpp"
 #include "../h/type.hpp"
+inline constexpr int NR_ZONE_NUMS = 9;
+inline constexpr int NR_INODES = 32;
+inline constexpr zone_nr NO_ZONE = static_cast<zone_nr>(0);
 #include "../include/lib.hpp" // C++23 header
-#include "extent.hpp"
-#include "inode.hpp"
+#include "compat.hpp"
 
-/*===========================================================================*
- *                              compat_get_size                              *
- *===========================================================================*/
-/* Return the 64-bit size of an inode.
- * ip: inode to query.
+/**
+ * @brief Return the 64-bit size of an inode.
+ * @param ip inode to query.
+ * @return 64-bit file size.
  */
-PUBLIC file_pos64 compat_get_size(const struct inode *ip) {
+file_pos64 compat_get_size(const struct inode *ip) {
     return ip->i_size64 ? ip->i_size64 : (file_pos64)ip->i_size;
 }
 
-/*===========================================================================*
- *                              compat_set_size                              *
- *===========================================================================*/
-/* Update both the 64-bit and 32-bit size fields.
- * ip: inode to update.
- * sz: new file size.
+/**
+ * @brief Update both the 64-bit and 32-bit size fields.
+ * @param ip inode to update.
+ * @param sz new file size.
  */
-PUBLIC void compat_set_size(struct inode *ip, file_pos64 sz) {
+void compat_set_size(struct inode *ip, file_pos64 sz) {
     ip->i_size64 = sz;
     ip->i_size = (file_pos)sz;
 }
 
-/*===========================================================================*
- *                              init_extended_inode                           *
- *===========================================================================*/
-/* Initialize the 64-bit fields of an inode.
- * ip: inode to set up.
+/**
+ * @brief Initialize the 64-bit fields of an inode.
+ * @param ip inode to set up.
  */
-PUBLIC void init_extended_inode(struct inode *ip) {
+void init_extended_inode(struct inode *ip) {
     ip->i_size64 = ip->i_size;
-    ip->i_extents = NIL_PTR;
+    ip->i_extents = nullptr;
     ip->i_extent_count = 0;
 }
 
-/*===========================================================================*
- *                              alloc_extent_table                           *
- *===========================================================================*/
-/* Allocate and zero 'count' extents for an inode.
- * ip: inode receiving the extent table.
- * count: number of extents to allocate.
+/**
+ * @brief Allocate and zero @p count extents for an inode.
+ * @param ip inode receiving the extent table.
+ * @param count number of extents to allocate.
+ * @return OK on success or ErrorCode on failure.
  */
-PUBLIC int alloc_extent_table(struct inode *ip, unsigned short count) {
+int alloc_extent_table(struct inode *ip, unsigned short count) {
 
     // RAII wrapper for the extent table memory.
     SafeBuffer<extent> table_buf(count); // managed table memory
@@ -59,9 +56,9 @@ PUBLIC int alloc_extent_table(struct inode *ip, unsigned short count) {
 
     /* Reject zero-sized tables to avoid undefined behaviour. */
     if (count == 0) {
-        ip->i_extents = NIL_PTR;
+        ip->i_extents = nullptr;
         ip->i_extent_count = 0;
-        return ErrorCode::EINVAL;
+        return static_cast<int>(ErrorCode::EINVAL);
     }
 
     /* Memory was successfully allocated by SafeBuffer. */

--- a/fs/compat.hpp
+++ b/fs/compat.hpp
@@ -1,20 +1,38 @@
-/* Compatibility layer for legacy Minix file system structures. */
+/**
+ * @brief Compatibility layer for legacy Minix file system structures.
+ */
 #ifndef FS_COMPAT_H
 #define FS_COMPAT_H
 
 #include "extent.hpp"
 #include "inode.hpp"
 
-/* Retrieve the 64-bit size of an inode. */
-PUBLIC file_pos64 compat_get_size(const struct inode *ip);
+/**
+ * @brief Retrieve the 64-bit size of an inode.
+ * @param ip inode to query.
+ * @return 64-bit file size.
+ */
+file_pos64 compat_get_size(const struct inode *ip);
 
-/* Update both 64-bit and 32-bit size fields. */
-PUBLIC void compat_set_size(struct inode *ip, file_pos64 sz);
+/**
+ * @brief Update both 64-bit and 32-bit size fields.
+ * @param ip inode to update.
+ * @param sz new file size.
+ */
+void compat_set_size(struct inode *ip, file_pos64 sz);
 
-/* Initialize extended fields of an inode. */
-PUBLIC void init_extended_inode(struct inode *ip);
+/**
+ * @brief Initialize the extended fields of an inode.
+ * @param ip inode to set up.
+ */
+void init_extended_inode(struct inode *ip);
 
-/* Allocate an extent table. */
-PUBLIC int alloc_extent_table(struct inode *ip, unsigned short count);
+/**
+ * @brief Allocate an extent table for an inode.
+ * @param ip inode receiving the extent table.
+ * @param count number of extents to allocate.
+ * @return OK on success or ErrorCode on failure.
+ */
+int alloc_extent_table(struct inode *ip, unsigned short count);
 
 #endif /* FS_COMPAT_H */

--- a/fs/extent.hpp
+++ b/fs/extent.hpp
@@ -1,15 +1,20 @@
-/* Extent-based allocation structures. */
+/**
+ * @brief Extent-based allocation structures.
+ */
 #ifndef FS_EXTENT_H
 #define FS_EXTENT_H
 
 #include "../h/type.hpp"
 
-/* An extent describes a contiguous range of zones on disk. */
+/**
+ * @brief Describes a contiguous range of zones on disk.
+ */
 struct extent {
-    zone_nr e_start; /* first zone in the extent */
-    zone_nr e_count; /* number of zones in the extent */
+    zone_nr e_start; /**< first zone in the extent */
+    zone_nr e_count; /**< number of zones in the extent */
 };
 
-#define NIL_EXTENT (extent *)0
+/// Null extent pointer used to denote absence of an extent table.
+inline constexpr extent *NIL_EXTENT = nullptr;
 
 #endif /* FS_EXTENT_H */

--- a/fs/inode.cpp
+++ b/fs/inode.cpp
@@ -170,7 +170,7 @@ PUBLIC void wipe_inode(struct inode *rip) { // Added void return, modernized par
 
     rip->i_size = 0;               // file_pos (int32_t)
     rip->i_size64 = 0;             // file_pos64 (int64_t)
-    rip->i_extents = NIL_EXTENT;   // NIL_EXTENT is extent* (nullptr or specific value)
+    rip->i_extents = NIL_EXTENT;   // no extent table
     rip->i_extent_count = 0;       // uint16_t
     rip->i_modtime = clock_time(); // real_time (int64_t)
     rip->i_dirt = DIRTY;

--- a/fs/tests/compat_tests.cpp
+++ b/fs/tests/compat_tests.cpp
@@ -1,0 +1,37 @@
+#include "../../h/const.hpp"
+inline constexpr int NR_ZONE_NUMS = 9;
+inline constexpr int NR_INODES = 32;
+#include "compat.hpp"
+#include "error.hpp"
+#include "lib.hpp"
+
+#include <cassert>
+#include <cstddef>
+
+int main() {
+    struct inode ip{};
+    ip.i_size = 42;
+    ip.i_size64 = 0;
+    assert(compat_get_size(&ip) == 42);
+
+    ip.i_size64 = 1000;
+    assert(compat_get_size(&ip) == 1000);
+
+    init_extended_inode(&ip);
+    assert(ip.i_size64 == ip.i_size);
+    assert(ip.i_extents == nullptr);
+    assert(ip.i_extent_count == 0);
+
+    assert(alloc_extent_table(&ip, 0) == static_cast<int>(ErrorCode::EINVAL));
+    assert(ip.i_extents == nullptr);
+    assert(ip.i_extent_count == 0);
+
+    assert(alloc_extent_table(&ip, 2) == OK);
+    assert(ip.i_extents != nullptr);
+    assert(ip.i_extent_count == 2);
+
+    safe_free(ip.i_extents);
+    ip.i_extents = nullptr;
+
+    return 0;
+}

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -114,6 +114,17 @@ add_executable(minix_test_memory_stream
 target_include_directories(minix_test_memory_stream PRIVATE ${XINIM_INCLUDES})
 add_test(NAME minix_test_memory_stream COMMAND minix_test_memory_stream)
 
+# -----------------------------------------------------------------------------
+# File System Tests
+# -----------------------------------------------------------------------------
+add_executable(minix_test_fs_compat
+    ${PROJECT_ROOT}/fs/tests/compat_tests.cpp
+    ${PROJECT_ROOT}/fs/compat.cpp
+    ${PROJECT_ROOT}/lib/safe_alloc.cpp
+)
+target_include_directories(minix_test_fs_compat PRIVATE ${XINIM_INCLUDES} ${PROJECT_ROOT}/fs)
+add_test(NAME minix_test_fs_compat COMMAND minix_test_fs_compat)
+
 # Optional stream tests (disabled by default)
 add_executable(minix_test_streams
     test_streams.cpp


### PR DESCRIPTION
## Summary
- remove PUBLIC/NIL_PTR macros in FS compat helpers in favor of constexpr and `nullptr`
- document FS compatibility helpers with Doxygen-style comments
- cover inode compatibility helpers with unit tests

## Testing
- `ctest --test-dir tests/build -R minix_test_fs_compat`

------
https://chatgpt.com/codex/tasks/task_e_68a812b47b588331a61e44af3d2dd8a6