### PR TITLE
Introduce RAII printer handle with formatted error reporting

### DIFF
--- a/kernel/printer.cpp
+++ b/kernel/printer.cpp
@@ -31,7 +31,9 @@
 #include "type.hpp"
 #include <cstddef> // For std::size_t
 #include <cstdint> // For uint64_t
-#include <cstdio>  // For printf
+#include <cstdio>  // For output
+#include <format>  // For std::format
+#include <memory>  // For RAII device wrapper
 
 #define NORMAL_STATUS 0xDF  /* printer gives this status when idle */
 #define BUSY_STATUS 0x5F    /* printer gives this status when busy */
@@ -50,7 +52,42 @@
 #define DELAY_LOOP 1000     /* delay when printer is busy */
 #define MAX_REP 1000        /* controls max delay when busy */
 
-static int port_base;          /* I/O port for printer: 0x 378 or 0x3BC */
+/**
+ * @brief RAII wrapper for the parallel printer device.
+ *
+ * The constructor initializes the hardware interface while the destructor
+ * returns the device to a safe state.
+ */
+class PrinterDevice {
+  public:
+    /**
+     * @brief Construct a new PrinterDevice.
+     * @param base I/O base port used to access the printer.
+     */
+    explicit PrinterDevice(int base) noexcept : base_{base} {
+        port_out(base_ + 2, INIT_PRINTER);
+        for (int i = 0; i < DELAY_COUNT; ++i) {
+            // busy wait during initialization
+        }
+        port_out(base_ + 2, SELECT);
+    }
+
+    /**
+     * @brief Destroy the PrinterDevice and reset the hardware.
+     */
+    ~PrinterDevice() noexcept { port_out(base_ + 2, INIT_PRINTER); }
+
+    /**
+     * @brief Retrieve the base port number.
+     * @return Base port for subsequent I/O operations.
+     */
+    [[nodiscard]] int base() const noexcept { return base_; }
+
+  private:
+    int base_; /**< Base port for the printer device. */
+};
+
+static std::unique_ptr<PrinterDevice> g_printer_device; /**< Active printer device. */
 static int caller;             /* process to tell when printing done (FS) */
 static int requesting_proc;    /* user requesting the printing */
 static std::size_t orig_count; /* original byte count (was int) */
@@ -64,12 +101,16 @@ PUBLIC int prev_ct;        /* value of cum_count 100 msec ago */
 /*===========================================================================*
  *				printer_task				     *
  *===========================================================================*/
-PUBLIC void printer_task() noexcept { // Added void return, noexcept
-    /* Main routine of the printer task. */
+/**
+ * @brief Entry point for the printer task.
+ *
+ * Handles incoming messages and dispatches them to the appropriate
+ * sub‑routines.
+ */
+PUBLIC void printer_task() noexcept {
+    message print_mess; /**< Buffer for all incoming messages. */
 
-    message print_mess; /* buffer for all incoming messages */
-
-    print_init(); /* initialize */
+    print_init();
 
     while (TRUE) {
         receive(ANY, &print_mess);
@@ -92,64 +133,57 @@ PUBLIC void printer_task() noexcept { // Added void return, noexcept
 /*===========================================================================*
  *				do_write				     *
  *===========================================================================*/
-static void do_write(message *m_ptr) noexcept { // PRIVATE -> static, modernized signature, noexcept
-    /* The printer is used by sending TTY_WRITE messages to it. Process one. */
-
+/**
+ * @brief Handle a TTY_WRITE request from user space.
+ *
+ * @param m_ptr Message describing the write request.
+ */
+static void do_write(message *m_ptr) noexcept {
     int i, j, r, value;
     struct proc *rp;
-    uint64_t phys; // phys_bytes -> uint64_t
-    // extern phys_bytes umap(); // umap returns uint64_t
+    uint64_t phys;
 
-    r = OK; /* so far, no errors */
+    r = OK;
 
-    /* Reject command if printer is busy or count is not positive. */
     if (pr_busy)
         r = ErrorCode::EAGAIN;
     if (count(*m_ptr) <= 0)
         r = ErrorCode::EINVAL;
 
-    /* Compute the physical address of the data buffer within user space. */
     rp = proc_addr(proc_nr(*m_ptr));
-    // umap expects (proc*, int, std::size_t, std::size_t) returns uint64_t
-    // ADDRESS from message is char*, COUNT is int
     phys = umap(rp, D, reinterpret_cast<std::size_t>(address(*m_ptr)),
                 static_cast<std::size_t>(count(*m_ptr)));
     if (phys == 0)
         r = ErrorCode::E_BAD_ADDR;
 
     if (r == OK) {
-        /* Save information needed later. */
-        lock(); // noexcept
+        lock();
         caller = m_ptr->m_source;
         requesting_proc = proc_nr(*m_ptr);
         pcount = static_cast<std::size_t>(count(*m_ptr));
         orig_count = static_cast<std::size_t>(count(*m_ptr));
-        // phys is uint64_t. es, offset are int. CLICK_SHIFT, LOW_FOUR are int.
         es = static_cast<int>(phys >> CLICK_SHIFT);
         offset = static_cast<int>(phys & LOW_FOUR);
 
-        /* Start the printer. */
         for (i = 0; i < MAX_REP; i++) {
-            port_in(port_base + 1, &value);
+            port_in(g_printer_device->base() + 1, &value);
             if (value == NORMAL_STATUS) {
                 pr_busy = TRUE;
-                pr_char();   /* print first character */
-                r = SUSPEND; /* tell FS to suspend user until done */
-                break;
-            } else {
-                if (value == BUSY_STATUS) {
-                    for (j = 0; j < DELAY_LOOP; j++) /* delay */
-                        ;
-                    continue;
-                }
-                pr_error(value);
-                r = ErrorCode::EIO;
+                pr_char();
+                r = SUSPEND;
                 break;
             }
+            if (value == BUSY_STATUS) {
+                for (j = 0; j < DELAY_LOOP; j++)
+                    ;
+                continue;
+            }
+            pr_error(value);
+            r = ErrorCode::EIO;
+            break;
         }
     }
 
-    /* Reply to FS, no matter what happened. */
     if (value == BUSY_STATUS)
         r = ErrorCode::EAGAIN;
     reply(TASK_REPLY, m_ptr->m_source, proc_nr(*m_ptr), r);
@@ -158,12 +192,13 @@ static void do_write(message *m_ptr) noexcept { // PRIVATE -> static, modernized
 /*===========================================================================*
  *				do_done					     *
  *===========================================================================*/
-static void do_done(message *m_ptr) noexcept { // PRIVATE -> static, modernized signature, noexcept
-    /* Printing is finished.  Reply to caller (FS). */
-
-    int status;
-
-    status = (rep_status(*m_ptr) == OK ? orig_count : ErrorCode::EIO);
+/**
+ * @brief Handle completion of a print job.
+ *
+ * @param m_ptr Message describing the completion event.
+ */
+static void do_done(message *m_ptr) noexcept {
+    int status = (rep_status(*m_ptr) == OK ? orig_count : ErrorCode::EIO);
     if (requesting_proc != CANCELED) {
         reply(REVIVE, caller, requesting_proc, status);
         if (status == ErrorCode::EIO)
@@ -175,112 +210,105 @@ static void do_done(message *m_ptr) noexcept { // PRIVATE -> static, modernized 
 /*===========================================================================*
  *				do_cancel				     *
  *===========================================================================*/
-PRIVATE do_cancel(m_ptr)
-message *m_ptr; /* pointer to the newly arrived message */
-{
-    /* Cancel a print request that has already started.  Usually this means that
-     * the process doing the printing has been killed by a signal.
-     */
-
+/**
+ * @brief Cancel a previously started print operation.
+ *
+ * @param m_ptr Pointer to the cancel message.
+ */
+static void do_cancel(message *m_ptr) noexcept {
     if (pr_busy == FALSE)
-        return;      /* this statement avoids race conditions */
-    pr_busy = FALSE; /* mark printer as idle */
-    pcount = 0;      /* causes printing to stop at next interrupt (pcount is std::size_t) */
-    requesting_proc = CANCELED; /* marks process as canceled */
+        return;
+    pr_busy = FALSE;
+    pcount = 0;
+    requesting_proc = CANCELED;
     reply(TASK_REPLY, m_ptr->m_source, proc_nr(*m_ptr), ErrorCode::EINTR);
 }
 
 /*===========================================================================*
  *				reply					     *
  *===========================================================================*/
-// Modernized K&R (already had types but now explicit), added noexcept
+/**
+ * @brief Send a reply to the file system.
+ *
+ * @param code Message type (TASK_REPLY or REVIVE).
+ * @param replyee Destination process.
+ * @param process User process involved.
+ * @param status Status or byte count.
+ */
 static void reply(int code, int replyee, int process, int status) noexcept {
-    /* Send a reply telling FS that printing has started or stopped. */
-
     message pr_mess;
-
-    pr_mess.m_type = code;          /* TASK_REPLY or REVIVE */
-    rep_status(pr_mess) = status;   /* count or ErrorCode::EIO */
-    rep_proc_nr(pr_mess) = process; /* which user does this pertain to */
-    send(replyee, &pr_mess);        /* send the message */
+    pr_mess.m_type = code;
+    rep_status(pr_mess) = status;
+    rep_proc_nr(pr_mess) = process;
+    send(replyee, &pr_mess);
 }
 
 /*===========================================================================*
  *				pr_error				     *
  *===========================================================================*/
-static void pr_error(int status) noexcept { // PRIVATE -> static, modernized signature, noexcept
-    /* The printer is not ready.  Display a message on the console telling why. */
-
+/**
+ * @brief Report hardware error conditions.
+ *
+ * @param status Status register bits returned by the device.
+ */
+static void pr_error(int status) noexcept {
     if (status & NO_PAPER)
-        printf("Printer is out of paper\n");
+        std::fputs(std::format("Printer is out of paper\n").c_str(), stdout);
     if ((status & OFF_LINE) == 0)
-        printf("Printer is not on line\n");
+        std::fputs(std::format("Printer is not on line\n").c_str(), stdout);
     if ((status & PR_ERROR) == 0)
-        printf("Printer error\n");
+        std::fputs(std::format("Printer error\n").c_str(), stdout);
 }
 
 /*===========================================================================*
  *				print_init				     *
  *===========================================================================*/
-static void print_init() noexcept { // PRIVATE -> static, modernized signature (was void), noexcept
-    /* Color display uses 0x378 for printer; mono display uses 0x3BC. */
-
-    int i;
+/**
+ * @brief Initialize the printer device and prepare the handle.
+ */
+static void print_init() noexcept {
     extern int color;
-
-    port_base = (color ? PR_COLOR_BASE : PR_MONO_BASE);
+    g_printer_device = std::make_unique<PrinterDevice>(color ? PR_COLOR_BASE : PR_MONO_BASE);
     pr_busy = FALSE;
-    port_out(port_base + 2, INIT_PRINTER); // port_out is noexcept
-    for (i = 0; i < DELAY_COUNT; i++)
-        ;                            /* delay loop */
-    port_out(port_base + 2, SELECT); // port_out is noexcept
 }
 
 /*===========================================================================*
  *				pr_char				     *
  *===========================================================================*/
-PUBLIC void pr_char() noexcept { // Added void return, noexcept
-    /* This is the interrupt handler.  When a character has been printed, an
-     * interrupt occurs, and the assembly code routine trapped to calls pr_char().
-     * One annoying problem is that the 8259A controller sometimes generates
-     * spurious interrupts to vector 15, which is the printer vector.  Ignore them.
-     */
-
+/**
+ * @brief Interrupt handler invoked after a character is printed.
+ */
+PUBLIC void pr_char() noexcept {
     int value, ch, i;
     char c;
-    extern unsigned char get_byte(unsigned int seg,
-                                  unsigned int off) noexcept; // Assuming modernized get_byte
+    extern unsigned char get_byte(unsigned int seg, unsigned int off) noexcept;
 
-    // pcount and orig_count are std::size_t
     if (pcount != orig_count)
-        port_out(INT_CTL, ENABLE); // port_out is noexcept
+        port_out(INT_CTL, ENABLE);
     if (pr_busy == FALSE)
-        return; /* spurious 8259A interrupt */
+        return;
 
-    while (pcount > 0) {                // pcount is std::size_t
-        port_in(port_base + 1, &value); /* get printer status (port_in is noexcept) */
+    while (pcount > 0) {
+        port_in(g_printer_device->base() + 1, &value);
         if (value == NORMAL_STATUS) {
-            /* Everything is all right.  Output another character. */
-            // es, offset are int. get_byte expects unsigned.
             c = static_cast<char>(
                 get_byte(static_cast<unsigned int>(es), static_cast<unsigned int>(offset)));
-            ch = c & BYTE;                          // BYTE is int
-            port_out(port_base, ch);                // port_out is noexcept
-            port_out(port_base + 2, ASSERT_STROBE); // port_out is noexcept
-            port_out(port_base + 2, NEGATE_STROBE); // port_out is noexcept
-            offset++;                               // offset is int
-            pcount--;                               // pcount is std::size_t
-            cum_count++;                            /* count characters output (int) */
+            ch = c & BYTE;
+            port_out(g_printer_device->base(), ch);
+            port_out(g_printer_device->base() + 2, ASSERT_STROBE);
+            port_out(g_printer_device->base() + 2, NEGATE_STROBE);
+            offset++;
+            pcount--;
+            cum_count++;
             for (i = 0; i < DELAY_COUNT; i++)
-                ; /* delay loop */
+                ;
         } else if (value == BUSY_STATUS) {
-            return; /* printer is busy; wait for interrupt*/
+            return;
         } else {
-            break; /* err: send message to printer task */
+            break;
         }
     }
 
-    /* Count is 0 or an error occurred; send message to printer task. */
     int_mess.m_type = TTY_O_DONE;
     rep_status(int_mess) = (pcount == 0 ? OK : value);
     interrupt(PRINTER, &int_mess);


### PR DESCRIPTION
## Summary
- encapsulate printer I/O base port in a RAII `PrinterDevice`
- format hardware error messages with `std::format`
- document printer driver functions with Doxygen comments

## Testing
- `doxygen "docs/Doxyfile 2"`
- `sphinx-build -b html docs/sphinx docs/sphinx/_build`
- `cmake -S . -B build`
- `cmake --build build`
- `cd build && ctest` *(fails: No test configuration file found)*

------
https://chatgpt.com/codex/tasks/task_e_68a81a5e8e808331b688baf9cf7d1321