### PR TITLE
Configure Doxygen output paths

### DIFF
--- a/docs/Doxyfile
+++ b/docs/Doxyfile
@@ -8,8 +8,8 @@ DOXYFILE_ENCODING      = UTF-8
 PROJECT_NAME           = "XINIM"
 PROJECT_NUMBER         = "2.0"
 PROJECT_BRIEF          = "Modern C++23 MINIX filesystem utilities with type safety and performance"
-PROJECT_LOGO           = 
-OUTPUT_DIRECTORY       = @DOXYGEN_OUTPUT_DIRECTORY@
+PROJECT_LOGO           =
+OUTPUT_DIRECTORY       = docs/doxygen
 CREATE_SUBDIRS         = YES
 ALLOW_UNICODE_NAMES    = NO
 OUTPUT_LANGUAGE        = English
@@ -106,7 +106,7 @@ WARN_LOGFILE           =
 #---------------------------------------------------------------------------
 # Configuration options related to the input files
 #---------------------------------------------------------------------------
-INPUT                  = @DOXYGEN_INPUT@ commands \
+INPUT                  = commands \
                          fs \
                          kernel \
                          mm \


### PR DESCRIPTION
## Summary
- Set Doxygen to emit generated documentation into `docs/doxygen`
- Enumerate `commands`, `fs`, `kernel`, `mm`, `lib`, and `include` as explicit input sources

## Testing
- `doxygen docs/Doxyfile`

------
https://chatgpt.com/codex/tasks/task_e_68aa5a92a97c8331a34308faf12621b3