### PR TITLE
Fix filesystem CMake source enumeration

### DIFF
--- a/fs/CMakeLists.txt
+++ b/fs/CMakeLists.txt
@@ -1,22 +1,44 @@
-##
-#List all source files for the file system server explicitly.Using an
-#explicit list avoids surprises when new files are added and makes
-#dependencies clear.
-    ##set(FS_SRC
-#Buffer cache implementation with RAII semantics
-              cache.cpp compat.cpp device.cpp filedes.cpp inode.cpp link.cpp main.cpp misc.cpp mount
-                  .cpp open.cpp path.cpp pipe.cpp protect.cpp putc.cpp read.cpp stadir.cpp super
-                  .cpp table.cpp time.cpp utility.cpp write.cpp)
+cmake_minimum_required(VERSION 3.12)
 
-        add_executable(minix_fs_server ${FS_SRC})
+# File system server build configuration
+# --------------------------------------
+# Explicitly enumerate each translation unit to avoid unintentionally pulling
+# in editor backups or experimental sources.  This mirrors the behaviour of the
+# original handwritten makefiles and keeps dependencies transparent.
 
-#FS server should link against the C library(minix_libc)
-#Assuming minixlib will be renamed to minix_libc from lib / CMakeLists.txt
-            target_link_libraries(minix_fs_server PRIVATE minix_libc)
+set(FS_SRC
+    cache.cpp
+    compat.cpp
+    device.cpp
+    filedes.cpp
+    inode.cpp
+    link.cpp
+    main.cpp
+    misc.cpp
+    mount.cpp
+    open.cpp
+    path.cpp
+    pipe.cpp
+    protect.cpp
+    putc.cpp
+    read.cpp
+    stadir.cpp
+    super.cpp
+    table.cpp
+    time.cpp
+    utility.cpp
+    write.cpp
+)
 
-#Add include directories that might be needed by FS source files
-                target_include_directories(
-                    minix_fs_server PUBLIC "." #For headers in fs /
-                    itself(e.g., buf.h, const.h, dev.h,
-                           etc.) "${CMAKE_SOURCE_DIR}/include" #For global includes
-                                 "${CMAKE_SOURCE_DIR}/h" #For global includes from h /)
+add_executable(minix_fs_server ${FS_SRC})
+
+# Link against the Minix C library implemented in lib/
+target_link_libraries(minix_fs_server PRIVATE minix_libc)
+
+# Public include paths required by the file system sources and their consumers
+target_include_directories(minix_fs_server PUBLIC
+    .
+    ${CMAKE_SOURCE_DIR}/include
+    ${CMAKE_SOURCE_DIR}/h
+)
+


### PR DESCRIPTION
## Summary
- restore proper file list in `fs/CMakeLists.txt` so all filesystem sources are built
- link filesystem server with `minix_libc` and expose required include paths

## Testing
- `cmake -S . -B build -DBUILD_SYSTEM=ON`
- `cmake --build build --target minix_fs_server` *(fails: unused variables in brk.cpp)*

------
https://chatgpt.com/codex/tasks/task_e_68a818de58088331a93713fc80c55fa9