### PR TITLE
feat: add optional getenv wrapper

### DIFF
--- a/lib/getenv.cpp
+++ b/lib/getenv.cpp
@@ -1,18 +1,40 @@
-// Modern C++23 implementation of the classic getenv routine.
-#include <cstring>
+/**
+ * @file
+ * @brief Safe wrapper around the C library's environment lookup.
+ *
+ * This translation unit defines a modern interface for querying process
+ * environment variables.  Instead of exposing raw C strings, the function
+ * returns a `std::optional<std::string>` which conveys the absence of a value
+ * without resorting to null pointers.  The implementation delegates to
+ * `std::getenv` provided by the standard library and is therefore entirely
+ * portable.
+ */
 
-// The environment is provided by the hosting process.
-extern "C" char **environ;
+#include <cstdlib>
+#include <optional>
+#include <string>
+#include <string_view>
 
-// Retrieve the value of the environment variable ``name`` or ``nullptr``.
-char *getenv(const char *name) {
-    size_t len = std::strlen(name);
-    for (char **env = environ; *env != nullptr; ++env) {
-        const char *entry = *env;
-        if (std::strncmp(entry, name, len) == 0 && entry[len] == '=') {
-            // Cast away const for legacy compatibility.
-            return const_cast<char *>(entry + len + 1);
-        }
+namespace xinim {
+
+/**
+ * @brief Retrieve the value of an environment variable.
+ *
+ * This function wraps `std::getenv` and converts the result into an
+ * `std::optional`.  If the environment variable identified by @p name exists,
+ * its value is returned as a `std::string`; otherwise `std::nullopt` is
+ * returned.  The wrapper avoids the pitfalls associated with direct use of
+ * C-string pointers and is safe against accidental modification.
+ *
+ * @param name Name of the environment variable to query.
+ * @return `std::optional<std::string>` containing the variable's value when
+ *         present; `std::nullopt` otherwise.
+ */
+[[nodiscard]] std::optional<std::string> getenv(std::string_view name) {
+    if (const char *value = std::getenv(name.data())) {
+        return std::string{value};
     }
-    return nullptr;
+    return std::nullopt;
 }
+
+} // namespace xinim


### PR DESCRIPTION
## Summary
- replace manual environment scan with std::getenv wrapper returning std::optional
- document environment query helper with Doxygen comments

## Testing
- `cmake -S . -B build`
- `cmake --build build`
- `cmake --build build --target doc` *(fails: No rule to make target 'doc')*


------
https://chatgpt.com/codex/tasks/task_e_68a81a3874ac8331bc8c1c44690c4b5a