### PR TITLE
Fix Doxygen config and resolve doc warnings

### DIFF
--- a/docs/Doxyfile
+++ b/docs/Doxyfile
@@ -9,7 +9,7 @@ PROJECT_NAME           = "XINIM"
 PROJECT_NUMBER         = "2.0"
 PROJECT_BRIEF          = "Modern C++23 MINIX filesystem utilities with type safety and performance"
 PROJECT_LOGO           = 
-OUTPUT_DIRECTORY       = @DOXYGEN_OUTPUT_DIRECTORY@
+OUTPUT_DIRECTORY       = docs/doxygen
 CREATE_SUBDIRS         = YES
 ALLOW_UNICODE_NAMES    = NO
 OUTPUT_LANGUAGE        = English
@@ -28,7 +28,9 @@ MULTILINE_CPP_IS_BRIEF = NO
 INHERIT_DOCS           = YES
 SEPARATE_MEMBER_PAGES  = NO
 TAB_SIZE               = 4
-ALIASES                = 
+ALIASES                = "sideeffects=\\par Side Effects:\\n" \
+                         "thread_safety=\\par Thread Safety:\\n" \
+                         "compat=\\par Compatibility:\\n"
 OPTIMIZE_OUTPUT_FOR_C  = NO
 OPTIMIZE_OUTPUT_JAVA   = NO
 OPTIMIZE_FOR_FORTRAN   = NO
@@ -106,7 +108,7 @@ WARN_LOGFILE           =
 #---------------------------------------------------------------------------
 # Configuration options related to the input files
 #---------------------------------------------------------------------------
-INPUT                  = @DOXYGEN_INPUT@ commands \
+INPUT                  = commands \
                          fs \
                          kernel \
                          mm \

--- a/lib/access.cpp
+++ b/lib/access.cpp
@@ -6,7 +6,7 @@
 
 /**
  * @file access.cpp
- * @brief C++23 wrapper providing permission checks for ::access.
+ * @brief C++23 wrapper providing permission checks for @c access.
  *
  * The function performs a preliminary permission check using
  * `std::filesystem` before delegating to the MINIX file system
@@ -18,7 +18,7 @@
  * @brief Test a file's accessibility.
  *
  * @param name Path to the file or directory being examined.
- * @param mode Permission mask composed of ::F_OK, ::R_OK, ::W_OK, and ::X_OK.
+ * @param mode Permission mask composed of @c F_OK, @c R_OK, @c W_OK, and @c X_OK.
  * @return ``0`` on success or ``-1`` on failure with ``errno`` set.
  */
 int access(const char *name, int mode) {


### PR DESCRIPTION
## Summary
- refine Doxygen setup to write output to `docs/doxygen`, add custom aliases, and list repository sources explicitly
- clarify `std::filesystem` references in `ls` utility documentation
- correct `access` permission mask docs to avoid unresolved references

## Testing
- `doxygen docs/Doxyfile`
- `SKIP=clang-tidy,cppcheck pre-commit run --files docs/Doxyfile commands/ls.cpp lib/access.cpp`


------
https://chatgpt.com/codex/tasks/task_e_68aa5a3660fc8331ad8bf3317e32b77d