### PR TITLE
chore: add C++ pre-commit formatting and compile checks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,17 @@
+repos:
+  - repo: https://github.com/pre-commit/mirrors-clang-format
+    rev: v20.1.8
+    hooks:
+      - id: clang-format
+        types: [c++]
+        additional_dependencies: []
+
+  - repo: local
+    hooks:
+      - id: cxx-compile
+        name: "C++ compilation"
+        entry: g++
+        language: system
+        types: [c++]
+        exclude: '\\.(h|hpp|hh|hxx)$'
+        args: ['-std=c++23', '-Wall', '-Wextra', '-Werror', '-pedantic', '-fsyntax-only']

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,31 @@
+# Contributing Guidelines
+
+This project employs [pre-commit](https://pre-commit.com) to guarantee stylistic and
+compilability checks before any commit reaches the repository.
+
+## Quick start
+1. Install the tooling:
+   ```bash
+   pip install pre-commit
+   ```
+2. Register the git hook:
+   ```bash
+   pre-commit install
+   ```
+3. Run checks manually (optional):
+   ```bash
+   pre-commit run --files <path/to/file.cpp>
+   ```
+
+The configured hooks perform two actions on every staged C++ source file:
+
+* **Formatting** – `clang-format` enforces the project's `.clang-format` style.
+* **Compilation** – `g++ -std=c++23 -Wall -Wextra -Werror -pedantic -fsyntax-only`
+  validates that the file passes a pedantic compilation step without producing
+  warnings.
+
+To update hook versions, execute:
+```bash
+pre-commit autoupdate
+```
+


### PR DESCRIPTION
## Summary
- add pre-commit config for clang-format and a g++ pedantic compile check
- document pre-commit usage in CONTRIBUTING

## Testing
- `pre-commit run --files tmp.cpp`
- `pre-commit run --files .pre-commit-config.yaml CONTRIBUTING.md`


------
https://chatgpt.com/codex/tasks/task_e_68a90bf89f9c8331aa160ba34482118d