### PR TITLE
Enable Doxygen warnings

### DIFF
--- a/docs/Doxyfile
+++ b/docs/Doxyfile
@@ -95,7 +95,7 @@ CITE_BIB_FILES         =
 # Configuration options related to warning and progress messages
 #---------------------------------------------------------------------------
 QUIET                  = NO
-WARNINGS               = NO
+WARNINGS               = YES
 WARN_IF_UNDOCUMENTED   = YES
 WARN_IF_DOC_ERROR      = YES
 WARN_NO_PARAMDOC       = NO


### PR DESCRIPTION
## Summary
- Enable warnings in Doxygen configuration to surface documentation issues

## Testing
- `doxygen docs/Doxyfile`

------
https://chatgpt.com/codex/tasks/task_e_68aa5a93bf748331b486d94207e86d40