### PR TITLE
docs: broaden Doxygen search paths

### DIFF
--- a/docs/Doxyfile.in
+++ b/docs/Doxyfile.in
@@ -106,7 +106,7 @@ WARN_LOGFILE           =
 #---------------------------------------------------------------------------
 # Configuration options related to the input files
 #---------------------------------------------------------------------------
-INPUT                  = @DOXYGEN_INPUT@
+INPUT                  = @DOXYGEN_INPUT@ commands fs mm lib
 INPUT_ENCODING         = UTF-8
 FILE_PATTERNS          = *.cpp \
                          *.hpp \


### PR DESCRIPTION
## Summary
- include commands, fs, mm and lib directories in Doxygen input
- ensure Doxygen parses C++ sources via *.cpp and *.hpp patterns

## Testing
- `doxygen /tmp/Doxyfile`

------
https://chatgpt.com/codex/tasks/task_e_68a81a148ab083318c0f78774935cfa9