### PR TITLE
Add Doxygen headers to core files

### DIFF
--- a/commands/cal.cpp
+++ b/commands/cal.cpp
@@ -2,7 +2,7 @@
  * @file cal.cpp
  * @brief Modern C++23 calendar utility
  * @author Martin Minow (original), modernized for XINIM
- * 
+ *
  * A calendar printing utility that displays monthly or yearly calendars.
  * Fully modernized with C++23 features including constexpr, strong typing,
  * and static assertions for compile-time validation.
@@ -52,12 +52,12 @@ constexpr std::array<std::string_view, 13> monthname = {
  * @param argc Number of command line arguments
  * @param argv Array of command line argument strings
  * @return IO_SUCCESS on success, IO_ERROR on failure
- * 
+ *
  * Parses command line arguments to determine whether to display a month,
  * year, or specific month within a year. Handles argument ambiguity
  * intelligently based on value ranges.
  */
-int main(int argc, char* argv[]) {
+int main(int argc, char *argv[]) {
     if (argc <= 1) {
         usage(usage_msg);
         return IO_ERROR;
@@ -66,7 +66,7 @@ int main(int argc, char* argv[]) {
     try {
         const int arg1val = std::stoi(argv[1]);
         const auto arg1len = std::strlen(argv[1]);
-        
+
         if (argc == 2) {
             // Single argument: small values (≤12) with ≤2 digits are months,
             // larger values are years
@@ -78,7 +78,7 @@ int main(int argc, char* argv[]) {
         } else if (argc == 3) {
             // Two arguments: handle both "month year" and "year month" formats
             const int arg2val = std::stoi(argv[2]);
-            
+
             if (arg1len > 2) {
                 // First argument is likely the year (more than 2 digits)
                 domonth(arg1val, arg2val);
@@ -90,19 +90,21 @@ int main(int argc, char* argv[]) {
             usage(usage_msg);
             return IO_ERROR;
         }
-    } catch (const std::exception& e) {
+    } catch (const std::exception &e) {
         usage(badarg);
         return IO_ERROR;
     }
-    
+
     return IO_SUCCESS;
 }
 
-static void doyear(int year)
-/*
- * Print the calendar for an entire year.
+/**
+ * @brief Print the calendar for an entire year.
+ *
+ * @param year Year number in Gregorian
+ * calendar.
  */
-{
+static void doyear(int year) {
     register int month;
 
     if (year < 1 || year > 9999)
@@ -115,7 +117,8 @@ static void doyear(int year)
         printf("%12s%23s%23s\n", monthname[month], monthname[month + 1], monthname[month + 2]);
         printf("%s   %s   %s\n", weekday, weekday, weekday);
         calendar(year, month + 0, 0);
-        calendar(year, month + 1, 1);        calendar(year, month + 2, 2);
+        calendar(year, month + 1, 1);
+        calendar(year, month + 2, 2);
         output(3);
         // Static assertion ensures MONTHS_PER_LINE is 3 for the above logic
         static_assert(MONTHS_PER_LINE == 3, "MONTHS_PER_LINE must be 3 for quarterly display");
@@ -123,11 +126,14 @@ static void doyear(int year)
     printf("\n\n\n");
 }
 
-static void domonth(int year, int month)
-/*
- * Do one specific month -- note: no longer used
+/**
+ * @brief Print the calendar for a single month.
+ *
+ * @param year Year number.
+ * @param month
+ * Month number (1-12).
  */
-{
+static void domonth(int year, int month) {
     if (year < 1 || year > 9999)
         usage(badarg);
     if (month <= 0 || month > 12)
@@ -138,11 +144,13 @@ static void domonth(int year, int month)
     printf("\n\n");
 }
 
-static void output(int nmonths) /* Number of months to do */
-/*
- * Clean up and output the text.
+/**
+ * @brief Emit formatted calendar text for collected months.
+ *
+ * @param nmonths Number of
+ * months to output.
  */
-{
+static void output(int nmonths) {
     register int week;
     register int month;
     register char *outp;
@@ -171,11 +179,15 @@ static void output(int nmonths) /* Number of months to do */
     }
 }
 
-static void calendar(int year, int month, int index) /* Which of the three months */
-/*
- * Actually build the calendar for this month.
+/**
+ * @brief Build the calendar layout for a given month.
+ *
+ * @param year Year being rendered.
+ *
+ * @param month Month being rendered.
+ * @param index Column index in the output layout.
  */
-{
+static void calendar(int year, int month, int index) {
     register char *tp;
     int week;
     register int wday;
@@ -201,9 +213,12 @@ static void calendar(int year, int month, int index) /* Which of the three month
     }
 }
 
+/**
+ * @brief Print usage information and terminate.
+ *
+ * @param s Usage message to display.
+ */
 static void usage(char *s) {
-    /* Fatal parameter error. */
-
     fprintf(stderr, "%s", s);
     exit(IO_ERROR);
 }
@@ -241,22 +256,30 @@ static struct {
 static int day_month[] = {/* 30 days hath September...		*/
                           0, 31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31};
 
-int static int date(int year, int month, int week, int wday) /* Calendar date being computed */
-/*
- * Return the date of the month that fell on this week and weekday.
- * Return zero if it's out of range.
+/**
+ * @brief Compute the date within a month for a given week and weekday.
+ *
+ * @param year Year
+ * number.
+ * @param month Month number.
+ * @param week Week index starting at 0.
+ * @param wday
+ * Weekday index starting at 0.
+ * @return Day of month or 0 if out of range.
  */
-{
+int static int date(int year, int month, int week, int wday) {
     setmonth(year, month);
     return (getdate(week, wday));
 }
 
-static void setmonth(int year, int month)
-/*
- * Setup the parameters needed to compute this month
- * (stored in the info structure).
+/**
+ * @brief Initialise calendar information for a given month.
+ *
+ * @param year Year number.
+ *
+ * @param month Month number.
  */
-{
+static void setmonth(int year, int month) {
     register int i;
 
     if (month < 1 || month > 12) { /* Verify caller's parameters	*/
@@ -300,6 +323,14 @@ static void setmonth(int year, int month)
     info.dow_first %= 7; /* Now it's Sunday to Saturday	*/
 }
 
+/**
+ *  Determine the date for a given week and weekday.
+ *
+ *  week Week index starting at 0.
+ *
+ * wday Weekday index starting at 0.
+ *  Day of month or 0 if not in range.
+ */
 static int getdate(int week, int wday) register int today;
 
 /*

--- a/kernel/mpx64.cpp
+++ b/kernel/mpx64.cpp
@@ -1,3 +1,8 @@
+/**
+ * @file mpx64.cpp
+ * @brief 64-bit context switch and interrupt stubs.
+ */
+
 #include "../h/const.hpp"
 #include "../h/type.hpp"
 #include "../include/defs.h"
@@ -32,7 +37,7 @@ extern char k_stack[K_STACK_BYTES];
 /*===========================================================================*
  *                              save                                         *
  *===========================================================================*/
-/* Save registers to the current process and switch stacks. */
+/** @brief Save registers to the current process and switch stacks. */
 void save(void) NAKED;
 void save(void) {
     __asm__ volatile("push %%rax\n\t"
@@ -101,7 +106,7 @@ void save(void) {
 /*===========================================================================*
  *                              restart                                      *
  *===========================================================================*/
-/* Restore registers and continue the interrupted task. */
+/** @brief Restore registers and continue the interrupted task. */
 void restart(void) NAKED;
 void restart(void) {
     __asm__ volatile("movq _proc_ptr(%%rip), %%r15\n\t"
@@ -135,7 +140,7 @@ void restart(void) {
 /*===========================================================================*
  *                              isr_default                                  *
  *===========================================================================*/
-/* Default interrupt service routine. */
+/** @brief Default interrupt service routine. */
 void isr_default(void) NAKED;
 void isr_default(void) {
     __asm__ volatile("call save\n\t"
@@ -146,7 +151,7 @@ void isr_default(void) {
 /*===========================================================================*
  *                              isr_clock                                    *
  *===========================================================================*/
-/* Clock interrupt service routine. */
+/** @brief Clock interrupt service routine. */
 void isr_clock(void) NAKED;
 void isr_clock(void) {
     __asm__ volatile("call save\n\t"
@@ -157,7 +162,7 @@ void isr_clock(void) {
 /*===========================================================================*
  *                              isr_keyboard                                 *
  *===========================================================================*/
-/* Keyboard interrupt service routine. */
+/** @brief Keyboard interrupt service routine. */
 void isr_keyboard(void) NAKED;
 void isr_keyboard(void) {
     __asm__ volatile("call save\n\t"
@@ -168,7 +173,7 @@ void isr_keyboard(void) {
 /*===========================================================================*
  *                              s_call                                       *
  *===========================================================================*/
-/* System call entry point. */
+/** @brief System call entry point. */
 void s_call(void) NAKED;
 void s_call(void) {
     __asm__ volatile("call save\n\t"
@@ -183,7 +188,7 @@ void s_call(void) {
 /*===========================================================================*
  *                              lpr_int                                      *
  *===========================================================================*/
-/* Printer interrupt service routine. */
+/** @brief Printer interrupt service routine. */
 void lpr_int(void) NAKED;
 void lpr_int(void) {
     __asm__ volatile("call save\n\t"
@@ -194,7 +199,7 @@ void lpr_int(void) {
 /*===========================================================================*
  *                              disk_int                                     *
  *===========================================================================*/
-/* Disk interrupt service routine. */
+/** @brief Disk interrupt service routine. */
 void disk_int(void) NAKED;
 void disk_int(void) {
     __asm__ volatile("call save\n\t"
@@ -207,7 +212,7 @@ void disk_int(void) {
 /*===========================================================================*
  *                              divide                                       *
  *===========================================================================*/
-/* Divide trap handler. */
+/** @brief Divide trap handler. */
 void divide(void) NAKED;
 void divide(void) {
     __asm__ volatile("call save\n\t"
@@ -218,7 +223,7 @@ void divide(void) {
 /*===========================================================================*
  *                              trp                                          *
  *===========================================================================*/
-/* General trap handler. */
+/** @brief General trap handler. */
 void trp(void) NAKED;
 void trp(void) {
     __asm__ volatile("call save\n\t"

--- a/kernel/syscall.cpp
+++ b/kernel/syscall.cpp
@@ -1,3 +1,8 @@
+/**
+ * @file syscall.cpp
+ * @brief x86_64 system call entry and configuration.
+ */
+
 #include "../include/defs.h"
 #include "const.hpp"
 #include "glo.hpp"
@@ -9,7 +14,9 @@
 /*===========================================================================*
  *                              init_syscall_msrs                            *
  *===========================================================================*/
-/* Configure system call Model Specific Registers. */
+/**
+ * @brief Configure system-call related model specific registers.
+ */
 void init_syscall_msrs() noexcept { // (void) -> (), noexcept
     asm volatile("mov $0xC0000080, %%ecx\n\t"
                  "rdmsr\n\t"
@@ -34,9 +41,11 @@ void init_syscall_msrs() noexcept { // (void) -> (), noexcept
 /*===========================================================================*
  *                              syscall_entry                                *
  *===========================================================================*/
-/* Entry point for user mode syscalls. */
+/**
+ * @brief Entry point for user-mode system calls.
+ */
 void syscall_entry() noexcept NAKED; // (void) -> (), noexcept
-void syscall_entry() noexcept {     // (void) -> (), noexcept
+void syscall_entry() noexcept {      // (void) -> (), noexcept
     __asm__ volatile("call save\n\t"
                      "mov %rdi, %rax\n\t"
                      "mov %rdx, %rdi\n\t"

--- a/lib/syscall_x86_64.cpp
+++ b/lib/syscall_x86_64.cpp
@@ -1,4 +1,8 @@
 #ifdef __x86_64__
+/**
+ * @file syscall_x86_64.cpp
+ * @brief User-space syscall wrappers for x86_64.
+ */
 #include "../h/com.hpp"
 #include "../h/const.hpp"
 #include "../h/type.hpp"


### PR DESCRIPTION
## Summary
- document archive utility structures and helpers with Doxygen
- document calendar tool and core date routines
- add file-level headers and function docs to kernel syscall and context stubs
- document x86_64 userspace syscall wrappers

## Testing
- `cmake -S . -B build`
- `cmake --build build -j2`


------
https://chatgpt.com/codex/tasks/task_e_68a81a0745c8833189bae924e723a88c