### PR TITLE
Add CMake Doxygen doc target and build docs guide

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -138,3 +138,28 @@ if(ENABLE_UNIT_TESTS)
   enable_testing()
   add_subdirectory(tests)
 endif()
+
+# ─────────────────────────────────────────────────────────────────────────────
+# 9. Documentation target
+# ─────────────────────────────────────────────────────────────────────────────
+find_package(Doxygen)
+if(DOXYGEN_FOUND)
+  set(DOXYGEN_OUTPUT_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/docs/doxygen")
+  set(DOXYGEN_INPUT_DIRS
+      "${CMAKE_CURRENT_SOURCE_DIR}/commands"
+      "${CMAKE_CURRENT_SOURCE_DIR}/fs"
+      "${CMAKE_CURRENT_SOURCE_DIR}/kernel"
+      "${CMAKE_CURRENT_SOURCE_DIR}/mm"
+      "${CMAKE_CURRENT_SOURCE_DIR}/lib"
+      "${CMAKE_CURRENT_SOURCE_DIR}/crypto")
+  list(JOIN DOXYGEN_INPUT_DIRS " " DOXYGEN_INPUT)
+  configure_file(${CMAKE_CURRENT_SOURCE_DIR}/docs/Doxyfile.in
+                 ${CMAKE_CURRENT_BINARY_DIR}/Doxyfile @ONLY)
+  add_custom_target(doc
+    COMMAND ${DOXYGEN_EXECUTABLE} ${CMAKE_CURRENT_BINARY_DIR}/Doxyfile
+    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+    COMMENT "Generating API documentation with Doxygen"
+    VERBATIM)
+else()
+  message(STATUS "Doxygen not found. Documentation target will be unavailable.")
+endif()

--- a/docs/BUILD.md
+++ b/docs/BUILD.md
@@ -1,0 +1,24 @@
+# Build Instructions
+
+## Prerequisites
+- CMake 3.5 or newer
+- Clang 18 toolchain and LLVM utilities (`lld`, `lldb`)
+- Doxygen for API documentation
+
+## Configure
+```bash
+cmake -S . -B build
+```
+
+## Compile
+```bash
+cmake --build build
+```
+
+## Generate Documentation
+```bash
+cmake --build build --target doc
+```
+
+The documentation target emits HTML and XML into `docs/doxygen`,
+ready for consumption by Sphinx via the Breathe extension.

--- a/docs/Doxyfile.in
+++ b/docs/Doxyfile.in
@@ -9,7 +9,7 @@ PROJECT_NAME           = "XINIM"
 PROJECT_NUMBER         = "2.0"
 PROJECT_BRIEF          = "Modern C++23 MINIX filesystem utilities with type safety and performance"
 PROJECT_LOGO           = 
-OUTPUT_DIRECTORY       = docs/doxygen
+OUTPUT_DIRECTORY       = @DOXYGEN_OUTPUT_DIRECTORY@
 CREATE_SUBDIRS         = YES
 ALLOW_UNICODE_NAMES    = NO
 OUTPUT_LANGUAGE        = English
@@ -106,7 +106,7 @@ WARN_LOGFILE           =
 #---------------------------------------------------------------------------
 # Configuration options related to the input files
 #---------------------------------------------------------------------------
-INPUT                  = kernel include commands fs lib mm h
+INPUT                  = @DOXYGEN_INPUT@
 INPUT_ENCODING         = UTF-8
 FILE_PATTERNS          = *.cpp \
                          *.hpp \


### PR DESCRIPTION
## Summary
- Wire up a `doc` target using `find_package(Doxygen)` to auto-generate API docs
- Template the Doxygen configuration to document commands, fs, kernel, mm, lib and crypto
- Add concise build instructions covering configuration, compilation and documentation

## Testing
- `cmake -S . -B build`
- `cmake --build build --target doc`


------
https://chatgpt.com/codex/tasks/task_e_68a812ba63748331b5622e701a80f73a