### PR TITLE
Add pre-commit hooks for C++ analysis

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,21 @@
+repos:
+  - repo: local
+    hooks:
+      - id: clang-format
+        name: clang-format
+        entry: tools/pre-commit-clang-format.sh
+        language: script
+        files: '\.(c|cc|cpp|cxx|h|hh|hpp)$'
+        pass_filenames: false
+      - id: clang-tidy
+        name: clang-tidy
+        entry: tools/run_clang_tidy.sh
+        language: script
+        files: '\.(c|cc|cpp|cxx|h|hh|hpp)$'
+        pass_filenames: false
+      - id: cppcheck
+        name: cppcheck
+        entry: tools/run_cppcheck.sh
+        language: script
+        files: '\.(c|cc|cpp|cxx|h|hh|hpp)$'
+        pass_filenames: false

--- a/docs/BUILD.md
+++ b/docs/BUILD.md
@@ -4,6 +4,24 @@
 - CMake 3.5 or newer
 - Clang 18 toolchain and LLVM utilities (`lld`, `lldb`)
 - Doxygen for API documentation
+- pre-commit for Git hook management (`pip install pre-commit`)
+
+## Pre-commit Hooks
+Install the project's hooks after cloning to automatically run formatting and
+static analysis helpers located under `tools/`:
+
+```bash
+pre-commit install
+```
+
+Run the entire suite manually before pushing changes:
+
+```bash
+pre-commit run --all-files
+```
+
+These hooks chain `clang-format`, `clang-tidy`, and `cppcheck` through local
+scripts to enforce style and detect issues early.
 
 ## Configure
 ```bash


### PR DESCRIPTION
## Summary
- add pre-commit configuration using helper scripts for clang-format, clang-tidy, and cppcheck
- document pre-commit setup in build guide

## Testing
- `pre-commit run --files .pre-commit-config.yaml docs/BUILD.md`

------
https://chatgpt.com/codex/tasks/task_e_68a90c09171c83318f6d70f0d5d9eb09