### PR TITLE
refactor: add safe wrappers for program break

### DIFF
--- a/lib/brk.cpp
+++ b/lib/brk.cpp
@@ -1,30 +1,73 @@
 #include "../include/lib.hpp" // C++23 header
+#include <expected>
 
-// Current end of the data segment managed by brk/sbrk.
+/// Current end of the data segment managed by brk/sbrk.
 extern char *brksize;
 
-// Set the program break to the address specified by 'addr'.
-char *brk(char *addr) {
-    int k;
+namespace xinim {
 
-    k = callm1(MM, BRK, 0, 0, 0, addr, NIL_PTR, NIL_PTR);
-    if (k == OK) {
+/**
+ * @brief Safe C++ interface for manipulating the program break.
+ *
+ * The functions wrap the underlying system calls and use std::expected
+ * to report errors instead of relying on sentinel values.
+ */
+class ProgramBreakManager final {
+  public:
+    ProgramBreakManager() = delete;
+    ProgramBreakManager(const ProgramBreakManager &) = delete;
+    ProgramBreakManager &operator=(const ProgramBreakManager &) = delete;
+
+    /**
+     * @brief Set the program break to the specified address.
+     * @param addr Desired end of the data segment.
+     * @return std::expected<void, int> Empty on success, otherwise error code.
+     */
+    [[nodiscard]] static std::expected<void, int> set(char *addr) noexcept;
+
+    /**
+     * @brief Increment the program break by a given amount.
+     * @param incr Number of bytes to grow the data segment.
+     * @return std::expected<char *, int> Previous break on success; error code otherwise.
+     */
+    [[nodiscard]] static std::expected<char *, int> increment(int incr) noexcept;
+};
+
+inline std::expected<void, int> ProgramBreakManager::set(char *addr) noexcept {
+    if (auto k = callm1(MM, BRK, 0, 0, 0, addr, NIL_PTR, NIL_PTR); k == OK) {
         brksize = M.m2_p1();
-        return (NIL_PTR);
-    } else {
-        return ((char *)-1);
+        return {};
     }
+    return std::unexpected(k);
 }
 
-// Increment the program break by 'incr' bytes.
-char *sbrk(int incr) {
-    char *newsize, *oldsize;
-    extern int endv, dorgv;
+inline std::expected<char *, int> ProgramBreakManager::increment(int incr) noexcept {
+    char *oldsize = brksize;
+    char *newsize = brksize + incr;
+    if (auto result = set(newsize); result) {
+        return oldsize;
+    }
+    return std::unexpected(result.error());
+}
 
-    oldsize = brksize;
-    newsize = brksize + incr;
-    if (brk(newsize) == 0)
-        return (oldsize);
-    else
-        return ((char *)-1);
+} // namespace xinim
+
+/**
+ * @brief C-compatible wrapper for setting the program break.
+ * @param addr Desired end of the data segment.
+ * @return NIL_PTR on success, `(char*)-1` on failure.
+ */
+extern "C" char *brk(char *addr) {
+    auto result = xinim::ProgramBreakManager::set(addr);
+    return result ? NIL_PTR : reinterpret_cast<char *>(-1);
+}
+
+/**
+ * @brief C-compatible wrapper for incrementing the program break.
+ * @param incr Number of bytes to grow the data segment.
+ * @return Previous break on success, `(char*)-1` on failure.
+ */
+extern "C" char *sbrk(int incr) {
+    auto result = xinim::ProgramBreakManager::increment(incr);
+    return result ? result.value() : reinterpret_cast<char *>(-1);
 }


### PR DESCRIPTION
## Summary
- wrap brk/sbrk system calls with ProgramBreakManager using std::expected
- expose C wrappers over the new safe abstractions
- document brk handling with Doxygen comments

## Testing
- `clang-format -i lib/brk.cpp`
- `cmake --build build --target doc`


------
https://chatgpt.com/codex/tasks/task_e_68a81a42eac48331a8699484c425233b