### PR TITLE
Document kernel initialization and scheduling assumptions

### DIFF
--- a/kernel/clock.cpp
+++ b/kernel/clock.cpp
@@ -202,6 +202,8 @@ static void do_set_time(message *m_ptr) noexcept { boot_time = new_time(*m_ptr) 
  * handles scheduling related bookkeeping. This function is invoked on
  * every timer interrupt.
  *
+ * @pre Programmable interval timer was configured by ::init_clock.
+ * @post Pending alarms are dispatched and scheduler counters updated.
  */
 static void do_clocktick() noexcept {
 
@@ -247,7 +249,11 @@ static void do_clocktick() noexcept {
     /* If a user process has been running too long, pick another one. */
     if (--sched_ticks == 0) {
         if (bill_ptr == prev_ptr)
-            sched();              /* process has run too long */
+            /**
+             * @brief Round-robin scheduling decision.
+             * @warning Assumes a single CPU; SMP fairness needs review.
+             */
+            sched(); /* process has run too long */
         sched_ticks = SCHED_RATE; /* reset quantum */
         prev_ptr = bill_ptr;      /* new previous process */
 
@@ -291,6 +297,9 @@ static void accounting() noexcept { // Changed (void) to ()
  * Programs timer channel zero to generate periodic interrupts at the
  * system tick rate defined by @c HZ.
  *
+ * @pre I/O ports @c TIMER0 and @c TIMER_MODE must be accessible.
+ * @post Timer generates square-wave interrupts at @c HZ frequency.
+ * @todo Replace legacy PIT with HPET/APIC timer for higher precision.
  */
 static void init_clock() noexcept {
 

--- a/kernel/idt64.cpp
+++ b/kernel/idt64.cpp
@@ -76,6 +76,10 @@ static void idt_set_gate(int n, void (*handler)() noexcept, unsigned int ist) no
 
 /**
  * @brief Initialize the 64-bit IDT and TSS.
+ *
+ * @pre Global descriptor table must contain a valid TSS descriptor.
+ * @post Interrupt vectors for clock and keyboard are installed.
+ * @warning Currently assumes legacy PIC remapping; APIC setup pending.
  */
 void idt_init() noexcept {
     int i;

--- a/kernel/main.cpp
+++ b/kernel/main.cpp
@@ -12,6 +12,10 @@
  * The implementation currently acts as a placeholder and simply prints
  * a startup banner. Real initialization logic will be added once the
  * supporting subsystems are in place.
+ *
+ * @pre Executed in early boot context with interrupts disabled.
+ * @post Returns only for testing; real kernel would not return.
+ * @todo Wire up full subsystem initialization and scheduling start-up.
  */
 int main() noexcept {
     Console::printf("XINIM kernel stub\n");

--- a/kernel/memory.cpp
+++ b/kernel/memory.cpp
@@ -84,6 +84,10 @@ extern void phys_copy(void *dst, const void *src, std::size_t num_bytes) noexcep
  *
  * Waits for driver messages and services /dev/null, /dev/mem,
  * /dev/kmem and /dev/ram requests.
+ *
+ * @pre Memory manager has initialized RAM device parameters.
+ * @post Task replies to each request; loop runs indefinitely.
+ * @warning No interrupt-driven I/O; all requests are synchronous.
  */
 PUBLIC void mem_task() noexcept {
 

--- a/kernel/net_driver.cpp
+++ b/kernel/net_driver.cpp
@@ -1,6 +1,7 @@
 /**
  * @file net_driver.cpp
  * @brief Robust UDP/TCP networking backend for Lattice IPC (IPv4/IPv6, C++23).
+ * @warning Lacks zero-copy optimizations; consider io_uring for future refactor.
  */
 
 #include "net_driver.hpp"
@@ -143,6 +144,9 @@ void tcp_accept_loop() {
  * @param cfg Configuration parameters controlling socket ports and queue
  *            behaviour.
  * @throws std::system_error If socket creation or binding fails.
+ * @pre Network interfaces are up and accessible.
+ * @post I/O threads are spawned and sockets bound to @p cfg.port.
+ * @warning No hardware IRQ handling; relies solely on OS-level buffering.
  */
 void init(const Config &cfg) {
     g_cfg = cfg;

--- a/kernel/paging.cpp
+++ b/kernel/paging.cpp
@@ -19,6 +19,9 @@ static uint64_t next_kernel_va;   // PRIVATE -> static
  *===========================================================================*/
 /**
  * @brief Initialize kernel paging structures.
+ *
+ * @pre Boot memory allocator is operational.
+ * @post Kernel PML4 cleared and higher-half mapping base set.
  */
 PUBLIC void paging_init() noexcept { // (void) -> (), noexcept
     int i;
@@ -37,6 +40,9 @@ PUBLIC void paging_init() noexcept { // (void) -> (), noexcept
  * @param bytes Size in bytes to allocate.
  * @param flags Allocation flags (unused).
  * @return Pointer to allocated virtual address space.
+ *
+ * @pre ::paging_init has prepared @c next_kernel_va.
+ * @post Reserved region is advanced by requested number of pages.
  */
 // bytes is u64_t (uint64_t)
 PUBLIC void *alloc_virtual(uint64_t bytes, int flags) noexcept {
@@ -60,6 +66,10 @@ PUBLIC void *alloc_virtual(uint64_t bytes, int flags) noexcept {
  * @param pa    Physical address to map to.
  * @param flags Mapping attributes (unused).
  * @return OK on success.
+ *
+ * @pre Corresponding PML4 entry has been allocated.
+ * @post Lower level page tables remain unallocated (stub).
+ * @todo Implement full 4-level page table population.
  */
 // va, pa are virt_addr64, phys_addr64 (both uint64_t)
 PUBLIC int map_page(uint64_t va, uint64_t pa, int flags) noexcept {

--- a/kernel/proc.cpp
+++ b/kernel/proc.cpp
@@ -34,6 +34,8 @@
  *
  * @param task   Task number to notify.
  * @param m_ptr  Message payload for the task.
+ * @pre Interrupts are disabled and @p task is a valid kernel task.
+ * @post Target task receives the interrupt message or it is queued.
  */
 PUBLIC void interrupt(int task, message *m_ptr) {
     /* An interrupt has occurred.  Schedule the task that handles it. */
@@ -425,6 +427,10 @@ PUBLIC void unready(struct proc *rp) {
  * @brief Reschedule a process after it has exhausted its time slice.
  *
  * Performs a round-robin rotation within the current priority queue.
+ *
+ * @pre Ready queue for the current priority is non-empty.
+ * @post Next runnable process is placed at queue head.
+ * @warning SMP-aware load balancing remains a TODO.
  */
 PUBLIC void sched() { // Modernized signature
     /* The current process has run too long.  If another low priority (user)

--- a/kernel/service.cpp
+++ b/kernel/service.cpp
@@ -44,6 +44,10 @@ bool ServiceManager::has_path(xinim::pid_t start, xinim::pid_t target,
  * @brief Register a new service with dependency information.
  *
  * Contracts are created lazily for each service and track restart counts.
+ *
+ * @pre @p pid is a valid process ID and not already registered.
+ * @post Service is marked running and scheduled for execution.
+ * @warning Scheduler queue does not yet enforce priority inheritance.
  */
 void ServiceManager::register_service(xinim::pid_t pid, const std::vector<xinim::pid_t> &deps,
                                       std::uint32_t limit) {
@@ -61,6 +65,11 @@ void ServiceManager::register_service(xinim::pid_t pid, const std::vector<xinim:
     }
 
     info.running = true;
+    /**
+     * @brief Place service onto ready queue.
+     * @pre Scheduler subsystem initialized via sched::init().
+     * @post Service will eventually be dispatched by scheduler.
+     */
     sched::scheduler.enqueue(pid);
 }
 

--- a/kernel/system.cpp
+++ b/kernel/system.cpp
@@ -83,6 +83,10 @@ PRIVATE char sig_stuff[SIG_PUSH_BYTES]; /* used to send signals to processes */
  *
  * Waits for system requests and routes them to the correct handler.
  * Runs continuously as a dedicated task and never returns.
+ *
+ * @pre Message passing system initialized; interrupts enabled.
+ * @post This routine never returns; termination indicates fatal error.
+ * @warning Lacks priority-based handling of competing system tasks.
  */
 PUBLIC void sys_task() noexcept { // Added void return, noexcept
     /* Main entry point of sys_task.  Get the message and dispatch on type. */

--- a/kernel/table.cpp
+++ b/kernel/table.cpp
@@ -46,6 +46,13 @@ extern void printer_task() noexcept;
  * The order of the names here MUST agree with the numerical values assigned to
  * the tasks in ../h/com.hpp.
  */
+/**
+ * @brief Kernel task start table.
+ *
+ * @pre Task entry points such as ::sys_task and ::clock_task are valid.
+ * @post Scheduler uses this table during boot to spawn tasks.
+ * @warning Placeholder @c nullptr entries remain for unimplemented tasks.
+ */
 // Changed array type from int(*)() to void(*)() noexcept
 void (*task[NR_TASKS + INIT_PROC_NR + 1])() noexcept = {
     printer_task,

--- a/kernel/tty.cpp
+++ b/kernel/tty.cpp
@@ -197,6 +197,11 @@ PRIVATE char m24[] = {0,    033,  '!',  '"',  '#',  '$',  '%',  '&',  047,  '(',
 /*===========================================================================*
  *				tty_task				     *
  *===========================================================================*/
+/**
+ * @brief Terminal task main loop.
+ * @pre tty_init() has configured device tables.
+ * @post Runs indefinitely handling TTY requests and interrupts.
+ */
 PUBLIC void tty_task() noexcept { // Added void return, noexcept
     /* Main routine of the terminal task. */
 
@@ -837,6 +842,11 @@ PRIVATE int vid_port;      /* I/O port for accessing 6845 */
 /*===========================================================================*
  *				keyboard				     *
  *===========================================================================*/
+/**
+ * @brief Interrupt handler for keyboard events.
+ * @pre Executing on keyboard IRQ with interrupts disabled.
+ * @post Raw scancode is acknowledged and queued for tty_task().
+ */
 PUBLIC keyboard() {
     /* A keyboard interrupt has occurred.  Process it. */
 
@@ -1166,6 +1176,12 @@ static void beep(int f) noexcept { // PRIVATE -> static, modernized signature, n
 /*===========================================================================*
  *				tty_init				     *
  *===========================================================================*/
+/**
+ * @brief Initialise TTY descriptor tables.
+ *
+ * @pre Console driver initialised.
+ * @post All TTY structures set to default line discipline.
+ */
 static void tty_init() noexcept { // PRIVATE -> static, modernized signature, noexcept
     /* Initialize the tty tables. */
 

--- a/kernel/wait_graph.cpp
+++ b/kernel/wait_graph.cpp
@@ -23,6 +23,13 @@ bool WaitForGraph::has_path(xinim::pid_t from, xinim::pid_t to,
     return false;
 }
 
+/**
+ * @brief Insert a wait dependency edge.
+ *
+ * @pre Both @p src and @p dst refer to valid process identifiers.
+ * @post Detects cycles and rolls back insertion if a cycle would form.
+ * @warning Current implementation is O(E); consider incremental SCC.
+ */
 bool WaitForGraph::add_edge(xinim::pid_t src, xinim::pid_t dst) {
     edges_[src].push_back(dst);
     std::unordered_set<xinim::pid_t> visited;


### PR DESCRIPTION
## Summary
- Annotate clock tick handler with hardware pre/postconditions and scheduling warnings
- Document IDT setup, scheduler calls, and service registration with TODOs and warnings
- Add pre/postcondition comments across paging, memory, TTY, and networking modules

## Testing
- `make -C kernel WINI_DRIVER=pc` *(fails: variable 'base' set but not used and string constant conversion errors in dmp.cpp)*

------
https://chatgpt.com/codex/tasks/task_e_68a819e742488331bb78e51eeaef7f5a