### PR TITLE
Refactor xt_wini driver to modern enums and containers

### DIFF
--- a/docs/PROJECT_STATUS.md
+++ b/docs/PROJECT_STATUS.md
@@ -30,3 +30,4 @@ This document tracks repository maintenance and cleanup activities.
 ## 2025-08-22
 - Documented kernel system services with granular Doxygen comments.
 - Regenerated API reference via Doxygen and verified Sphinx+Breathe integration.
+- Modernized `kernel/xt_wini.cpp` with `enum class` and `std::array` and expanded Doxygen coverage.


### PR DESCRIPTION
## Summary
- replace legacy macros in xt_wini driver with `enum class` constructs and `constexpr` constants
- modernize driver state with `std::array` and document all routines using Doxygen
- note modernization of xt_wini in project status log

## Testing
- `clang-format-18 -i kernel/xt_wini.cpp`
- `doxygen docs/Doxyfile.in` *(warnings: tag INPUT does not exist; No files to be processed)*
- `sphinx-build -b html docs/sphinx docs/sphinx/_build` *(failure: No module named 'myst_parser')*
- `cmake -S . -B build`
- `cmake --build build`
- `ctest --test-dir build` *(no tests found)*

------
https://chatgpt.com/codex/tasks/task_e_68a81a5adab08331bbd49d10153e6765