### PR TITLE
Use RAII for exec images

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -117,7 +117,8 @@ std::array<uint8_t, 32> compute_shared_secret(const KeyPair& local,
 
 **User Mode Servers**
 - **PM (Process Manager)**: Process lifecycle and signal handling
-- **MM (Memory Manager)**: Virtual memory and paging policy  
+- **MM (Memory Manager)**: Virtual memory, paging policy, RAII-managed process
+  images via `std::filesystem`
 - **FS (File System)**: VFS layer with MINIX filesystem support
 - **RS (Resurrection Server)**: Service monitoring and restart
 - **DS (Data Store)**: Configuration and state persistence


### PR DESCRIPTION
## Summary
- Encapsulate exec file handling with RAII `ProcessImage` and directory guard
- Switch to `std::filesystem::path` for executable lookup
- Document RAII-managed process images in architecture overview

## Testing
- `cmake -S . -B build`
- `cmake --build build`
- `ctest --test-dir build`

------
https://chatgpt.com/codex/tasks/task_e_68a81a522e308331b6ee63355b7a2f01