### PR TITLE
docs(mm): reference paging.h

### DIFF
--- a/include/paging.h
+++ b/include/paging.h
@@ -1,0 +1,11 @@
+/*
+ * @file paging.h
+ * @brief Transitional header to provide a C-style interface to paging structures.
+ *
+ * This wrapper includes the C++ header @c paging.hpp while presenting a
+ * traditional @c .h interface for components that expect it.
+ */
+#ifndef PAGING_H
+#define PAGING_H
+#include "paging.hpp"
+#endif /* PAGING_H */

--- a/mm/paging.cpp
+++ b/mm/paging.cpp
@@ -8,7 +8,7 @@
  *
  * The allocator dispenses sequential virtual address ranges from a monotonically
  * increasing cursor.  Actual page table structures are defined in
- * @ref paging.hpp but are not manipulated here.
+ * @ref paging.h but are not manipulated here.
  *
  * @ingroup memory
  */


### PR DESCRIPTION
## Summary
- point `paging.cpp` docs to `paging.h`
- add `paging.h` wrapper including existing `paging.hpp`

## Testing
- `pre-commit run --files mm/paging.cpp include/paging.h` *(fails: CMake parse error in mm/CMakeLists.txt; cppcheck missing `cloc`)*
- `doxygen docs/Doxyfile`

------
https://chatgpt.com/codex/tasks/task_e_68aa5a9590ac83319847b9a79ca36b17